### PR TITLE
Fix renderer encoding property for three.js r128

### DIFF
--- a/index.html
+++ b/index.html
@@ -480,7 +480,7 @@
             renderer.setSize(window.innerWidth, window.innerHeight);
             renderer.shadowMap.enabled = true;
             renderer.shadowMap.type = THREE.PCFSoftShadowMap;
-            renderer.outputColorSpace = THREE.SRGBColorSpace;
+            renderer.outputEncoding = THREE.sRGBEncoding;
             renderer.toneMapping = THREE.ACESFilmicToneMapping;
             renderer.toneMappingExposure = 0.7; // Adjusted for less brightness
             document.body.appendChild(renderer.domElement);
@@ -1355,7 +1355,7 @@
                         pitchDecay: 0.01,
                         octaves: 6,
                         envelope: { attack: 0.001, decay: 0.2, sustain: 0 }
-                    }).toDestination(),
+                    }),
                     panner: new Tone.Panner3D().toDestination()
                 };
                 chicken.sound.connect(chicken.panner);


### PR DESCRIPTION
## Summary
- replace the WebGLRenderer color space assignment with the r128-compatible outputEncoding API
- route the chicken MembraneSynth instances exclusively through their positional panners to avoid double output

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_b_68ce857dc4288327936883c45f52ba50