### PR TITLE
Fix flight descent control

### DIFF
--- a/index.html
+++ b/index.html
@@ -406,7 +406,7 @@
         // --- GLOBAL VARIABLES ---
         let scene, camera, renderer, composer, ambientLight, directionalLight, hemisphereLight, player;
         let world;
-        let controls = { W: false, A: false, S: false, D: false, E: false, ShiftLeft: false, Space: false, ArrowUp: false, ArrowLeft: false, ArrowDown: false, ArrowRight: false };
+        let controls = { W: false, A: false, S: false, D: false, E: false, ShiftLeft: false, ShiftRight: false, Space: false, ArrowUp: false, ArrowLeft: false, ArrowDown: false, ArrowRight: false };
         const playerSpeed = 8.0;
         const playerRotationSpeed = 3.0;
         const flightSpeed = 10.0;
@@ -1852,7 +1852,7 @@
 
                 let verticalVelocity = 0;
                 if (controls.Space) verticalVelocity += flightVerticalSpeed;
-                if (controls.ShiftLeft) verticalVelocity -= flightVerticalSpeed;
+                if (controls.ShiftLeft || controls.ShiftRight) verticalVelocity -= flightVerticalSpeed;
 
                 const flightVelocity = new CANNON.Vec3(
                     moveDirection.x * flightSpeed,


### PR DESCRIPTION
## Summary
- allow both left and right shift keys to be tracked in the controls state
- let either shift key trigger downward flight so players can consistently descend

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_b_68cea6da4844832793f9c37520cdac9b