### PR TITLE
Fix GLB paths for NPC and temple models

### DIFF
--- a/index.html
+++ b/index.html
@@ -4689,7 +4689,7 @@
         const loadTemple = () => {
             const templeGroup = new THREE.Group();
             gltfLoader.load(
-                './data/models/greek_temple.glb',
+                './models/greek_temple.glb',
                 (gltf) => {
                     const temple = gltf.scene || new THREE.Group();
                     temple.scale.set(3, 3, 3);
@@ -4708,7 +4708,7 @@
         const loadNPC = () => {
             const npcGroup = new THREE.Group();
             gltfLoader.load(
-                './data/models/npc_athenian.glb',
+                './models/character.glb',
                 (gltf) => {
                     const npc = gltf.scene || new THREE.Group();
                     npc.scale.set(1.2, 1.2, 1.2);


### PR DESCRIPTION
## Summary
- point the NPC loader at the existing `models/character.glb` so the character asset is found at runtime
- update the late-scene temple loader to read from `models/greek_temple.glb`, matching the asset layout already in the repo

## Testing
- python -m http.server 4173 (manually verified in browser that character GLB loads without NPC load warning)

------
https://chatgpt.com/codex/tasks/task_b_68d1db64b36083279e1ac65ec54b1eb4