### PR TITLE
Add GeoJSON loader and local projection utilities

### DIFF
--- a/index.html
+++ b/index.html
@@ -2426,6 +2426,42 @@
         };
 
     </script>
+
+    <script type="module">
+        import { loadGeoJson } from './src/geo/geoLoader.js';
+        import { LocalEquirectangularProjection } from './src/geo/projection.js';
+
+        const origin = { lat: 37.9715379, lon: 23.7266531 }; // Parthenon
+        const rotationDegrees = 0;
+        const projector = new LocalEquirectangularProjection({ origin, rotationDegrees });
+
+        loadGeoJson()
+            .then((geoJson) => {
+                if (!geoJson || !Array.isArray(geoJson.features)) {
+                    console.warn('GeoJSON file did not contain any features to transform.');
+                    return;
+                }
+
+                console.group('Athens GeoJSON → local meters');
+                geoJson.features
+                    .filter((feature) => feature?.geometry?.type === 'Point')
+                    .forEach((feature) => {
+                        const [lon, lat] = feature.geometry.coordinates;
+                        const { x, y } = projector.project({ lat, lon });
+                        const name = feature.properties?.title || feature.properties?.name || 'Unnamed feature';
+                        console.log(name, { x, y, lat, lon });
+                    });
+                console.groupEnd();
+            })
+            .catch((error) => {
+                console.error('Failed to load Athens GeoJSON data', error);
+            });
+
+        window.AthensGeo = {
+            projector,
+            setRotation: (degrees) => projector.setRotation(degrees)
+        };
+    </script>
 </body>
 </html>
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "athens",
+  "version": "1.0.0",
+  "description": "Ancient Athens web experience",
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/src/geo/__tests__/projection.test.js
+++ b/src/geo/__tests__/projection.test.js
@@ -1,0 +1,40 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { LocalEquirectangularProjection } from '../projection.js';
+
+const PARTHENON_COORDS = { lat: 37.9715379, lon: 23.7266531 };
+const AGORA_COORDS = { lat: 37.975, lon: 23.723 };
+const PNYX_COORDS = { lat: 37.973, lon: 23.718 };
+
+test('Parthenon projects to the local origin', () => {
+    const projector = new LocalEquirectangularProjection({ origin: PARTHENON_COORDS });
+    const { x, y } = projector.project(PARTHENON_COORDS);
+
+    assert.ok(Math.abs(x) < 0.01, `Expected x ≈ 0 but received ${x}`);
+    assert.ok(Math.abs(y) < 0.01, `Expected y ≈ 0 but received ${y}`);
+});
+
+test('Agora falls northwest of the Parthenon', () => {
+    const projector = new LocalEquirectangularProjection({ origin: PARTHENON_COORDS });
+    const { x, y } = projector.project(AGORA_COORDS);
+
+    assert.ok(x < -200, `Expected x to be west (negative) of origin, received ${x}`);
+    assert.ok(y > 200, `Expected y to be north (positive) of origin, received ${y}`);
+});
+
+test('Pnyx falls west or northwest of the Parthenon', () => {
+    const projector = new LocalEquirectangularProjection({ origin: PARTHENON_COORDS });
+    const { x, y } = projector.project(PNYX_COORDS);
+
+    assert.ok(x < -500, `Expected x to be significantly west of origin, received ${x}`);
+    assert.ok(y > 50, `Expected y to be slightly north of origin, received ${y}`);
+});
+
+test('Rotation parameter rotates the local grid clockwise', () => {
+    const projector = new LocalEquirectangularProjection({ origin: PARTHENON_COORDS, rotationDegrees: 90 });
+    const { x, y } = projector.project({ lat: PARTHENON_COORDS.lat + 0.001, lon: PARTHENON_COORDS.lon });
+
+    assert.ok(x > 0, 'Clockwise rotation should move northward displacement onto the +x axis');
+    assert.ok(Math.abs(y) < 1e-6, 'Clockwise rotation should align that displacement with the x axis');
+});

