### PR TITLE
Deploy Athenian NPC guards

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,8 @@
             "three/examples/jsm/objects/Sky.js": "https://cdn.jsdelivr.net/npm/three@0.128.0/examples/jsm/objects/Sky.js",
             "three/examples/jsm/postprocessing/EffectComposer.js": "https://cdn.jsdelivr.net/npm/three@0.128.0/examples/jsm/postprocessing/EffectComposer.js",
             "three/examples/jsm/postprocessing/RenderPass.js": "https://cdn.jsdelivr.net/npm/three@0.128.0/examples/jsm/postprocessing/RenderPass.js",
-            "three/examples/jsm/postprocessing/UnrealBloomPass.js": "https://cdn.jsdelivr.net/npm/three@0.128.0/examples/jsm/postprocessing/UnrealBloomPass.js"
+            "three/examples/jsm/postprocessing/UnrealBloomPass.js": "https://cdn.jsdelivr.net/npm/three@0.128.0/examples/jsm/postprocessing/UnrealBloomPass.js",
+            "three/examples/jsm/utils/SkeletonUtils.js": "https://cdn.jsdelivr.net/npm/three@0.128.0/examples/jsm/utils/SkeletonUtils.js"
         }
     }
     </script>
@@ -5492,6 +5493,7 @@ function createBasicAgoraFallback() {
 <script type="module">
         import THREE from './src/three.js';
         import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
+        import { SkeletonUtils } from 'three/examples/jsm/utils/SkeletonUtils.js';
 
         const waitForWorld = () => {
             if (window.athensWorldBuilt && window.scene && window.renderer) {
@@ -5540,6 +5542,34 @@ function createBasicAgoraFallback() {
                 object.position.set(x, y, z);
             }
         };
+
+        const athenianGuardPlacements = [
+            {
+                name: 'Agora Guard',
+                position: { x: -1090.575, y: 0, z: 950.573 },
+                rotation: Math.PI / 3
+            },
+            {
+                name: 'Acropolis Guard',
+                position: { x: 115.092, y: 0, z: -85.479 },
+                rotation: -Math.PI / 2
+            },
+            {
+                name: 'Pnyx Guard',
+                position: { x: -1643.722, y: 0, z: 623.381 },
+                rotation: (3 * Math.PI) / 4
+            },
+            {
+                name: 'Areopagus Guard',
+                position: { x: 2161.233, y: 0, z: -1655.909 },
+                rotation: Math.PI / 8
+            },
+            {
+                name: 'Kerameikos Guard',
+                position: { x: 1398.34, y: 0, z: -708.156 },
+                rotation: -Math.PI / 4
+            }
+        ];
 
         await waitForWorld();
 
@@ -5612,7 +5642,7 @@ function createBasicAgoraFallback() {
             );
         };
 
-        const loadNPC = () => {
+        const loadAthenianGuards = () => {
             loadModelWithFallback(
                 [
                     './models/npc_athenian.glb',
@@ -5620,33 +5650,60 @@ function createBasicAgoraFallback() {
                     './models/character.glb'
                 ],
                 (gltf, modelPath) => {
-                    const npcGroup = new THREE.Group();
-                    const npc = gltf.scene || new THREE.Group();
-                    npc.scale.set(1.2, 1.2, 1.2);
-                    npcGroup.add(npc);
-                    applyMeshEnhancements(npcGroup, renderer);
-                    placeObject(npcGroup, -10, 0, 5);
-                    scene.add(npcGroup);
+                    const baseModel = gltf.scene || new THREE.Group();
+                    const mixers = window.externalAnimationMixers || (window.externalAnimationMixers = []);
+                    const guardGroups = [];
 
-                    if (Array.isArray(gltf.animations) && gltf.animations.length) {
-                        const mixers = window.externalAnimationMixers || (window.externalAnimationMixers = []);
-                        const npcMixer = new THREE.AnimationMixer(npc);
-                        gltf.animations.forEach((clip) => {
-                            npcMixer.clipAction(clip).play();
-                        });
-                        mixers.push(npcMixer);
-                    }
+                    athenianGuardPlacements.forEach((placement, index) => {
+                        const guardGroup = new THREE.Group();
+                        const guard = SkeletonUtils?.clone
+                            ? SkeletonUtils.clone(baseModel)
+                            : baseModel.clone(true);
 
-                    console.info(`NPC model loaded from ${modelPath}.`);
+                        guard.scale.set(1.2, 1.2, 1.2);
+                        guardGroup.add(guard);
+
+                        if (typeof placement.rotation === 'number') {
+                            guardGroup.rotation.y = placement.rotation;
+                        }
+
+                        guardGroup.name = placement.name || `Athenian Guard ${index + 1}`;
+                        guardGroup.userData = {
+                            ...guardGroup.userData,
+                            npcRole: placement.name,
+                            npcIndex: index
+                        };
+
+                        applyMeshEnhancements(guardGroup, renderer);
+
+                        const { x, y = 0, z } = placement.position;
+                        placeObject(guardGroup, x, y, z);
+                        scene.add(guardGroup);
+                        guardGroups.push(guardGroup);
+
+                        if (Array.isArray(gltf.animations) && gltf.animations.length) {
+                            const mixer = new THREE.AnimationMixer(guard);
+                            gltf.animations.forEach((clip) => {
+                                mixer.clipAction(clip).play();
+                            });
+                            mixers.push(mixer);
+                        }
+                    });
+
+                    window.athenianNPCs = guardGroups;
+
+                    console.info(
+                        `Athenian NPC model loaded from ${modelPath} and deployed at ${athenianGuardPlacements.length} locations.`
+                    );
                 },
                 (error) => {
-                    console.error('NPC model failed to load after all fallback attempts.', error);
+                    console.error('Athenian NPC model failed to load after all fallback attempts.', error);
                 }
             );
         };
 
         loadTemple();
-        loadNPC();
+        loadAthenianGuards();
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a SkeletonUtils import map entry so animated GLB characters can be cloned safely
- load the Athenian NPC model (with fallbacks) and deploy five cloned guards across key city districts
- expose references for the spawned guard groups while preserving existing temple loading behavior

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d2916268fc8327a2635c9981efaf27