### PR TITLE
Integrate reusable landmarks loader for GeoJSON features

### DIFF
--- a/index.html
+++ b/index.html
@@ -701,130 +701,6 @@
         const externalAnimationMixers = [];
         window.externalAnimationMixers = externalAnimationMixers;
 
-        // --- GEOJSON LOADER & LANDMARK RENDERING ---
-// Put your file at:  ./data/athens_places.geojson  (folder "data" next to index.html)
-async function loadAthensGeo() {
-    try {
-        // Make sure the projector exists (it’s defined in your <script type="module"> below)
-        const projector = window?.AthensGeo?.projector;
-        if (!projector) {
-            console.warn("Geo projector not ready yet; delaying GeoJSON load by 1s…");
-            setTimeout(loadAthensGeo, 1000);
-            return;
-        }
-
-        // 1) Load the GeoJSON
-        const response = await fetch('./data/athens_places.geojson');
-        if (!response.ok) throw new Error(`HTTP ${response.status}`);
-        const geoJson = await response.json();
-
-        // 2) Add simple 3D pins for each Point feature
-        const pinGroup = new THREE.Group();
-        pinGroup.name = "AthensGeoPins";
-        scene.add(pinGroup);
-
-        const pinMaterial = new THREE.MeshStandardMaterial({ color: 0xFFD700, metalness: 0.2, roughness: 0.6 });
-        const labelMaterial = new THREE.MeshBasicMaterial({ color: 0xffffff });
-
-        // Helper to make a pin (a small cylinder + sphere)
-        function makePin() {
-            const g = new THREE.Group();
-            const shaft = new THREE.Mesh(new THREE.CylinderGeometry(0.15 * CITY_SCALE, 0.15 * CITY_SCALE, 1.2, 8), pinMaterial);
-            shaft.castShadow = true;
-            const head  = new THREE.Mesh(new THREE.SphereGeometry(0.32 * CITY_SCALE, 12, 10), pinMaterial);
-            head.position.y = 0.75;
-            head.castShadow = true;
-            g.add(shaft, head);
-            return g;
-        }
-
-        // Helper to add a floating nameplate (simple plane; optional)
-        function addNameplate(text) {
-            const canvas = document.createElement('canvas');
-            canvas.width = 512; canvas.height = 128;
-            const ctx = canvas.getContext('2d');
-            ctx.fillStyle = 'rgba(0,0,0,0.6)';
-            ctx.fillRect(0, 0, canvas.width, canvas.height);
-            ctx.fillStyle = '#FFD700';
-            ctx.font = '48px Cinzel, serif';
-            ctx.textAlign = 'center';
-            ctx.textBaseline = 'middle';
-            ctx.fillText(text, canvas.width / 2, canvas.height / 2);
-            const tex = new THREE.CanvasTexture(canvas);
-            const mat = new THREE.MeshBasicMaterial({ map: tex, transparent: true });
-            const geo = new THREE.PlaneGeometry(3 * CITY_SCALE, 0.75 * CITY_SCALE);
-            const mesh = new THREE.Mesh(geo, mat);
-            mesh.position.y = 1.2;
-            return mesh;
-        }
-
-        // 3) Convert each Point feature’s lon/lat to local x/z and drop a pin
-        const newlyAddedLocations = []; // to show in your mini-map & on-screen location text
-        for (const f of geoJson.features || []) {
-            if (f?.geometry?.type !== 'Point') continue;
-
-            const [lon, lat] = f.geometry.coordinates;
-            const name = f.properties?.title || f.properties?.name || 'Unnamed';
-            const categoryRaw = (f.properties?.category || 'cultural').toString().toLowerCase();
-            const category = ['democracy', 'cultural', 'natural'].includes(categoryRaw) ? categoryRaw : 'cultural';
-
-            // Convert lon/lat → local meters using your projector
-            const { x, y } = projector.project({ lat, lon }); // y here is “northing”; we’ll use it as z
-            const localX = x;     // meters east from origin (Parthenon)
-            const localZ = y;     // meters north from origin
-
-            // Scale down to your scene scale (your helpers use CITY_SCALE on top of these numbers)
-            // We’ll treat these as your “design units” and set position via setScaledPosition.
-            const pin = makePin();
-            setScaledPosition(pin, localX, 0, localZ);
-            pinGroup.add(pin);
-
-            // Optional floating label
-            const label = addNameplate(name);
-            pin.add(label);
-
-            // Register in your “locations” list so UI picks it up
-            newlyAddedLocations.push({
-                name,
-                position: new THREE.Vector3(scaleValue(localX), 0, scaleValue(localZ)),
-                radius: scaleValue(12),
-                title: `📍 ${name}`,
-                type: category
-            });
-        }
-
-        // 4) Add the new points into your existing systems:
-        //    - locations[] (for on-screen “You are at …”)
-        //    - mini-map icons
-        if (Array.isArray(newlyAddedLocations) && newlyAddedLocations.length) {
-            // Add to locations array the simplest way: push them in
-            if (Array.isArray(locations)) {
-                newlyAddedLocations.forEach(loc => locations.push(loc));
-            }
-
-            // Add icons to mini-map (reusing your createMapIcons() logic: we’ll just add the DOM dots ourselves)
-            const mapContainer = document.getElementById('mini-map-container');
-            const worldWidth = mapBounds.xMax - mapBounds.xMin;
-            const worldDepth = mapBounds.zMax - mapBounds.zMin;
-
-            newlyAddedLocations.forEach(loc => {
-                const icon = document.createElement('div');
-                const rawType = typeof loc.type === 'string' ? loc.type.toLowerCase() : 'cultural';
-                const cat = ['democracy', 'cultural', 'natural'].includes(rawType) ? rawType : 'cultural';
-                icon.className = `map-icon map-icon-${cat}`;
-                const percentX = THREE.MathUtils.clamp((loc.position.x - mapBounds.xMin) / worldWidth, 0, 1);
-                const percentZ = THREE.MathUtils.clamp((loc.position.z - mapBounds.zMin) / worldDepth, 0, 1);
-                icon.style.left = `${percentX * 200}px`;
-                icon.style.top  = `${percentZ * 200}px`;
-                mapContainer.appendChild(icon);
-            });
-
-            console.log(`Loaded ${newlyAddedLocations.length} Athens landmarks from GeoJSON.`);
-        }
-    } catch (err) {
-        console.error('loadAthensGeo() failed:', err);
-    }
-}
 
         const scaleBounds = ({ xMin, xMax, zMin, zMax }) => ({
             xMin: scaleValue(xMin),
@@ -876,6 +752,8 @@ async function loadAthensGeo() {
         let templeChantSynth, templeChantPanner, templeVolume, templeChantLoop;
         let animalAmbiences = null;
         let masterBus, environmentReverb;
+        let landmarkLabelUpdater = null;
+        let landmarkGroups = null;
         const blacksmithPosition = scaleLocation({ x: -12, y: 1, z: 10 });
         const marketAmbiencePosition = scaleLocation({ x: 12, y: 1.5, z: -8 });
         const fountainPosition = scaleLocation({ x: 24, y: 1, z: 14 });
@@ -927,7 +805,7 @@ async function loadAthensGeo() {
 
 
         // --- INITIALIZATION ---
-        function init() {
+        async function init() {
             // Physics World
             world = new CANNON.World();
             world.gravity.set(0, -9.82, 0); 
@@ -1096,7 +974,8 @@ async function loadAthensGeo() {
             createMapIcons();
             // Load the temple model (GLB)
             loadGreekTemple();
-            loadAthensGeo();
+
+            await setupLandmarks();
 
 
 
@@ -3593,7 +3472,10 @@ async function loadAthensGeo() {
             updateNPCs(delta);
             updateCamera();
             updateMiniMap();
-            
+            if (typeof landmarkLabelUpdater === 'function') {
+                landmarkLabelUpdater(camera);
+            }
+
             composer.render();
         }
 
@@ -4356,36 +4238,102 @@ async function loadAthensGeo() {
             camera.lookAt(lookAtPosition);
         }
 
-        function createMapIcons() {
+        function addMiniMapDot(category, worldPos) {
             const mapContainer = document.getElementById('mini-map-container');
+            if (!mapContainer || !worldPos) {
+                return null;
+            }
+
+            const worldWidth = mapBounds.xMax - mapBounds.xMin;
+            const worldDepth = mapBounds.zMax - mapBounds.zMin;
+            if (worldWidth === 0 || worldDepth === 0) {
+                return null;
+            }
+
+            const safeCategory = (category ?? 'cultural').toString().toLowerCase();
+            const normalizedCategory = ['democracy', 'cultural', 'natural'].includes(safeCategory)
+                ? safeCategory
+                : 'cultural';
+
+            const icon = document.createElement('div');
+            icon.className = `map-icon map-icon-${normalizedCategory}`;
+
+            const mapWidth = 200;
+            const mapHeight = 200;
+            const percentX = THREE.MathUtils.clamp((worldPos.x - mapBounds.xMin) / worldWidth, 0, 1);
+            const percentZ = THREE.MathUtils.clamp((worldPos.z - mapBounds.zMin) / worldDepth, 0, 1);
+
+            icon.style.left = `${percentX * mapWidth}px`;
+            icon.style.top = `${percentZ * mapHeight}px`;
+
+            mapContainer.appendChild(icon);
+            return icon;
+        }
+
+        function createMapIcons() {
             const allLocations = [
-                ...locations.map(l => ({...l, type: 'cultural'})),
+                ...locations.map(l => ({...l, type: (l.type || 'cultural')})),
                 { name: 'Pnyx', position: scaleLocation({ x: PNYX_POSITION.x, z: PNYX_POSITION.z }), type: 'democracy' },
                 { name: 'Dikasteria', position: scaleLocation({ x: 0, z: -15 }), type: 'democracy' },
                 { name: 'Bouleuterion', position: scaleLocation({ x: AGORA_FEATURES.bouleuterion.position.x, z: AGORA_FEATURES.bouleuterion.position.z }), type: 'democracy' }
             ];
 
             allLocations.forEach(loc => {
-                const icon = document.createElement('div');
-                icon.className = `map-icon map-icon-${loc.type}`;
-                
-                const mapWidth = 200;
-                const mapHeight = 200;
-                const worldWidth = mapBounds.xMax - mapBounds.xMin;
-                const worldDepth = mapBounds.zMax - mapBounds.zMin;
+                if (!loc || !loc.position) {
+                    return;
+                }
 
-                let percentX = (loc.position.x - mapBounds.xMin) / worldWidth;
-                let percentZ = (loc.position.z - mapBounds.zMin) / worldDepth;
-                percentX = THREE.MathUtils.clamp(percentX, 0, 1);
-                percentZ = THREE.MathUtils.clamp(percentZ, 0, 1);
-
-                icon.style.left = `${percentX * mapWidth}px`;
-                icon.style.top = `${percentZ * mapHeight}px`;
-
-                mapContainer.appendChild(icon);
+                addMiniMapDot(loc.type, loc.position);
             });
         }
-        
+
+        async function setupLandmarks() {
+            try {
+                const { loadLandmarks } = await import('./src/landmarks-loader.js');
+
+                const projectorInstance = window?.AthensGeo?.projector;
+                const projectorFn = projectorInstance && typeof projectorInstance.project === 'function'
+                    ? (lon, lat) => {
+                        const { x, y } = projectorInstance.project({ lat, lon });
+                        return new THREE.Vector3(scaleValue(x), 0, scaleValue(y));
+                    }
+                    : null;
+
+                const { groups, update } = await loadLandmarks({
+                    scene,
+                    geoJsonUrl: './data/athens_places.geojson',
+                    projector: projectorFn,
+                    onPoint: (feature, pin, worldPos) => {
+                        const props = feature.properties || {};
+                        const name = props.title || props.name || 'Unnamed';
+                        const rawCategory = (props.category || 'cultural').toString().toLowerCase();
+                        const category = ['democracy', 'cultural', 'natural'].includes(rawCategory) ? rawCategory : 'cultural';
+
+                        locations.push({
+                            name,
+                            position: worldPos.clone(),
+                            radius: scaleValue(12),
+                            title: `📍 ${name}`,
+                            type: category
+                        });
+
+                        addMiniMapDot(category, worldPos);
+                    }
+                });
+
+                landmarkGroups = groups;
+                landmarkLabelUpdater = update;
+
+                if (landmarkGroups?.democracy) landmarkGroups.democracy.visible = true;
+                if (landmarkGroups?.cultural) landmarkGroups.cultural.visible = true;
+                if (landmarkGroups?.natural) landmarkGroups.natural.visible = true;
+
+                window.AthensLandmarks = { groups, update };
+            } catch (error) {
+                console.error('Failed to load landmarks:', error);
+            }
+        }
+
         function updateMiniMap() {
             if (!player || !player.body || !player.model) return;
 
@@ -4420,7 +4368,9 @@ async function loadAthensGeo() {
         }
         
         // Initialize the application
-        init();
+        init().catch((error) => {
+            console.error('Failed to initialize Athens experience:', error);
+        });
         
         } // End of main function
         

--- a/src/landmarks-loader.js
+++ b/src/landmarks-loader.js
@@ -1,0 +1,173 @@
+import * as THREE from 'three';
+
+/**
+ * Load every feature from a GeoJSON file and add to the scene.
+ * - projector(lon, lat) -> THREE.Vector3: optional; if missing we use a local Athens projection.
+ * - onPoint(feature, obj3d, worldPos): optional callback (e.g., add to mini-map).
+ */
+export async function loadLandmarks({
+  scene,
+  geoJsonUrl = './data/athens_places.geojson',
+  projector = null,
+  onPoint = null
+}) {
+  const root = new THREE.Group();
+  root.name = 'Landmarks';
+  scene.add(root);
+
+  const groups = {
+    democracy: new THREE.Group(),
+    cultural: new THREE.Group(),
+    natural: new THREE.Group(),
+    lines: new THREE.Group(),
+    polygons: new THREE.Group()
+  };
+  Object.entries(groups).forEach(([k, g]) => { g.name = `Landmarks_${k}`; root.add(g); });
+
+  const res = await fetch(geoJsonUrl);
+  if (!res.ok) throw new Error(`Failed to load ${geoJsonUrl}: ${res.status}`);
+  const geo = await res.json();
+
+  const markers = [];
+  const labels = [];
+
+  for (const f of geo.features || []) {
+    const props = f.properties || {};
+    const name = props.title || props.name || 'Unnamed';
+    const cat = (props.category || 'cultural').toLowerCase();
+    const targetGroup = groups[cat] || groups.cultural;
+
+    if (f.geometry?.type === 'Point') {
+      const [lon, lat] = f.geometry.coordinates;
+      const pos = projector ? projector(lon, lat) : lonLatToLocal(lon, lat);
+
+      const pin = makePinMesh(cat);
+      pin.position.copy(pos);
+      pin.userData = { name, props };
+      targetGroup.add(pin);
+      markers.push(pin);
+
+      const label = makeLabelSprite(name);
+      label.position.copy(pos).add(new THREE.Vector3(0, 15, 0));
+      targetGroup.add(label);
+      labels.push(label);
+
+      onPoint?.(f, pin, pos.clone());
+
+    } else if (f.geometry?.type === 'LineString') {
+      const line = makeLine(f.geometry.coordinates, projector);
+      line.userData = { name, props };
+      groups.lines.add(line);
+
+    } else if (f.geometry?.type === 'Polygon') {
+      // Outline only (outer ring)
+      const poly = makePolygonOutline(f.geometry.coordinates[0], projector);
+      poly.userData = { name, props };
+      groups.polygons.add(poly);
+
+    } else if (f.geometry?.type === 'MultiLineString') {
+      for (const seg of f.geometry.coordinates) {
+        const line = makeLine(seg, projector);
+        line.userData = { name, props };
+        groups.lines.add(line);
+      }
+    } else if (f.geometry?.type === 'MultiPolygon') {
+      for (const polyCoords of f.geometry.coordinates) {
+        const poly = makePolygonOutline(polyCoords[0], projector);
+        poly.userData = { name, props };
+        groups.polygons.add(poly);
+      }
+    }
+  }
+
+  // keep labels facing the camera (utility; call this each frame)
+  const update = (camera) => {
+    for (const s of labels) s.quaternion.copy(camera.quaternion);
+  };
+
+  return { root, groups, markers, labels, update };
+}
+
+/* ---------- helpers ---------- */
+
+function lonLatToLocal(lon, lat) {
+  // Simple local meters-at-Athens projection centered near Syntagma
+  const lon0 = 23.7275, lat0 = 37.9838;
+  const toRad = Math.PI / 180;
+  const mPerDegLat = 111132.92 - 559.82 * Math.cos(2 * lat0 * toRad) + 1.175 * Math.cos(4 * lat0 * toRad);
+  const mPerDegLon = 111412.84 * Math.cos(lat0 * toRad) - 93.5 * Math.cos(3 * lat0 * toRad);
+  const x = (lon - lon0) * mPerDegLon;
+  const z = -(lat - lat0) * mPerDegLat; // -lat so north is -Z (Three's default forward)
+  return new THREE.Vector3(x, 0, z);
+}
+
+function makePinMesh(cat) {
+  const colors = { democracy: 0x14b8a6, cultural: 0x60a5fa, natural: 0x22c55e };
+  const c = colors[cat] ?? 0x60a5fa;
+
+  const pin = new THREE.Group();
+
+  const stalk = new THREE.Mesh(
+    new THREE.CylinderGeometry(0.75, 0.75, 4, 8),
+    new THREE.MeshStandardMaterial({ color: c, roughness: 0.6, metalness: 0.15 })
+  );
+  stalk.position.y = 2;
+
+  const head = new THREE.Mesh(
+    new THREE.ConeGeometry(2.6, 6.5, 10),
+    new THREE.MeshStandardMaterial({ color: c, emissive: c, emissiveIntensity: 0.12, roughness: 0.45, metalness: 0.15 })
+  );
+  head.position.y = 7;
+  head.rotation.x = Math.PI;
+
+  pin.add(stalk, head);
+  pin.castShadow = false; pin.receiveShadow = false;
+  return pin;
+}
+
+function makeLabelSprite(text) {
+  const pad = 6, fontPx = 28;
+  const canvas = document.createElement('canvas');
+  const ctx = canvas.getContext('2d');
+  ctx.font = `${fontPx}px ui-sans-serif, system-ui, Segoe UI, Roboto, Helvetica, Arial`;
+  const tw = Math.ceil(ctx.measureText(text).width);
+
+  canvas.width = tw + pad * 2;
+  canvas.height = fontPx + pad * 2;
+
+  // bg
+  ctx.fillStyle = 'rgba(0,0,0,0.55)';
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  // border
+  ctx.strokeStyle = 'rgba(255,255,255,0.25)';
+  ctx.lineWidth = 2;
+  ctx.strokeRect(0.5, 0.5, canvas.width - 1, canvas.height - 1);
+  // text
+  ctx.fillStyle = '#e2e8f0';
+  ctx.textBaseline = 'top';
+  ctx.fillText(text, pad, pad);
+
+  const tex = new THREE.CanvasTexture(canvas);
+  if ('colorSpace' in tex) tex.colorSpace = THREE.SRGBColorSpace;
+  const mat = new THREE.SpriteMaterial({ map: tex, transparent: true, depthWrite: false });
+  const s = new THREE.Sprite(mat);
+  s.scale.set(canvas.width / 6, canvas.height / 6, 1);
+  s.renderOrder = 10;
+  return s;
+}
+
+function makeLine(coords, projector) {
+  const pts = coords.map(([lon, lat]) => projector ? projector(lon, lat) : lonLatToLocal(lon, lat));
+  const geom = new THREE.BufferGeometry().setFromPoints(pts);
+  const mat = new THREE.LineBasicMaterial({ color: 0x94a3b8, transparent: true, opacity: 0.95 });
+  return new THREE.Line(geom, mat);
+}
+
+function makePolygonOutline(coords, projector) {
+  const pts = coords.map(([lon, lat]) => projector ? projector(lon, lat) : lonLatToLocal(lon, lat));
+  const geom = new THREE.BufferGeometry().setFromPoints(pts);
+  const mat = new THREE.LineDashedMaterial({ color: 0xa8a29e, dashSize: 6, gapSize: 3, transparent: true, opacity: 0.85 });
+  const loop = new THREE.LineLoop(geom, mat);
+  loop.computeLineDistances();
+  return loop;
+}


### PR DESCRIPTION
## Summary
- add a reusable `loadLandmarks` module that converts GeoJSON points, lines, and polygons into scene primitives with billboard labels
- wire the loader into the main Athens initialization to replace the bespoke loader, update the mini-map, and keep labels facing the camera
- expose mini-map helpers and landmark metadata so locations and toggles remain accessible

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d14b65f2fc8327a14fb11abd132dc1