### PR TITLE
Fix sky texture loading path

### DIFF
--- a/index.html
+++ b/index.html
@@ -1113,13 +1113,13 @@
             document.body.appendChild(renderer.domElement);
             window.renderer = renderer;
 
-          const sunsetSky = await createPhotoSkydome({
-  scene,
-  renderer,
-  url: 'athens/assets/sky/sunset.jpg',   // <— your new file
-  radius: 5000,
-  initialYawDeg: 0
-});
+            const photoSky = await createPhotoSkydome({
+                scene,
+                renderer,
+                url: new URL('./src/sky/sunset.jpg', import.meta.url).href,
+                radius: 5000,
+                initialYawDeg: 0
+            });
 
             photoSky.setAmount(1);
             window.__AthensSky__ = photoSky;


### PR DESCRIPTION
## Summary
- load the photo skydome texture from the repository using a proper relative URL
- keep a reference to the created skydome so initialization can continue

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d28a5d12e48327a47148146ed04322