### PR TITLE
Add night sky and starfield controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -462,6 +462,7 @@
         let scene, camera, renderer, composer, ambientLight, directionalLight, hemisphereLight, player;
         let world;
         let controls = { W: false, A: false, S: false, D: false, E: false, ShiftLeft: false, ShiftRight: false, Space: false, ArrowUp: false, ArrowLeft: false, ArrowDown: false, ArrowRight: false };
+        const toggleKeyTimestamps = {};
         const playerSpeed = 8.0;
         const playerRotationSpeed = 3.0;
         const flightSpeed = 10.0;
@@ -772,9 +773,12 @@ async function loadAthensGeo() {
         const catAlleyPosition = scaleLocation({ x: AGORA_ANCHOR_SCENE.x + 14, y: 1.2, z: AGORA_ANCHOR_SCENE.z + 6 });
         const cowPasturePosition = scaleLocation({ x: AGORA_ANCHOR_SCENE.x - 42, y: 1.5, z: AGORA_ANCHOR_SCENE.z - 26 });
         
-        let currentTimeOfDay = 0;
         let enhancedLighting = true;
         const timeNames = ["Golden Dawn", "Blue Hour", "High Noon", "Golden Dusk", "Starlit Night"];
+        let currentTimeOfDay = timeNames.indexOf("Starlit Night");
+        if (currentTimeOfDay === -1) {
+            currentTimeOfDay = 0;
+        }
 
         // Declare texture and material variables globally
         let stoneTexture, marbleTexture, redTileTexture, groundTexture, pavedRoadTexture;
@@ -820,7 +824,10 @@ async function loadAthensGeo() {
             // Scene and Camera
             scene = new THREE.Scene();
             window.scene = scene;
-            camera = new THREE.PerspectiveCamera(60, window.innerWidth / window.innerHeight, 0.1, 1000);
+            const farClip = 60000;
+            camera = new THREE.PerspectiveCamera(60, window.innerWidth / window.innerHeight, 0.1, farClip);
+            camera.far = Math.max(camera.far, 60000);
+            camera.updateProjectionMatrix();
             window.camera = camera;
             
             // Renderer
@@ -864,6 +871,7 @@ async function loadAthensGeo() {
             // Sky, stars, and post-processing
             createStarsAndSky();
             setupPostFX();
+            console.log("[Athens] Night diagnostics: sky + stars forced ON.");
 
             // Initialize textures and materials now that renderer exists
             stoneTexture = generateTexture(256, 256, (ctx, w, h) => {
@@ -2138,57 +2146,90 @@ async function loadAthensGeo() {
 
             const SkyClass = window.Sky;
             if (SkyClass) {
-                sky = new SkyClass();
-                sky.scale.setScalar(18000);
-                scene.add(sky);
+                if (!sky) {
+                    sky = new SkyClass();
+                    sky.material.fog = false;
+                    sky.material.depthWrite = false;
+                    sky.material.transparent = true;
+                    sky.scale.setScalar(60000);
+                    scene.add(sky);
+                }
 
                 skyUniforms = sky.material.uniforms;
                 skyUniforms.turbidity.value = 4.0;
                 skyUniforms.rayleigh.value = 1.4;
                 skyUniforms.mieCoefficient.value = 0.002;
                 skyUniforms.mieDirectionalG.value = 0.8;
-                sun = new THREE.Vector3();
+                if (!sun) {
+                    sun = new THREE.Vector3(0, -1, 0);
+                } else {
+                    sun.set(0, -1, 0);
+                }
                 if (skyUniforms.sunPosition) {
-                    skyUniforms.sunPosition.value.copy(sun);
+                    skyUniforms.sunPosition.value.set(0, -1, 0).multiplyScalar(400000);
                 }
             } else {
                 console.warn('Sky class is unavailable; using fallback background.');
-                sun = new THREE.Vector3();
+                if (!sun) {
+                    sun = new THREE.Vector3(0, -1, 0);
+                } else {
+                    sun.set(0, -1, 0);
+                }
                 scene.background = new THREE.Color(0x04060f);
             }
 
-            starLayerInner = createStarLayer(3200, 1500, 1.3, 0xffffff);
-            starLayerOuter = createStarLayer(4200, 2400, 1.1, 0xdfe8ff);
+            if (!starLayerInner) {
+                starLayerInner = createStarLayer(3000, 16000, 140, 0xffffff);
+            }
+            if (!starLayerOuter) {
+                starLayerOuter = createStarLayer(6000, 24000, 200, 0xdfe8ff);
+            }
+            if (starLayerInner) {
+                starMaterials.push(starLayerInner.material);
+            }
+            if (starLayerOuter) {
+                starMaterials.push(starLayerOuter.material);
+            }
 
-            const milkyTexture = createMilkyWayTexture();
-            milkyWayMaterial = new THREE.MeshBasicMaterial({
-                map: milkyTexture,
-                transparent: true,
-                opacity: 0,
-                depthWrite: false,
-                side: THREE.BackSide
-            });
-            milkyWayMesh = new THREE.Mesh(new THREE.SphereGeometry(2600, 64, 64), milkyWayMaterial);
-            milkyWayMesh.rotation.set(0, Math.PI * 0.22, Math.PI * 0.05);
-            scene.add(milkyWayMesh);
+            if (!milkyWayMaterial) {
+                const milkyTexture = createMilkyWayTexture();
+                milkyWayMaterial = new THREE.MeshBasicMaterial({
+                    map: milkyTexture,
+                    transparent: true,
+                    opacity: 0,
+                    fog: false,
+                    depthWrite: false,
+                    depthTest: false,
+                    side: THREE.BackSide
+                });
+            }
+            if (!milkyWayMesh) {
+                milkyWayMesh = new THREE.Mesh(new THREE.SphereGeometry(32000, 64, 64), milkyWayMaterial);
+                milkyWayMesh.rotation.set(0, Math.PI * 0.22, Math.PI * 0.05);
+                scene.add(milkyWayMesh);
+            }
 
-            const moonMaterial = new THREE.MeshStandardMaterial({
-                color: 0xf6f3e8,
-                roughness: 0.55,
-                metalness: 0.08,
-                emissive: new THREE.Color(0x202428),
-                emissiveIntensity: 0.06
-            });
-            moon = new THREE.Mesh(new THREE.SphereGeometry(22, 48, 48), moonMaterial);
-            moon.castShadow = false;
-            moon.receiveShadow = false;
-            scene.add(moon);
+            if (!moon) {
+                const moonMaterial = new THREE.MeshStandardMaterial({
+                    color: 0xf6f3e8,
+                    roughness: 0.55,
+                    metalness: 0.08,
+                    emissive: new THREE.Color(0x202428),
+                    emissiveIntensity: 0.06
+                });
+                moon = new THREE.Mesh(new THREE.SphereGeometry(22, 48, 48), moonMaterial);
+                moon.castShadow = false;
+                moon.receiveShadow = false;
+                scene.add(moon);
+            }
 
-            moonLight = new THREE.DirectionalLight(0xbfd6ff, 0.0);
-            moonLight.castShadow = false;
-            moonLight.position.set(0, 1, 0);
-            scene.add(moonLight);
-            scene.add(moonLight.target);
+            if (!moonLight) {
+                moonLight = new THREE.DirectionalLight(0xbfd6ff, 0.0);
+                moonLight.castShadow = false;
+                moonLight.position.set(0, 1, 0);
+                scene.add(moonLight);
+                scene.add(moonLight.target);
+            }
 
             starOpacityTarget = 0;
             milkyWayOpacityTarget = 0;
@@ -2201,26 +2242,30 @@ async function loadAthensGeo() {
                     Math.random() * 2 - 1,
                     Math.random() * 2 - 1,
                     Math.random() * 2 - 1
-                ).normalize().multiplyScalar(radius + Math.random() * 80 - 40);
+                ).normalize().multiplyScalar(radius + (Math.random() - 0.5) * 800);
                 positions[i * 3] = direction.x;
                 positions[i * 3 + 1] = direction.y;
                 positions[i * 3 + 2] = direction.z;
             }
             const geometry = new THREE.BufferGeometry();
             geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+            const baseOpacity = 0.9;
             const material = new THREE.PointsMaterial({
                 color,
                 size,
                 sizeAttenuation: true,
                 transparent: true,
-                opacity: 0,
+                opacity: baseOpacity,
+                fog: false,
                 depthWrite: false,
                 blending: THREE.AdditiveBlending
             });
+            material.depthTest = false;
+            material.userData.baseOpacity = baseOpacity;
             const layer = new THREE.Points(geometry, material);
             layer.frustumCulled = false;
+            layer.renderOrder = -5;
             scene.add(layer);
-            starMaterials.push(material);
             return layer;
         }
 
@@ -2397,7 +2442,7 @@ async function loadAthensGeo() {
                     settings.hemisphereIntensity = 0.55;
                     settings.hemiSkyColor = 0x8fc7ff;
                     settings.hemiGroundColor = 0xc5a572;
-                    settings.exposure = 1.02;
+                    settings.exposure = 1.0;
                     settings.bloomStrength = 0.18;
                     settings.fogColor = 0xcfe8ff;
                     settings.skyTurbidity = 3.5;
@@ -2432,11 +2477,11 @@ async function loadAthensGeo() {
                     settings.hemisphereIntensity = 0.15;
                     settings.hemiSkyColor = 0x0a1330;
                     settings.hemiGroundColor = 0x020205;
-                    settings.exposure = 0.78;
+                    settings.exposure = 0.85;
                     settings.bloomStrength = 0.55;
                     settings.fogColor = 0x0a101b;
-                    settings.starOpacity = 0.55;
-                    settings.milkyOpacity = 0.25;
+                    settings.starOpacity = 1.0;
+                    settings.milkyOpacity = 0.3;
                     settings.moonVisible = true;
                     settings.moonLightIntensity = 0.35;
                     settings.skyTurbidity = 1.2;
@@ -2517,18 +2562,19 @@ async function loadAthensGeo() {
 
             const twinkleTime = performance.now() * 0.0005;
             starMaterials.forEach((material, index) => {
+                const baseOpacity = material?.userData?.baseOpacity ?? 1;
                 const flicker = starOpacityTarget > 0 ? 0.03 * Math.sin(twinkleTime + index) : 0;
-                const target = THREE.MathUtils.clamp(starOpacityTarget + flicker, 0, 1);
+                const target = THREE.MathUtils.clamp((starOpacityTarget + flicker) * baseOpacity, 0, baseOpacity);
                 material.opacity = THREE.MathUtils.lerp(material.opacity, target, 0.08);
             });
 
             if (starLayerInner) {
-                starLayerInner.rotation.y += delta * 0.003;
-                starLayerInner.rotation.x += delta * 0.0005;
+                starLayerInner.rotation.y += delta * 0.0007;
+                starLayerInner.rotation.x += delta * 0.0002;
             }
             if (starLayerOuter) {
-                starLayerOuter.rotation.y -= delta * 0.0018;
-                starLayerOuter.rotation.z += delta * 0.0003;
+                starLayerOuter.rotation.y -= delta * 0.0004;
+                starLayerOuter.rotation.z += delta * 0.00015;
             }
 
             if (milkyWayMaterial) {
@@ -3344,6 +3390,22 @@ async function loadAthensGeo() {
             setTimeOfDay(currentName);
             updateAmbientSoundscape();
         }
+
+        function forceNightMode() {
+            const nightIndex = timeNames.indexOf('Starlit Night');
+            if (nightIndex !== -1) {
+                currentTimeOfDay = nightIndex;
+                updateEnvironment();
+            }
+        }
+
+        function forceDayMode() {
+            const dayIndex = timeNames.indexOf('High Noon');
+            if (dayIndex !== -1) {
+                currentTimeOfDay = dayIndex;
+                updateEnvironment();
+            }
+        }
         
         function updateNPCs(delta) {
             const time = clock.getElapsedTime();
@@ -4085,9 +4147,23 @@ async function loadAthensGeo() {
                     e.preventDefault();
                 }
                 controls[e.code] = true;
+                if (e.code === 'KeyD' || e.code === 'KeyN') {
+                    toggleKeyTimestamps[e.code] = performance.now();
+                }
             });
             document.addEventListener('keyup', (e) => {
                 controls[e.code] = false;
+                if (e.code === 'KeyN') {
+                    forceNightMode();
+                    delete toggleKeyTimestamps[e.code];
+                }
+                if (e.code === 'KeyD') {
+                    const downTime = toggleKeyTimestamps[e.code];
+                    if (!downTime || performance.now() - downTime < 250) {
+                        forceDayMode();
+                    }
+                    delete toggleKeyTimestamps[e.code];
+                }
                 if(e.code === 'KeyE') {
                     for(const obj of interactables) {
                         if(obj.isPlayerNear && obj.promptElement) {


### PR DESCRIPTION
## Summary
- default the scene to the Starlit Night preset with extended camera range and a diagnostic log so the new night environment is obvious on load
- rebuild the sky and starfield using the Three.js Sky helper plus large additive Points layers and tweaked tone-mapping for night and day
- add keyboard shortcuts for forcing day or night while keeping the existing time-of-day system intact

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d13c98765083278b17ed4eeeca150f