### PR TITLE
Enhance night sky shader with nebula and tone controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -1413,16 +1413,27 @@ async function loadAthensGeo() {
             uniform vec3 uHorizonColor;
             uniform vec3 uBottomColor;
             uniform vec3 uCloudColor;
-            uniform vec3 uStarColor;
             uniform vec3 uGalaxyColor;
+            uniform vec3 uStarWarmColor;
+            uniform vec3 uStarCoolColor;
+            uniform vec3 uStarAccentColor;
+            uniform vec3 uNebulaColorA;
+            uniform vec3 uNebulaColorB;
             uniform float uCloudIntensity;
             uniform float uStarIntensity;
+            uniform float uStarBrightness;
             uniform float uGalaxyIntensity;
+            uniform float uNebulaIntensity;
+            uniform float uNebulaScale;
+            uniform float uNebulaSharpness;
             uniform float uTime;
             uniform float uCloudScale;
             uniform float uCloudSharpness;
             uniform float uHorizonHeight;
             uniform float uHorizonSpread;
+            uniform float uToneExposure;
+            uniform float uToneContrast;
+            uniform float uToneSaturation;
 
             const float PI = 3.14159265359;
 
@@ -1453,16 +1464,29 @@ async function loadAthensGeo() {
                 return value;
             }
 
-            float starLayer(vec2 uv, float density, float twinkleSpeed) {
+            vec3 sampleStarPalette(float seed) {
+                float warmMix = smoothstep(0.15, 0.85, seed);
+                vec3 palette = mix(uStarCoolColor, uStarWarmColor, warmMix);
+                float accent = smoothstep(0.75, 1.0, seed);
+                palette = mix(palette, uStarAccentColor, accent);
+                return palette;
+            }
+
+            vec3 starLayer(vec2 uv, float density, float twinkleSpeed) {
                 vec2 grid = floor(uv);
                 vec2 f = fract(uv) - 0.5;
                 float n = hash(grid);
                 float star = step(1.0 - density, n);
                 vec2 offset = vec2(hash(grid + 1.3), hash(grid + 8.7)) - 0.5;
                 float dist = length(f - offset * 0.35);
-                star *= smoothstep(0.45, 0.0, dist);
+                float falloff = smoothstep(0.45, 0.0, dist);
+                star *= falloff;
                 float twinkle = 0.55 + 0.45 * sin(uTime * twinkleSpeed + n * 6.28318);
-                return star * twinkle;
+                float jitter = 0.75 + 0.25 * hash(grid + 23.17);
+                float intensity = star * twinkle * jitter;
+                float paletteSeed = hash(grid + 12.8);
+                vec3 palette = sampleStarPalette(paletteSeed);
+                return palette * intensity;
             }
 
             void main() {
@@ -1485,12 +1509,13 @@ async function loadAthensGeo() {
                 vec3 cloudTint = mix(baseGradient, uCloudColor, 0.65);
                 vec3 color = mix(baseGradient, cloudTint, clamp(cloudShape, 0.0, 1.0));
 
-                float stars = 0.0;
+                vec3 starColor = vec3(0.0);
                 if (uStarIntensity > 0.0) {
-                    float density = clamp(uStarIntensity, 0.0, 0.6);
-                    stars += starLayer(uv * 800.0, density, 12.0);
-                    stars += starLayer(uv * 450.0 + 10.0, density * 0.7, 6.0);
-                    stars += starLayer(uv * 200.0 + 25.0, density * 0.45, 4.0);
+                    float density = clamp(uStarIntensity, 0.0, 0.85);
+                    starColor += starLayer(uv * 800.0, density, 12.0);
+                    starColor += starLayer(uv * 450.0 + 10.0, density * 0.7, 6.0);
+                    starColor += starLayer(uv * 200.0 + 25.0, density * 0.45, 4.0);
+                    starColor *= uStarBrightness;
                 }
 
                 float galaxyAxis = dir.y + dir.x * 0.35;
@@ -1499,7 +1524,26 @@ async function loadAthensGeo() {
                 galaxyBand *= uGalaxyIntensity;
 
                 color += uGalaxyColor * galaxyBand;
-                color += uStarColor * stars;
+
+                if (uNebulaIntensity > 0.0) {
+                    float nebulaNoise = fbm(uv * uNebulaScale + vec2(uTime * 0.01, -uTime * 0.008));
+                    nebulaNoise = pow(clamp(nebulaNoise, 0.0, 1.0), max(uNebulaSharpness, 0.0001));
+                    float nebulaMask = smoothstep(0.35, 0.95, nebulaNoise);
+                    nebulaMask *= smoothstep(0.25, 0.9, height);
+                    nebulaMask *= uNebulaIntensity;
+                    vec3 nebulaColor = mix(uNebulaColorA, uNebulaColorB, nebulaNoise);
+                    color += nebulaColor * nebulaMask;
+                }
+
+                color += starColor;
+
+                color = max(color, 0.0);
+                color *= uToneExposure;
+
+                float luminance = dot(color, vec3(0.2126, 0.7152, 0.0722));
+                color = mix(vec3(luminance), color, uToneSaturation);
+
+                color = (color - 0.5) * uToneContrast + 0.5;
 
                 color = clamp(color, 0.0, 1.0);
                 gl_FragColor = vec4(color, 1.0);
@@ -1509,28 +1553,47 @@ async function loadAthensGeo() {
         function createSkybox() {
             const skyGeo = new THREE.SphereGeometry(500, 32, 32);
 
-            const createSkyMaterial = (config) => new THREE.ShaderMaterial({
-                uniforms: {
-                    uTime: { value: 0 },
-                    uTopColor: { value: new THREE.Color(config.topColor) },
-                    uHorizonColor: { value: new THREE.Color(config.horizonColor) },
-                    uBottomColor: { value: new THREE.Color(config.bottomColor) },
-                    uCloudColor: { value: new THREE.Color(config.cloudColor || config.topColor) },
-                    uStarColor: { value: new THREE.Color(config.starColor || 0xffffff) },
-                    uGalaxyColor: { value: new THREE.Color(config.galaxyColor || 0x8899ff) },
-                    uCloudIntensity: { value: config.cloudIntensity ?? 0.0 },
-                    uStarIntensity: { value: config.starDensity ?? 0.0 },
-                    uGalaxyIntensity: { value: config.galaxyIntensity ?? 0.0 },
-                    uCloudScale: { value: config.cloudScale ?? 2.5 },
-                    uCloudSharpness: { value: config.cloudSharpness ?? 0.5 },
-                    uHorizonHeight: { value: config.horizonHeight ?? 0.25 },
-                    uHorizonSpread: { value: config.horizonSpread ?? 6.0 }
-                },
-                vertexShader: skyVertexShader,
-                fragmentShader: skyFragmentShader,
-                side: THREE.BackSide,
-                depthWrite: false
-            });
+            const createSkyMaterial = (config = {}) => {
+                const starWarm = config.starWarmColor ?? (config.starColor ?? 0xfff2d4);
+                const starCool = config.starCoolColor ?? (config.starColor ?? 0xbdd9ff);
+                const starAccent = config.starAccentColor ?? (config.starColor ?? 0xffc1f0);
+                const nebulaA = config.nebulaColorA ?? (config.galaxyColor ?? 0x223045);
+                const nebulaB = config.nebulaColorB ?? (config.nebulaColorA ?? 0x3a1f5d);
+
+                return new THREE.ShaderMaterial({
+                    uniforms: {
+                        uTime: { value: 0 },
+                        uTopColor: { value: new THREE.Color(config.topColor) },
+                        uHorizonColor: { value: new THREE.Color(config.horizonColor) },
+                        uBottomColor: { value: new THREE.Color(config.bottomColor) },
+                        uCloudColor: { value: new THREE.Color(config.cloudColor || config.topColor) },
+                        uGalaxyColor: { value: new THREE.Color(config.galaxyColor || 0x8899ff) },
+                        uStarWarmColor: { value: new THREE.Color(starWarm) },
+                        uStarCoolColor: { value: new THREE.Color(starCool) },
+                        uStarAccentColor: { value: new THREE.Color(starAccent) },
+                        uNebulaColorA: { value: new THREE.Color(nebulaA) },
+                        uNebulaColorB: { value: new THREE.Color(nebulaB) },
+                        uCloudIntensity: { value: config.cloudIntensity ?? 0.0 },
+                        uStarIntensity: { value: config.starDensity ?? 0.0 },
+                        uStarBrightness: { value: config.starBrightness ?? 1.0 },
+                        uGalaxyIntensity: { value: config.galaxyIntensity ?? 0.0 },
+                        uNebulaIntensity: { value: config.nebulaIntensity ?? 0.0 },
+                        uNebulaScale: { value: config.nebulaScale ?? 2.0 },
+                        uNebulaSharpness: { value: config.nebulaSharpness ?? 2.0 },
+                        uCloudScale: { value: config.cloudScale ?? 2.5 },
+                        uCloudSharpness: { value: config.cloudSharpness ?? 0.5 },
+                        uHorizonHeight: { value: config.horizonHeight ?? 0.25 },
+                        uHorizonSpread: { value: config.horizonSpread ?? 6.0 },
+                        uToneExposure: { value: config.toneExposure ?? 1.0 },
+                        uToneContrast: { value: config.toneContrast ?? 1.0 },
+                        uToneSaturation: { value: config.toneSaturation ?? 1.0 }
+                    },
+                    vertexShader: skyVertexShader,
+                    fragmentShader: skyFragmentShader,
+                    side: THREE.BackSide,
+                    depthWrite: false
+                });
+            };
 
             skyboxMaterials.dawn = createSkyMaterial({
                 topColor: 0xF08D7E,
@@ -1575,33 +1638,55 @@ async function loadAthensGeo() {
             });
 
             skyboxMaterials.night = createSkyMaterial({
-                topColor: 0x06122A,
-                horizonColor: 0x132247,
-                bottomColor: 0x03040F,
-                cloudColor: 0x273B6D,
-                starColor: 0xC8E6FF,
-                galaxyColor: 0x7C5CFF,
-                cloudIntensity: 0.28,
-                cloudScale: 1.8,
-                cloudSharpness: 0.55,
-                starDensity: 0.08,
-                galaxyIntensity: 0.85,
+                topColor: 0x03091d,
+                horizonColor: 0x1d2f63,
+                bottomColor: 0x01030a,
+                cloudColor: 0x24386a,
+                galaxyColor: 0x8461ff,
+                cloudIntensity: 0.26,
+                cloudScale: 1.9,
+                cloudSharpness: 0.58,
+                starDensity: 0.12,
+                starWarmColor: 0xfff3d6,
+                starCoolColor: 0x96c7ff,
+                starAccentColor: 0xff8df5,
+                starBrightness: 1.65,
+                galaxyIntensity: 0.95,
+                nebulaColorA: 0x171d45,
+                nebulaColorB: 0x6330b4,
+                nebulaIntensity: 0.78,
+                nebulaScale: 1.6,
+                nebulaSharpness: 2.4,
+                toneExposure: 1.24,
+                toneContrast: 1.2,
+                toneSaturation: 1.38,
                 horizonHeight: 0.22,
                 horizonSpread: 5.0
             });
 
             skyboxMaterials.blueHour = createSkyMaterial({
-                topColor: 0x162A4F,
-                horizonColor: 0x3F5C89,
+                topColor: 0x162a4f,
+                horizonColor: 0x3f5c89,
                 bottomColor: 0x091224,
-                cloudColor: 0x4C5F8B,
-                starColor: 0xD0E3FF,
-                galaxyColor: 0x5C79FF,
-                cloudIntensity: 0.4,
+                cloudColor: 0x4c5f8b,
+                galaxyColor: 0x5c79ff,
+                cloudIntensity: 0.42,
                 cloudScale: 2.4,
-                cloudSharpness: 0.5,
+                cloudSharpness: 0.52,
                 starDensity: 0.045,
-                galaxyIntensity: 0.35,
+                starWarmColor: 0xffefd6,
+                starCoolColor: 0xa7c8ff,
+                starAccentColor: 0xffbdf3,
+                starBrightness: 0.95,
+                galaxyIntensity: 0.38,
+                nebulaColorA: 0x202a54,
+                nebulaColorB: 0x4455a8,
+                nebulaIntensity: 0.32,
+                nebulaScale: 1.8,
+                nebulaSharpness: 2.0,
+                toneExposure: 1.08,
+                toneContrast: 1.05,
+                toneSaturation: 1.12,
                 horizonHeight: 0.24,
                 horizonSpread: 6.5
             });


### PR DESCRIPTION
## Summary
- add a richer sky fragment shader with star palette variation, nebula blending, and tone mapping uniforms
- extend the sky material factory to wire the new uniforms with sensible defaults
- retune the night and blue hour presets with saturated colors, nebula hues, and brighter stars for an AAA-style sky

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d063c9dad48327adcf5e002529a05d