### PR TITLE
Update Tone.js mute toggle to destination API

### DIFF
--- a/index.html
+++ b/index.html
@@ -1724,7 +1724,7 @@
                 }
                 if(e.code === 'KeyM') {
                     soundEnabled = !soundEnabled;
-                    Tone.Master.mute = !soundEnabled;
+                    Tone.getDestination().mute = !soundEnabled;
                 }
                 if(e.code === 'KeyP') {
                     document.getElementById('fps-counter').classList.toggle('show');


### PR DESCRIPTION
## Summary
- update the M-key audio toggle to use Tone's destination API instead of the deprecated Master node

## Testing
- Manual verification: launched the experience, pressed `M`, and confirmed Tone's destination mute property toggles without errors


------
https://chatgpt.com/codex/tasks/task_b_68ce8a50c14c8327b13d0fccc20f094c