### PR TITLE
Move Parthenon landmark outside city walls

### DIFF
--- a/data/athens_places.geojson
+++ b/data/athens_places.geojson
@@ -13,8 +13,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          23.7264384999,
-          37.9716470903
+          23.7277356595,
+          37.9705497532
         ]
       },
       "properties": {
@@ -23,7 +23,8 @@
         "pleiades_uri": "https://pleiades.stoa.org/places/638356144",
         "source": "Pleiades",
         "license": "CC-BY 3.0",
-        "kind": "landmark"
+        "kind": "landmark",
+        "within_walls": false
       }
     },
     {

--- a/index.html
+++ b/index.html
@@ -418,6 +418,7 @@
         const flightSpeed = 10.0;
         const flightVerticalSpeed = 8.0;
         const CITY_SCALE = 2;
+        const ACROPOLIS_POSITION = Object.freeze({ x: 95, z: -110 });
         const scaleValue = (value) => value * CITY_SCALE;
         const scaleLocation = ({ x, y = 0, z }) => new THREE.Vector3(scaleValue(x), y, scaleValue(z));
         const scaleXZ = (x, z) => ({ x: scaleValue(x), z: scaleValue(z) });
@@ -596,10 +597,16 @@ async function loadAthensGeo() {
         let stoneMaterial, marbleMaterial, goldMaterial, redTileMaterial, groundMaterial, columnMaterial, waterMaterial, pavedRoadMaterial;
         
         const baseMapBounds = { xMin: -80, xMax: 80, zMin: -80, zMax: 80 };
-        const mapBounds = scaleBounds(baseMapBounds);
+        const spawnBounds = scaleBounds(baseMapBounds);
+        const mapBounds = scaleBounds({
+            xMin: Math.min(baseMapBounds.xMin, ACROPOLIS_POSITION.x - 10),
+            xMax: Math.max(baseMapBounds.xMax, ACROPOLIS_POSITION.x + 10),
+            zMin: Math.min(baseMapBounds.zMin, ACROPOLIS_POSITION.z - 10),
+            zMax: Math.max(baseMapBounds.zMax, ACROPOLIS_POSITION.z + 10)
+        });
         const getRandomWorldXZ = (padding = 0) => ({
-            x: THREE.MathUtils.randFloat(mapBounds.xMin + padding, mapBounds.xMax - padding),
-            z: THREE.MathUtils.randFloat(mapBounds.zMin + padding, mapBounds.zMax - padding)
+            x: THREE.MathUtils.randFloat(spawnBounds.xMin + padding, spawnBounds.xMax - padding),
+            z: THREE.MathUtils.randFloat(spawnBounds.zMin + padding, spawnBounds.zMax - padding)
         });
         const getRandomWorldVector3 = (y = 0, padding = 0) => {
             const { x, z } = getRandomWorldXZ(padding);
@@ -1278,7 +1285,7 @@ async function loadAthensGeo() {
             parthenon.position.y = plateauHeight;
             acropolis.add(parthenon);
 
-            setScaledPosition(acropolis, 0, 0, -50);
+            setScaledPosition(acropolis, ACROPOLIS_POSITION.x, 0, ACROPOLIS_POSITION.z);
             scene.add(acropolis);
         }
         
@@ -1976,7 +1983,7 @@ async function loadAthensGeo() {
         // --- GAME LOGIC & ANIMATION ---
         
         const locations = [
-            { name: "The Parthenon", position: scaleLocation({ x: 0, y: 10, z: -50 }), radius: scaleValue(30), title: "🏛️ The Parthenon" },
+            { name: "The Parthenon", position: scaleLocation({ x: ACROPOLIS_POSITION.x, y: 10, z: ACROPOLIS_POSITION.z }), radius: scaleValue(30), title: "🏛️ The Parthenon" },
             { name: "Stoa of Attalos", position: scaleLocation({ x: 40, y: 4, z: -20 }), radius: scaleValue(35), title: "🏛️ Stoa of Attalos" },
             { name: "Residential Quarter", position: scaleLocation({ x: -50, y: 3, z: 5 }), radius: scaleValue(20), title: "🏡 Residential Quarter" },
             { name: "Olive Grove", position: scaleLocation({ x: 35, y: 2, z: 25 }), radius: scaleValue(25), title: "🌳 Sacred Olive Grove" }

--- a/src/map/landmarks.js
+++ b/src/map/landmarks.js
@@ -350,9 +350,13 @@ export class LandmarkOverlay {
                 this._extendBounds(world);
                 const label = LANDMARK_LABELS[properties.name];
                 if (label) {
-                    const landmark = { name: properties.name, label, world };
+                    const withinWallsFlag = properties.within_walls ?? properties.withinWalls;
+                    const includeInCity = withinWallsFlag !== false;
+                    const landmark = { name: properties.name, label, world, withinWalls: includeInCity };
                     this.landmarks.push(landmark);
-                    cityPoints.push({ x: world.x, y: world.y });
+                    if (includeInCity) {
+                        cityPoints.push({ x: world.x, y: world.y });
+                    }
                 }
             } else if (geometry.type === 'LineString') {
                 const points = geometry.coordinates.map((coordinate) => this.projection.projectGeoJsonPosition(coordinate));


### PR DESCRIPTION
## Summary
- reposition the Parthenon/Acropolis model using a shared constant so it sits beyond the city fortifications
- expand map bounds for UI while keeping random spawns inside the old city and move the in-world location trigger accordingly
- update the GeoJSON data with the relocated coordinates and mark the Acropolis outside the walls so the 2D overlay excludes it from the city polygon

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68cf35e4d0c0832789f261ae6f159402