### PR TITLE
Enhance Athens soundscape

### DIFF
--- a/index.html
+++ b/index.html
@@ -623,9 +623,20 @@ async function loadAthensGeo() {
         let frameCount = 0;
         let lastTime = performance.now();
         
-        let ambientSound, soundEnabled = true;
-        let blacksmithSound, crowdChatter;
+        let soundEnabled = true;
+        let crowdChatter, crowdPanner, marketVolume, merchantSynth, merchantVolume, merchantLoop;
+        let blacksmithSound, blacksmithLoop;
+        let fountainNoise, fountainPanner, fountainVolume;
+        let windNoise, windPanner, windVolume;
+        let seagullSynth, seagullPanner, seagullVolume, seagullLoop;
+        let templeChantSynth, templeChantPanner, templeVolume, templeChantLoop;
+        let masterBus, environmentReverb;
         const blacksmithPosition = scaleLocation({ x: -12, y: 1, z: 10 });
+        const marketAmbiencePosition = scaleLocation({ x: 12, y: 1.5, z: -8 });
+        const fountainPosition = scaleLocation({ x: 24, y: 1, z: 14 });
+        const hillsideWindPosition = scaleLocation({ x: -26, y: 8, z: -12 });
+        const templeChantPosition = scaleLocation({ x: 90, y: 6, z: 35 });
+        const harbourBirdsPosition = scaleLocation({ x: 55, y: 10, z: 40 });
         
         let currentTimeOfDay = 0;
         let enhancedLighting = true;
@@ -2266,8 +2277,9 @@ async function loadAthensGeo() {
                 scene.fog.color.setHex(fogColor);
                 scene.fog.density = fogDensity;
             }
-            
+
             pointLights.forEach(light => light.visible = currentTimeOfDay === 3 || currentTimeOfDay === 4);
+            updateAmbientSoundscape();
         }
         
         function updateNPCs(delta) {
@@ -2411,10 +2423,6 @@ async function loadAthensGeo() {
                 chicken.panner.positionZ.value = chicken.model.position.z;
             });
             
