### PR TITLE
Refine night sky star rendering

### DIFF
--- a/index.html
+++ b/index.html
@@ -2071,28 +2071,45 @@ async function loadAthensGeo() {
             }
 
             vec3 sampleStarPalette(float seed) {
-                float warmMix = smoothstep(0.15, 0.85, seed);
+                float warmMix = smoothstep(0.2, 0.8, seed);
                 vec3 palette = mix(uStarCoolColor, uStarWarmColor, warmMix);
-                float accent = smoothstep(0.75, 1.0, seed);
-                palette = mix(palette, uStarAccentColor, accent);
+                float accentSeed = fract(seed * 2.37);
+                float accent = smoothstep(0.55, 1.0, accentSeed);
+                palette = mix(palette, uStarAccentColor, accent * 0.6);
+                float sparkle = smoothstep(0.4, 0.9, fract(seed * 4.13));
+                palette = mix(palette, vec3(1.0), sparkle * 0.15);
                 return palette;
             }
 
             vec3 starLayer(vec2 uv, float density, float twinkleSpeed) {
                 vec2 grid = floor(uv);
-                vec2 f = fract(uv) - 0.5;
-                float n = hash(grid);
-                float star = step(1.0 - density, n);
+                float spawn = hash(grid);
+                float star = step(1.0 - density, spawn);
+                if (star < 0.5) {
+                    return vec3(0.0);
+                }
+
                 vec2 offset = vec2(hash(grid + 1.3), hash(grid + 8.7)) - 0.5;
-                float dist = length(f - offset * 0.35);
-                float falloff = smoothstep(0.45, 0.0, dist);
-                star *= falloff;
-                float twinkle = 0.55 + 0.45 * sin(uTime * twinkleSpeed + n * 6.28318);
-                float jitter = 0.75 + 0.25 * hash(grid + 23.17);
-                float intensity = star * twinkle * jitter;
-                float paletteSeed = hash(grid + 12.8);
-                vec3 palette = sampleStarPalette(paletteSeed);
-                return palette * intensity;
+                vec2 local = fract(uv) - 0.5 - offset * 0.35;
+                float dist = length(local);
+
+                float halo = smoothstep(0.0, 0.6, 0.6 - dist);
+                float falloff = smoothstep(0.0, 0.4, 0.4 - dist);
+                float core = smoothstep(0.0, 0.18, 0.18 - dist);
+
+                float baseBrightness = mix(0.55, 1.2, hash(grid + 6.1));
+                float slowTwinkle = 0.8 + 0.2 * sin(uTime * (twinkleSpeed * 0.18) + spawn * 6.28318);
+                float fastTwinkle = 0.9 + 0.1 * sin(uTime * (twinkleSpeed * 0.72) + hash(grid + 19.7) * 6.28318);
+                float shimmer = 0.85 + 0.15 * pow(0.5 + 0.5 * sin(uTime * (twinkleSpeed * 0.42) + hash(grid + 4.3) * 6.28318), 2.0);
+                float twinkle = slowTwinkle * fastTwinkle * shimmer;
+
+                vec3 palette = sampleStarPalette(hash(grid + 12.8));
+                vec3 color = palette * (falloff * baseBrightness * twinkle);
+
+                color += palette * pow(halo, 2.0) * 0.25 * baseBrightness;
+                color += vec3(1.0) * pow(core, 6.0) * 0.35 * baseBrightness;
+
+                return color;
             }
 
             void main() {


### PR DESCRIPTION
## Summary
- enhance star palette sampling to introduce richer warm, cool, and accent colour variation
- redesign the star shader to add soft halos and multi-phase twinkling without harsh flashing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68d085664508832796fe7c666a2317a3