### PR TITLE
Fix column positioning for nested porticoes

### DIFF
--- a/index.html
+++ b/index.html
@@ -712,26 +712,32 @@
             createPavedRoads();
         }
 
-        function createEnhancedColumn(x, z, height = 8, material = columnMaterial) {
+        function createEnhancedColumn(height = 8, material = columnMaterial) {
             const group = new THREE.Group();
+            const baseHeight = 0.5;
+            const capitalHeight = 0.5;
+
             const columnGeometry = new THREE.CylinderGeometry(0.8, 1, height, 16);
             const column = new THREE.Mesh(columnGeometry, material);
             column.castShadow = true;
             if (column.material.map) {
                 column.material.map.repeat.set(1, 2);
             }
+            column.position.y = baseHeight + height / 2;
             group.add(column);
-            const capitalGeometry = new THREE.CylinderGeometry(1.2, 0.9, 0.5, 16);
+
+            const capitalGeometry = new THREE.CylinderGeometry(1.2, 0.9, capitalHeight, 16);
             const capital = new THREE.Mesh(capitalGeometry, goldMaterial);
-            capital.position.y = height / 2 + 0.25;
+            capital.position.y = baseHeight + height + capitalHeight / 2;
             capital.castShadow = true;
             group.add(capital);
-            const baseGeometry = new THREE.CylinderGeometry(1.1, 1.3, 0.5, 16);
+
+            const baseGeometry = new THREE.CylinderGeometry(1.1, 1.3, baseHeight, 16);
             const base = new THREE.Mesh(baseGeometry, material);
-            base.position.y = -height / 2 - 0.25;
+            base.position.y = baseHeight / 2;
             base.castShadow = true;
             group.add(base);
-            group.position.set(x, height/2, z);
+
             return group;
         }
 
@@ -795,12 +801,22 @@
             parthenonBase.position.y = 3.5;
             parthenon.add(parthenonBase);
             for (let i = 0; i < 8; i++) {
-                parthenon.add(createEnhancedColumn(-13 + i * 4, -7.5, 12));
-                parthenon.add(createEnhancedColumn(-13 + i * 4, 7.5, 12));
+                const frontColumn = createEnhancedColumn(12);
+                frontColumn.position.set(-13 + i * 4, -0.5, -7.5);
+                parthenon.add(frontColumn);
+
+                const backColumn = createEnhancedColumn(12);
+                backColumn.position.set(-13 + i * 4, -0.5, 7.5);
+                parthenon.add(backColumn);
             }
             for (let i = 0; i < 4; i++) {
-                parthenon.add(createEnhancedColumn(-15, -5.5 + i * 3.5, 12));
-                parthenon.add(createEnhancedColumn(15, -5.5 + i * 3.5, 12));
+                const leftColumn = createEnhancedColumn(12);
+                leftColumn.position.set(-15, -0.5, -5.5 + i * 3.5);
+                parthenon.add(leftColumn);
+
+                const rightColumn = createEnhancedColumn(12);
+                rightColumn.position.set(15, -0.5, -5.5 + i * 3.5);
+                parthenon.add(rightColumn);
             }
             const roofGeometry = new THREE.ConeGeometry(20, 6, 4);
             roofGeometry.rotateY(Math.PI/4);
@@ -823,7 +839,9 @@
         function createStoa() {
             const stoa = new THREE.Group();
             for (let i = 0; i < 12; i++) {
-                stoa.add(createEnhancedColumn(-30 + i * 5, 0, 8));
+                const column = createEnhancedColumn(8);
+                column.position.set(-30 + i * 5, -0.5, 0);
+                stoa.add(column);
             }
             const stoaRoof = createEnhancedBuilding(0, 0, 60, 8, 1.5, redTileMaterial, { includeDetails: false });
             if(stoaRoof.children[0].material.map) {
@@ -1125,18 +1143,22 @@
              const bouleuterion = createEnhancedBuilding(30, 15, 10, 8, 7, marbleMaterial);
              const portico = new THREE.Group();
              for(let i=0; i<4; i++){
-                 portico.add(createEnhancedColumn(i*2.5, 0, 6));
+                 const column = createEnhancedColumn(6);
+                 column.position.set(i * 2.5, 0, 0);
+                 portico.add(column);
              }
-             portico.position.set(-3.75, -0.5, 5);
+             portico.position.set(-3.75, -3.5, 5);
              bouleuterion.add(portico);
              scene.add(bouleuterion);
 
              const dikasteria = createEnhancedBuilding(0, -15, 8, 12, 6, marbleMaterial);
              const colonnade = new THREE.Group();
              for(let i=0; i<5; i++){
-                 colonnade.add(createEnhancedColumn(0, i * 2.5, 6));
+                 const column = createEnhancedColumn(6);
+                 column.position.set(0, 0, i * 2.5);
+                 colonnade.add(column);
              }
-             colonnade.position.set(4.5, -0.5, -5);
+             colonnade.position.set(4.5, -3, -5);
              dikasteria.add(colonnade);
              scene.add(dikasteria);
         }


### PR DESCRIPTION
## Summary
- update `createEnhancedColumn` so its meshes align on the parent origin and return an unpositioned column group
- update Parthenon, Stoa, and democracy monument builders to place columns explicitly now that positioning is handled by callers

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68ceacb7c12483279173ff8101f5c411