### PR TITLE
Fix Tone.js start handler structure

### DIFF
--- a/index.html
+++ b/index.html
@@ -4729,7 +4729,7 @@ function createAgoraComplex() {
                         const tone = await loadToneLibrary();
                         if (!tone || typeof tone.start !== 'function') {
                             throw new Error('Tone.js is unavailable after loading.');
-                        } catch (error) { console.error('Error caught in script:', error); }
+                        }
                         await tone.start();
                         console.log("Audio context started.");
                         createAmbientSounds();


### PR DESCRIPTION
## Summary
- restructure the start button click handler to keep the `try`/`catch` around the Tone.js startup calls while removing the redundant inline `catch`

## Testing
- not run (not applicable in this environment)


------
https://chatgpt.com/codex/tasks/task_b_68d2874fad8883278e222de3ee1ece01