### PR TITLE
Fix renderer encoding property for three.js r128

### DIFF
--- a/index.html
+++ b/index.html
@@ -480,7 +480,7 @@
             renderer.setSize(window.innerWidth, window.innerHeight);
             renderer.shadowMap.enabled = true;
             renderer.shadowMap.type = THREE.PCFSoftShadowMap;
-            renderer.outputColorSpace = THREE.SRGBColorSpace;
+            renderer.outputEncoding = THREE.sRGBEncoding;
             renderer.toneMapping = THREE.ACESFilmicToneMapping;
             renderer.toneMappingExposure = 0.7; // Adjusted for less brightness
             document.body.appendChild(renderer.domElement);


### PR DESCRIPTION
## Summary
- replace the WebGLRenderer color space assignment with the r128-compatible outputEncoding API

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_b_68ce857dc4288327936883c45f52ba50