### PR TITLE
Fix init error handling block in index module

### DIFF
--- a/index.html
+++ b/index.html
@@ -5121,27 +5121,26 @@ function createAgoraComplex() {
         }
         
         // Initialize the application
-try {
-    await init();
-} catch (error) {
-    console.error('Failed to initialize Athens experience:', error);
-    if (error?.stack) {
-        console.error(error.stack);
-    } catch (error) { console.error('Error caught in script:', error); }
-    logDetailedError('Async Initialization', error);
-    showErrorOverlay('Async Initialization', error, false);
-    error.__athensLogged = true;
-    throw error;
-}
+        try {
+            await init();
+        } catch (error) {
+            console.error('Failed to initialize Athens experience:', error);
+            if (error?.stack) {
+                console.error(error.stack);
+            }
+            logDetailedError('Async Initialization', error);
+            showErrorOverlay('Async Initialization', error, false);
+            error.__athensLogged = true;
+            throw error;
+        }
 
-        } // End of main function
+} // End of main function
         
         // --- START ---
         window.onload = function() {
             initializeAthens();
         };
-
-    }})</script>
+</script>
 <script type="module">
         import { loadGeoJson } from './src/geo/geoLoader.js';
         import { LocalEquirectangularProjection } from './src/geo/projection.js';


### PR DESCRIPTION
## Summary
- clean up the async init error handling block at the end of the main module so the catch logic sits outside the stack check
- remove the stray closing braces before the module script tag to restore the intended structure

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d27eba87608327a96e5f9b286683f0