### PR TITLE
Fix initialization try-catch structure

### DIFF
--- a/index.html
+++ b/index.html
@@ -816,7 +816,7 @@
             try {
                 if (window.threeJSReady) {
                     await window.threeJSReady;
-                } catch (error) { console.error('Error caught in script:', error); }
+                }
 
                 if (typeof THREE === 'undefined') {
                     console.error('THREE.js is not available. Please ensure external resources can be loaded.');
@@ -824,23 +824,24 @@
                     return;
                 }
 
-console.log('console.log('THREE.js is ready, initializing Athens...');
-try {
-    await main();
-} catch (error) {
-    if (!error?.__athensLogged) {
-        console.error('Athens experience failed to initialize:', error);
-        if (error?.stack) {
-            console.error(error.stack);
-        } catch (error) { console.error('Error caught in script:', error); }
-        logDetailedError('Main Function Execution', error);
-        showErrorOverlay('Main Function Execution', error, true);
-        error.__athensLogged = true;
-    }
-    throw error;
-}
+                console.log('THREE.js is ready, initializing Athens...');
 
-async function main() {
+                await main();
+            } catch (error) {
+                if (!error?.__athensLogged) {
+                    console.error('Athens experience failed to initialize:', error);
+                    if (error?.stack) {
+                        console.error(error.stack);
+                    }
+                    logDetailedError('Main Function Execution', error);
+                    showErrorOverlay('Main Function Execution', error, true);
+                    error.__athensLogged = true;
+                }
+                throw error;
+            }
+        }
+
+        async function main() {
 
         // --- GLOBAL VARIABLES ---
         let scene, camera, renderer, composer, ambientLight, directionalLight, hemisphereLight, player;


### PR DESCRIPTION
## Summary
- restructure the initialization try/catch so it cleanly wraps THREE.js readiness checks and main startup
- retain error overlay reporting while removing nested catch blocks and correct the readiness console log

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d27e159ba48327a2d8eb2d2ca99184