### PR TITLE
Fix THREE namespace selection without mutating module exports

### DIFF
--- a/index.html
+++ b/index.html
@@ -434,17 +434,17 @@
 
 
     <script type="module">
-        import * as THREE from 'three';
+        import * as ThreeModule from 'three';
         import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
         import { EffectComposer } from 'three/examples/jsm/postprocessing/EffectComposer.js';
         import { RenderPass } from 'three/examples/jsm/postprocessing/RenderPass.js';
         import { UnrealBloomPass } from 'three/examples/jsm/postprocessing/UnrealBloomPass.js';
         import { createPhotoSkydome } from './src/sky/photoSkydome.js';
 
-        if (typeof window.THREE !== 'undefined') {
-            Object.assign(THREE, window.THREE);
+        const THREE = window.THREE ?? ThreeModule;
+        if (!window.THREE) {
+            window.THREE = THREE;
         }
-        window.THREE = THREE;
 
         let __level = 1; // start at night since we call setAmount(1)
         window.addEventListener('keydown', (e) => {


### PR DESCRIPTION
## Summary
- guard the THREE initialization to reuse any existing global namespace without mutating the module export

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d1d776110083278f04072b14c01bf3