### PR TITLE
Align player model with physics capsule

### DIFF
--- a/index.html
+++ b/index.html
@@ -1326,15 +1326,10 @@
                 });
 
                 player.model.updateMatrixWorld(true);
-                const boundingBox = new THREE.Box3().setFromObject(player.model);
-                const minY = boundingBox.min.y;
-                const bodyShape = (player.body && player.body.shapes && player.body.shapes.length) ? player.body.shapes[0] : null;
-                const halfHeight = (bodyShape && bodyShape.height) ? bodyShape.height / 2 : 0.9;
-                player.model.userData = player.model.userData || {};
-                player.model.userData.minY = minY;
-                player.model.userData.groundOffset = halfHeight + minY;
+                const bbox = new THREE.Box3().setFromObject(gltf.scene);
+                player.modelOffsetY = -((player.body.shapes?.[0]?.height ?? 1.8) / 2) - bbox.min.y;
                 player.model.position.copy(player.body.position);
-                player.model.position.y -= player.model.userData.groundOffset;
+                player.model.position.y += player.modelOffsetY ?? 0;
 
                 mixer = new THREE.AnimationMixer(player.model);
                 player.animations = {};
@@ -1646,18 +1641,10 @@
             });
             
             if (player && player.body && player.model) {
-                const bodyShape = (player.body.shapes && player.body.shapes.length) ? player.body.shapes[0] : null;
-                const halfHeight = (bodyShape && bodyShape.height) ? bodyShape.height / 2 : 0.9;
-                let groundOffset = halfHeight;
-                if (player.model.userData) {
-                    if (typeof player.model.userData.groundOffset === 'number') {
-                        groundOffset = player.model.userData.groundOffset;
-                    } else if (typeof player.model.userData.minY === 'number') {
-                        groundOffset = halfHeight + player.model.userData.minY;
-                    }
-                }
                 player.model.position.copy(player.body.position);
-                player.model.position.y -= groundOffset;
+                if (player.modelOffsetY !== undefined) {
+                    player.model.position.y += player.modelOffsetY;
+                }
                 player.model.quaternion.copy(player.body.quaternion);
             }
             


### PR DESCRIPTION
## Summary
- compute the Ready Player Me avatar's bounding box to derive an offset from the physics capsule height
- store and reuse the calculated offset when positioning the player model each frame so visuals stay aligned with physics

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68ce8e422acc8327b93217d8eb5f75da