-            // Randomly trigger blacksmith sound
-            if (Math.random() < 0.003) {
-                blacksmithSound.triggerAttackRelease("C3", "4n", Tone.now(), 0.8);
-            }
         }
 
         function animate() {
@@ -2460,31 +2468,307 @@ async function loadAthensGeo() {
 
         // --- CONTROLS ---
         function createAmbientSounds() {
-            // Crowd Murmur
-            crowdChatter = new Tone.Noise("pink").start();
-            const crowdFilter = new Tone.AutoFilter({
-                frequency: "8m",
-                baseFrequency: 200,
-                octaves: 4
-            }).toDestination();
-            const crowdVolume = new Tone.Volume(-25).connect(crowdFilter);
-            crowdChatter.connect(crowdVolume);
+            if (crowdChatter) {
+                return;
+            }
 
-            // Blacksmith
+            if (!masterBus) {
+                masterBus = new Tone.Volume(-8).toDestination();
+            }
+            if (!environmentReverb) {
+                environmentReverb = new Tone.Reverb({
+                    decay: 3.8,
+                    preDelay: 0.4,
+                    wet: 0.35
+                }).toDestination();
+            }
+
+            Tone.Transport.bpm.value = 66;
+
+            // Marketplace crowd bed
+            crowdChatter = new Tone.Noise("pink").start();
+            crowdPanner = new Tone.Panner3D({
+                positionX: marketAmbiencePosition.x,
+                positionY: marketAmbiencePosition.y,
+                positionZ: marketAmbiencePosition.z,
+            });
+            const crowdFilter = new Tone.AutoFilter({
+                frequency: "4m",
+                baseFrequency: 180,
+                octaves: 2.5,
+                depth: 0.6
+            }).start();
+            const crowdEQ = new Tone.EQ3(-10, 1, -12);
+            marketVolume = new Tone.Volume(-20);
+            crowdChatter.chain(crowdFilter, crowdEQ, marketVolume, crowdPanner);
+            crowdPanner.connect(masterBus);
+            crowdPanner.connect(environmentReverb);
+
+            merchantSynth = new Tone.Synth({
+                oscillator: { type: "triangle" },
+                envelope: { attack: 0.02, decay: 0.3, sustain: 0.15, release: 0.6 }
+            });
+            const merchantVibrato = new Tone.Vibrato(5, 0.2).start();
+            merchantVolume = new Tone.Volume(-26);
+            const merchantPanner = new Tone.Panner3D({
+                positionX: marketAmbiencePosition.x + scaleValue(4),
+                positionY: marketAmbiencePosition.y,
+                positionZ: marketAmbiencePosition.z - scaleValue(2),
+            });
+            merchantSynth.chain(merchantVibrato, merchantVolume, merchantPanner);
+            merchantPanner.connect(masterBus);
+            merchantPanner.connect(environmentReverb);
+
+            merchantLoop = new Tone.Loop((time) => {
+                const baseNotes = ["C4", "D4", "E4", "G4"];
+                const baseNote = baseNotes[Math.floor(Math.random() * baseNotes.length)];
+                merchantSynth.triggerAttackRelease(baseNote, "8n", time, 0.35);
+
+                const replyDelay = Tone.Time("8n").toSeconds() * 0.75;
+                const followNote = Tone.Frequency(baseNote).transpose(5).toNote();
+                Tone.Transport.scheduleOnce((callTime) => {
+                    merchantSynth.triggerAttackRelease(followNote, "8n", callTime, 0.25);
+                }, time + replyDelay);
+            }, "4m").start("+1m");
+            merchantLoop.probability = 0.55;
+
+            // Fountain and water movement
+            fountainNoise = new Tone.Noise("white").start();
+            fountainPanner = new Tone.Panner3D({
+                positionX: fountainPosition.x,
+                positionY: fountainPosition.y,
+                positionZ: fountainPosition.z,
+            });
+            const fountainFilter = new Tone.Filter({
+                type: "bandpass",
+                frequency: 1200,
+                Q: 1.2
+            });
+            const fountainAuto = new Tone.AutoFilter({
+                frequency: 0.3,
+                baseFrequency: 900,
+                octaves: 1
+            }).start();
+            fountainVolume = new Tone.Volume(-28);
+            fountainNoise.chain(fountainFilter, fountainAuto, fountainVolume, fountainPanner);
+            fountainPanner.connect(masterBus);
+            fountainPanner.connect(environmentReverb);
+
+            // Hillside wind and trees
+            windNoise = new Tone.Noise("brown").start();
+            windPanner = new Tone.Panner3D({
+                positionX: hillsideWindPosition.x,
+                positionY: hillsideWindPosition.y,
+                positionZ: hillsideWindPosition.z,
+            });
+            const windFilter = new Tone.Filter({
+                type: "lowpass",
+                frequency: 500,
+                Q: 0.8
+            });
+            const windAuto = new Tone.AutoFilter({
+                frequency: 0.05,
+                baseFrequency: 200,
+                octaves: 1.5,
+                depth: 0.7
+            }).start();
+            const windLFO = new Tone.LFO({
+                frequency: 0.015,
+                min: 200,
+                max: 600
+            }).start();
+            windLFO.connect(windFilter.frequency);
+            windVolume = new Tone.Volume(-32);
+            windNoise.chain(windAuto, windFilter, windVolume, windPanner);
+            windPanner.connect(masterBus);
+            windPanner.connect(environmentReverb);
+
+            // Temple chanting ambience
+            templeChantSynth = new Tone.PolySynth(Tone.Synth, {
+                oscillator: { type: "sine" },
+                envelope: { attack: 1.5, decay: 0.5, sustain: 0.4, release: 4 }
+            });
+            const templeFilter = new Tone.Filter({
+                type: "lowpass",
+                frequency: 800,
+                Q: 0.7
+            });
+            templeVolume = new Tone.Volume(-30);
+            templeChantPanner = new Tone.Panner3D({
+                positionX: templeChantPosition.x,
+                positionY: templeChantPosition.y,
+                positionZ: templeChantPosition.z,
+            });
+            templeChantSynth.chain(templeFilter, templeVolume, templeChantPanner);
+            templeChantPanner.connect(masterBus);
+            templeChantPanner.connect(environmentReverb);
+
+            let chantIndex = 0;
+            const chantChords = [
+                ["C4", "G3", "E4"],
+                ["D4", "A3", "F4"],
+                ["E4", "B3", "G4"],
+                ["G3", "D4", "B3"],
+            ];
+            templeChantLoop = new Tone.Loop((time) => {
+                const chord = chantChords[chantIndex % chantChords.length];
+                chantIndex++;
+                templeChantSynth.triggerAttackRelease(chord, "2m", time, 0.25);
+            }, "4m").start("+0.5m");
+            templeChantLoop.probability = 0.85;
+
+            // Harbor birds
+            seagullSynth = new Tone.Synth({
+                oscillator: { type: "sine" },
+                envelope: { attack: 0.05, decay: 0.2, sustain: 0.05, release: 1.5 }
+            });
+            const seagullVibrato = new Tone.Vibrato(7, 0.4).start();
+            seagullPanner = new Tone.Panner3D({
+                positionX: harbourBirdsPosition.x,
+                positionY: harbourBirdsPosition.y,
+                positionZ: harbourBirdsPosition.z,
+            });
+            seagullVolume = new Tone.Volume(-32);
+            seagullSynth.chain(seagullVibrato, seagullVolume, seagullPanner);
+            seagullPanner.connect(masterBus);
+            seagullPanner.connect(environmentReverb);
+
+            const seagullDelay = Tone.Time("8n").toSeconds();
+            seagullLoop = new Tone.Loop((time) => {
+                const baseCalls = ["A5", "B5", "C6", "D6"];
+                const base = baseCalls[Math.floor(Math.random() * baseCalls.length)];
+                seagullSynth.triggerAttackRelease(base, "8n", time, 0.35);
+
+                const responseNote = Tone.Frequency(base).transpose(-3).toNote();
+                Tone.Transport.scheduleOnce((callTime) => {
+                    seagullSynth.triggerAttackRelease(responseNote, "4n", callTime, 0.25);
+                }, time + seagullDelay * (0.5 + Math.random() * 0.5));
+            }, "6m").start("+1m");
+            seagullLoop.probability = 0.4;
+
+            // Blacksmith forge rhythm
             const blacksmithPanner = new Tone.Panner3D({
                 positionX: blacksmithPosition.x,
                 positionY: blacksmithPosition.y,
                 positionZ: blacksmithPosition.z,
-            }).toDestination();
-
+            });
+            const blacksmithVolume = new Tone.Volume(-20);
             blacksmithSound = new Tone.MetalSynth({
                 frequency: 150,
-                envelope: { attack: 0.001, decay: 0.4, release: 0.2 },
+                envelope: { attack: 0.001, decay: 0.35, release: 0.2 },
                 harmonicity: 8.1,
-                modulationIndex: 20,
+                modulationIndex: 24,
                 resonance: 4000,
                 octaves: 1.5
-            }).connect(blacksmithPanner);
+            });
+            blacksmithSound.chain(blacksmithVolume, blacksmithPanner);
+            blacksmithPanner.connect(masterBus);
+            blacksmithPanner.connect(environmentReverb);
+
+            blacksmithLoop = new Tone.Loop((time) => {
+                const hitVelocity = 0.7 + Math.random() * 0.2;
+                blacksmithSound.triggerAttackRelease("C3", "16n", time, hitVelocity);
+                const eighth = Tone.Time("8n").toSeconds();
+
+                Tone.Transport.scheduleOnce((accentTime) => {
+                    blacksmithSound.triggerAttackRelease("G3", "32n", accentTime, hitVelocity * 0.7);
+                }, time + eighth * (0.45 + Math.random() * 0.1));
+
+                Tone.Transport.scheduleOnce((finishingTime) => {
+                    blacksmithSound.triggerAttackRelease("C3", "16n", finishingTime, hitVelocity * 0.9);
+                }, time + eighth * (0.95 + Math.random() * 0.1));
+            }, "1m").start("+0.5m");
+            blacksmithLoop.probability = 0.9;
+
+            if (Tone.Transport.state !== "started") {
+                Tone.Transport.start();
+            }
+
+            updateAmbientSoundscape();
+        }
+
+        function updateAmbientSoundscape() {
+            if (typeof Tone === 'undefined') {
+                return;
+            }
+
+            const now = Tone.now ? Tone.now() : 0;
+            const fadeVolume = (node, value) => {
+                if (!node || !node.volume) return;
+                if (typeof node.volume.cancelScheduledValues === 'function') {
+                    node.volume.cancelScheduledValues(now);
+                }
+                if (typeof node.volume.rampTo === 'function') {
+                    node.volume.rampTo(value, 3);
+                } else {
+                    node.volume.value = value;
+                }
+            };
+
+            const setLoopProbability = (loop, value) => {
+                if (loop && typeof loop.probability === 'number') {
+                    loop.probability = value;
+                }
+            };
+
+            switch (currentTimeOfDay) {
+                case 0: // Golden Dawn
+                    fadeVolume(marketVolume, -24);
+                    fadeVolume(merchantVolume, -32);
+                    fadeVolume(fountainVolume, -24);
+                    fadeVolume(windVolume, -28);
+                    fadeVolume(templeVolume, -26);
+                    fadeVolume(seagullVolume, -28);
+                    setLoopProbability(merchantLoop, 0.35);
+                    setLoopProbability(seagullLoop, 0.45);
+                    setLoopProbability(blacksmithLoop, 0.65);
+                    break;
+                case 1: // Bright Noon
+                    fadeVolume(marketVolume, -16);
+                    fadeVolume(merchantVolume, -22);
+                    fadeVolume(fountainVolume, -20);
+                    fadeVolume(windVolume, -30);
+                    fadeVolume(templeVolume, -24);
+                    fadeVolume(seagullVolume, -24);
+                    setLoopProbability(merchantLoop, 0.75);
+                    setLoopProbability(seagullLoop, 0.55);
+                    setLoopProbability(blacksmithLoop, 0.95);
+                    break;
+                case 2: // Crimson Sunset
+                    fadeVolume(marketVolume, -18);
+                    fadeVolume(merchantVolume, -26);
+                    fadeVolume(fountainVolume, -21);
+                    fadeVolume(windVolume, -26);
+                    fadeVolume(templeVolume, -22);
+                    fadeVolume(seagullVolume, -30);
+                    setLoopProbability(merchantLoop, 0.45);
+                    setLoopProbability(seagullLoop, 0.35);
+                    setLoopProbability(blacksmithLoop, 0.8);
+                    break;
+                case 3: // Starlit Night
+                    fadeVolume(marketVolume, -34);
+                    fadeVolume(merchantVolume, -40);
+                    fadeVolume(fountainVolume, -24);
+                    fadeVolume(windVolume, -24);
+                    fadeVolume(templeVolume, -18);
+                    fadeVolume(seagullVolume, -40);
+                    setLoopProbability(merchantLoop, 0.15);
+                    setLoopProbability(seagullLoop, 0.2);
+                    setLoopProbability(blacksmithLoop, 0.35);
+                    break;
+                case 4: // Blue Hour
+                default:
+                    fadeVolume(marketVolume, -22);
+                    fadeVolume(merchantVolume, -30);
+                    fadeVolume(fountainVolume, -22);
+                    fadeVolume(windVolume, -25);
+                    fadeVolume(templeVolume, -20);
+                    fadeVolume(seagullVolume, -32);
+                    setLoopProbability(merchantLoop, 0.25);
+                    setLoopProbability(seagullLoop, 0.3);
+                    setLoopProbability(blacksmithLoop, 0.55);
+                    break;
+            }
         }
 
         function initializeChickenAudio() {
@@ -2493,14 +2777,23 @@ async function loadAthensGeo() {
                     return;
                 }
 
-                const panner = new Tone.Panner3D().toDestination();
+                const panner = new Tone.Panner3D();
                 const synth = new Tone.MembraneSynth({
                     pitchDecay: 0.01,
                     octaves: 6,
                     envelope: { attack: 0.001, decay: 0.2, sustain: 0 }
                 });
 
+                synth.volume.value = -14;
                 synth.connect(panner);
+
+                if (masterBus && environmentReverb) {
+                    panner.connect(masterBus);
+                    panner.connect(environmentReverb);
+                } else {
+                    panner.toDestination();
+                }
+
                 panner.positionX.value = chicken.model.position.x;
                 panner.positionY.value = chicken.model.position.y;
                 panner.positionZ.value = chicken.model.position.z;


### PR DESCRIPTION
## Summary
- replace the single pink-noise loop with a layered ambient soundscape including market chatter, water, wind, birds, chanting, and improved blacksmith hammering
- introduce shared audio busses and panned 3D sources so chickens and new loops route through the same reverb and respond to listener movement
- add a time-of-day audio mixer that fades layers and loop probabilities to match the current environment state

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68cff808849883278d7ec8eef459caa6