### PR TITLE
Add photo skydome for night sky

### DIFF
--- a/index.html
+++ b/index.html
@@ -770,6 +770,13 @@
         if (currentTimeOfDay === -1) {
             currentTimeOfDay = 0;
         }
+        const debugSkyCycleModes = ["High Noon", "Blue Hour", "Starlit Night"];
+        const debugSkyLevels = [0, 0.4, 1];
+        let debugSkyCycleIndex = debugSkyCycleModes.indexOf(timeNames[currentTimeOfDay] || '');
+        if (debugSkyCycleIndex === -1) {
+            debugSkyCycleIndex = 0;
+        }
+        let skipNightHotkeyOnce = false;
 
         // Declare texture and material variables globally
         let stoneTexture, marbleTexture, redTileTexture, groundTexture, pavedRoadTexture;
@@ -841,6 +848,20 @@
             renderer.shadowMap.type = THREE.PCFSoftShadowMap;
             document.body.appendChild(renderer.domElement);
             window.renderer = renderer;
+
+            try {
+                const { createPhotoSkydome } = await import('./src/sky/photoSkydome.js');
+                const skydome = await createPhotoSkydome({
+                    scene,
+                    renderer,
+                    url: '/assets/textures/milkyway.jpg',
+                    radius: 5000,
+                    initialYawDeg: 35
+                });
+                window.__AthensSky__ = skydome;
+            } catch (error) {
+                console.error('Failed to initialize photo skydome:', error);
+            }
 
             const textureLoader = new THREE.TextureLoader();
             spaceNight = initSpaceNight({
@@ -2438,10 +2459,11 @@
 
             let night = 0;
             if (name === 'Starlit Night') night = 1;
-            else if (name === 'Blue Hour') night = 0.35;
+            else if (name === 'Blue Hour') night = 0.4;
             if (spaceNight) {
                 spaceNight.setAmount(night);
             }
+            window.__AthensSky__?.setAmount(night);
         }
 
         function updateNightCycle(dt = 0.016) {
@@ -3285,6 +3307,10 @@
         function updateEnvironment() {
             const currentName = timeNames[currentTimeOfDay];
             setTimeOfDay(currentName);
+            const cycleIdx = debugSkyCycleModes.indexOf(currentName);
+            if (cycleIdx !== -1) {
+                debugSkyCycleIndex = cycleIdx;
+            }
             updateAmbientSoundscape();
         }
 
@@ -4058,7 +4084,11 @@
             document.addEventListener('keyup', (e) => {
                 controls[e.code] = false;
                 if (e.code === 'KeyN') {
-                    forceNightMode();
+                    if (skipNightHotkeyOnce) {
+                        skipNightHotkeyOnce = false;
+                    } else {
+                        forceNightMode();
+                    }
                     delete toggleKeyTimestamps[e.code];
                 }
                 if (e.code === 'KeyD') {
@@ -4113,7 +4143,34 @@
                     document.getElementById('fps-counter').classList.toggle('show');
                 }
             });
-            
+
+            window.addEventListener('keydown', (e) => {
+                if (e.repeat) return;
+                const sky = window.__AthensSky__;
+                if (!sky) return;
+                if (e.key === '[' || e.key === ']') {
+                    const delta = e.key === '[' ? -5 : 5;
+                    const currentYawDeg = THREE.MathUtils.radToDeg(sky.mesh.rotation.y);
+                    sky.setYaw(currentYawDeg + delta);
+                    return;
+                }
+                if (e.key && e.key.toLowerCase() === 'n' && !e.shiftKey && !e.altKey && !e.metaKey) {
+                    e.preventDefault();
+                    debugSkyCycleIndex = (debugSkyCycleIndex + 1) % debugSkyCycleModes.length;
+                    const targetMode = debugSkyCycleModes[debugSkyCycleIndex];
+                    const nightAmount = debugSkyLevels[debugSkyCycleIndex] ?? 0;
+                    const idx = timeNames.indexOf(targetMode);
+                    if (idx !== -1) {
+                        currentTimeOfDay = idx;
+                        updateEnvironment();
+                    } else {
+                        sky.setAmount(nightAmount);
+                    }
+                    console.log('Night amount:', nightAmount);
+                    skipNightHotkeyOnce = true;
+                }
+            });
+
             document.getElementById('close-info-scroll').addEventListener('click', () => {
                 document.getElementById('info-scroll-overlay').classList.remove('show');
             });

--- a/src/sky/photoSkydome.js
+++ b/src/sky/photoSkydome.js
@@ -1,0 +1,44 @@
+import * as THREE from 'three';
+
+export async function createPhotoSkydome({ scene, renderer, url = '/assets/textures/milkyway.jpg', radius = 5000, initialYawDeg = 0 }) {
+  // Load texture
+  const tex = await new THREE.TextureLoader().loadAsync(url);
+  if ('colorSpace' in tex) tex.colorSpace = THREE.SRGBColorSpace;
+
+  // Big inside-out sphere
+  const geo = new THREE.SphereGeometry(radius, 64, 64);
+  const mat = new THREE.MeshBasicMaterial({
+    map: tex,
+    side: THREE.BackSide,
+    transparent: true,
+    opacity: 0.0,        // start hidden (day)
+    depthWrite: false
+  });
+  const dome = new THREE.Mesh(geo, mat);
+  dome.name = 'PhotoSkydome';
+  dome.renderOrder = -1000; // behind everything
+  dome.rotation.y = THREE.MathUtils.degToRad(initialYawDeg);
+  scene.add(dome);
+
+  // Optional: env map for nicer PBR at night (precompute once)
+  let envTex = null;
+  if (renderer) {
+    const pmrem = new THREE.PMREMGenerator(renderer);
+    envTex = pmrem.fromEquirectangular(tex).texture;
+    pmrem.dispose();
+  }
+
+  const api = {
+    mesh: dome,
+    setAmount(a) {
+      const t = THREE.MathUtils.clamp(a, 0, 1);
+      dome.material.opacity = t;
+      // only use environment when it's mostly night
+      if (envTex) scene.environment = t > 0.6 ? envTex : null;
+    },
+    setYaw(deg) {
+      dome.rotation.y = THREE.MathUtils.degToRad(deg);
+    }
+  };
+  return api;
+}


### PR DESCRIPTION
## Summary
- add a reusable photo-based skydome module that loads the Milky Way texture and exposes fade/yaw controls
- initialize the new skydome alongside the existing space night FX and hook it into the time-of-day transitions
- add debug hotkeys to cycle night levels and rotate the Milky Way band while preserving existing lighting modes

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d1bb8f51408327a655181365ec1231