### PR TITLE
Fix overlay options object closure

### DIFF
--- a/index.html
+++ b/index.html
@@ -5210,7 +5210,7 @@ function createAgoraComplex() {
         markerFill: '#FFD700',
         markerStroke: '#704c00',
         fitPadding: 48
-      } catch (error) { console.error('Error caught in script:', error); };
+      };
 
       let overlay = null;
       if (typeof createLandmarkOverlay === 'function') {


### PR DESCRIPTION
## Summary
- close the landmark overlay options object literal before the catch block
- keep the existing try/catch flow for overlay initialization

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d287c0b6bc832793236407b347d91b