--- a/src/geo/geoLoader.js
+++ b/src/geo/geoLoader.js
@@ -1,0 +1,28 @@
+const DEFAULT_GEOJSON_PATH = '/data/athens_places.geojson';
+
+/**
+ * Fetches a GeoJSON feature collection containing places around Athens.
+ *
+ * @param {string} [url=DEFAULT_GEOJSON_PATH] - Path to the GeoJSON file.
+ * @param {typeof fetch} [fetchImpl=globalThis.fetch] - Custom fetch implementation (useful for tests).
+ * @returns {Promise<object>} The parsed GeoJSON data.
+ */
+export async function loadGeoJson(url = DEFAULT_GEOJSON_PATH, fetchImpl = globalThis.fetch) {
+    if (typeof fetchImpl !== 'function') {
+        throw new TypeError('A valid fetch implementation must be provided');
+    }
+
+    const response = await fetchImpl(url, {
+        headers: {
+            'Accept': 'application/geo+json, application/json'
+        }
+    });
+
+    if (!response.ok) {
+        throw new Error(`Failed to load GeoJSON from ${url}: ${response.status} ${response.statusText}`);
+    }
+
+    return response.json();
+}
+
+export { DEFAULT_GEOJSON_PATH };

--- a/src/geo/projection.js
+++ b/src/geo/projection.js
@@ -1,0 +1,75 @@
+const EARTH_RADIUS_METERS = 6378137;
+
+const degToRad = (degrees) => (degrees * Math.PI) / 180;
+const radToDeg = (radians) => (radians * 180) / Math.PI;
+
+/**
+ * Equirectangular projection centered on a specific geographic origin.
+ */
+export class LocalEquirectangularProjection {
+    /**
+     * @param {{ lat: number, lon: number }} origin - Geographic origin of the local coordinate system.
+     * @param {number} [rotationDegrees=0] - Rotation to apply after projection, measured clockwise from east in degrees.
+     * @param {number} [radius=EARTH_RADIUS_METERS] - Earth radius to use for the projection.
+     */
+    constructor({ origin, rotationDegrees = 0, radius = EARTH_RADIUS_METERS }) {
+        if (!origin || typeof origin.lat !== 'number' || typeof origin.lon !== 'number') {
+            throw new TypeError('Origin with numeric lat and lon must be provided');
+        }
+
+        this.radius = radius;
+        this.originLat = origin.lat;
+        this.originLon = origin.lon;
+        this.originLatRad = degToRad(origin.lat);
+        this.originLonRad = degToRad(origin.lon);
+        this.setRotation(rotationDegrees);
+    }
+
+    /**
+     * Updates the rotation of the local grid.
+     * @param {number} rotationDegrees
+     */
+    setRotation(rotationDegrees = 0) {
+        this.rotationDegrees = rotationDegrees;
+        this.rotationRadians = degToRad(-rotationDegrees);
+        this._cosRotation = Math.cos(this.rotationRadians);
+        this._sinRotation = Math.sin(this.rotationRadians);
+    }
+
+    /**
+     * Projects a WGS84 coordinate into the local Cartesian plane.
+     * @param {{ lat: number, lon: number }} coordinate
+     * @returns {{ x: number, y: number }} - Local coordinates in meters.
+     */
+    project({ lat, lon }) {
+        if (typeof lat !== 'number' || typeof lon !== 'number') {
+            throw new TypeError('Coordinate must contain numeric lat and lon');
+        }
+
+        const latRad = degToRad(lat);
+        const lonRad = degToRad(lon);
+
+        const x = this.radius * (lonRad - this.originLonRad) * Math.cos(this.originLatRad);
+        const y = this.radius * (latRad - this.originLatRad);
+
+        const rotatedX = x * this._cosRotation - y * this._sinRotation;
+        const rotatedY = x * this._sinRotation + y * this._cosRotation;
+
+        return { x: rotatedX, y: rotatedY };
+    }
+
+    /**
+     * Convenience helper that projects GeoJSON Point coordinates which use [lon, lat].
+     * @param {number[]} position - GeoJSON position array [lon, lat].
+     * @returns {{ x: number, y: number }}
+     */
+    projectGeoJsonPosition(position) {
+        if (!Array.isArray(position) || position.length < 2) {
+            throw new TypeError('GeoJSON position must be a [lon, lat] array');
+        }
+        const [lon, lat] = position;
+        return this.project({ lat, lon });
+    }
+}
+
+export { EARTH_RADIUS_METERS, degToRad, radToDeg };


### PR DESCRIPTION
## Summary
- add a GeoJSON loader module to fetch Athens place data
- implement an equirectangular projection centered on the Parthenon with configurable rotation
- log transformed feature locations from index.html and cover the projection math with unit tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68cf22e0a0c48327af1d3bc84f4e0e9a