### PR TITLE
Separate Parthenon and Acropolis landmarks

### DIFF
--- a/index.html
+++ b/index.html
@@ -4159,7 +4159,6 @@ function createBasicAgoraFallback() {
         // --- GAME LOGIC & ANIMATION ---
         
         const locations = [
-            { name: "The Parthenon", position: scaleLocation({ x: ACROPOLIS_POSITION.x, y: 10, z: ACROPOLIS_POSITION.z }), radius: scaleValue(30), title: "🏛️ The Parthenon" },
             { name: "Temple of Hephaistos", position: scaleLocation({ x: AGORA_FEATURES.templeOfHephaistos.position.x, y: 4, z: AGORA_FEATURES.templeOfHephaistos.position.z }), radius: scaleValue(18), title: "🛠️ Temple of Hephaistos" },
             { name: "Stoa of Attalos", position: scaleLocation({ x: AGORA_FEATURES.stoaOfAttalos.position.x, y: 4, z: AGORA_FEATURES.stoaOfAttalos.position.z }), radius: scaleValue(28), title: "🏛️ Stoa of Attalos" },
             { name: "Tholos", position: scaleLocation({ x: AGORA_FEATURES.tholos.position.x, y: 3, z: AGORA_FEATURES.tholos.position.z }), radius: scaleValue(16), title: "⚖️ The Tholos" },
@@ -5306,6 +5305,19 @@ function createBasicAgoraFallback() {
                         const name = props.title || props.name || 'Unnamed';
                         const rawCategory = (props.category || 'cultural').toString().toLowerCase();
                         const category = ['democracy', 'cultural', 'natural'].includes(rawCategory) ? rawCategory : 'cultural';
+
+                        const normalizedName = name.toLowerCase();
+                        if (normalizedName === 'parthenon' || normalizedName === 'the parthenon') {
+                            locations.push({
+                                name: 'The Parthenon',
+                                position: worldPos.clone(),
+                                radius: scaleValue(30),
+                                title: '🏛️ The Parthenon',
+                                type: category
+                            });
+                            addMiniMapDot(category, worldPos);
+                            return;
+                        }
 
                         locations.push({
                             name,

--- a/src/buildings-from-geojson.js
+++ b/src/buildings-from-geojson.js
@@ -3,6 +3,7 @@ import {
   makeTemple, makeStoa, makeTheatre, makeTholos, makeWallPath,
   makePropylon, makeBlock, makeAltar, makeExedra
 } from './building-kit.js';
+import { applyFeatureOffset } from './geo/featureOffsets.js';
 
 const deg = (d)=> THREE.MathUtils.degToRad(d);
 
@@ -158,7 +159,10 @@ export async function buildFromGeoJSON({ scene, geoJsonUrl, projector }) {
     const rotDeg = props.rotation_deg ?? cfgDirect?.defaultRotationDeg ?? 0;
 
     if (f.geometry?.type === 'Point') {
-      const [lon, lat] = f.geometry.coordinates;
+      const [lon, lat] = applyFeatureOffset(
+        f.geometry.coordinates,
+        { properties: props, fallbackName: rawName }
+      );
       const pos = toWorld(lon, lat);
 
       const cfg = cfgDirect;

--- a/src/geo/__tests__/featureOffsets.test.js
+++ b/src/geo/__tests__/featureOffsets.test.js
@@ -1,0 +1,34 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { getFeatureOffset, applyFeatureOffset } from '../featureOffsets.js';
+
+const EPSILON = 1e-12;
+
+const PARTHENON_COORDS = [23.726663, 37.971536];
+
+function almostEqual(a, b, epsilon = EPSILON) {
+    assert.ok(Math.abs(a - b) <= epsilon, `Expected ${a} ≈ ${b}`);
+}
+
+test('getFeatureOffset resolves Parthenon offsets irrespective of casing', () => {
+    const offset = getFeatureOffset('parthenon');
+    assert.ok(offset, 'offset should be registered for the Parthenon');
+    almostEqual(offset.deltaLon, 0.0004);
+    almostEqual(offset.deltaLat, 0.0003);
+});
+
+test('applyFeatureOffset adjusts coordinates for matching features', () => {
+    const [lon, lat] = applyFeatureOffset(PARTHENON_COORDS, {
+        fallbackName: 'Parthenon'
+    });
+    almostEqual(lon, PARTHENON_COORDS[0] + 0.0004);
+    almostEqual(lat, PARTHENON_COORDS[1] + 0.0003);
+});
+
+test('applyFeatureOffset leaves unrelated coordinates untouched', () => {
+    const original = [23.7229, 37.9753];
+    const adjusted = applyFeatureOffset(original, { fallbackName: 'Agora of Athens' });
+    almostEqual(adjusted[0], original[0]);
+    almostEqual(adjusted[1], original[1]);
+});

--- a/src/geo/featureOffsets.js
+++ b/src/geo/featureOffsets.js
@@ -1,0 +1,74 @@
+const FEATURE_OFFSETS = new Map([
+    [
+        'parthenon',
+        {
+            /** Approximate longitudinal offset in degrees eastward */
+            deltaLon: 0.0004,
+            /** Approximate latitudinal offset in degrees northward */
+            deltaLat: 0.0003
+        }
+    ]
+]);
+
+function normalizeFeatureName(name) {
+    if (typeof name !== 'string') {
+        return '';
+    }
+    return name
+        .normalize('NFD')
+        .replace(/\p{Diacritic}/gu, '')
+        .toLowerCase()
+        .trim();
+}
+
+export function getFeatureOffset(name) {
+    const normalized = normalizeFeatureName(name ?? '');
+    if (!normalized) {
+        return null;
+    }
+    return FEATURE_OFFSETS.get(normalized) ?? null;
+}
+
+export function resolveFeatureOffset(properties = {}, fallbackName) {
+    const candidates = [];
+    if (typeof properties.title === 'string') {
+        candidates.push(properties.title);
+    }
+    if (typeof properties.name === 'string') {
+        candidates.push(properties.name);
+    }
+    if (typeof fallbackName === 'string') {
+        candidates.push(fallbackName);
+    }
+
+    for (const candidate of candidates) {
+        const offset = getFeatureOffset(candidate);
+        if (offset) {
+            return offset;
+        }
+    }
+    return null;
+}
+
+export function applyFeatureOffset(coordinates, { properties = {}, fallbackName } = {}) {
+    if (!Array.isArray(coordinates) || coordinates.length < 2) {
+        return coordinates;
+    }
+    const [lonRaw, latRaw, ...rest] = coordinates;
+    const lon = Number(lonRaw);
+    const lat = Number(latRaw);
+    if (!Number.isFinite(lon) || !Number.isFinite(lat)) {
+        return coordinates;
+    }
+
+    const offset = resolveFeatureOffset(properties, fallbackName);
+    if (!offset) {
+        return [lon, lat, ...rest];
+    }
+
+    const deltaLon = Number.isFinite(offset.deltaLon) ? offset.deltaLon : 0;
+    const deltaLat = Number.isFinite(offset.deltaLat) ? offset.deltaLat : 0;
+    return [lon + deltaLon, lat + deltaLat, ...rest];
+}
+
+export { FEATURE_OFFSETS };

--- a/src/landmarks-loader.js
+++ b/src/landmarks-loader.js
@@ -1,4 +1,5 @@
 import THREE from './three.js';
+import { applyFeatureOffset } from './geo/featureOffsets.js';
 
 /**
  * Load every feature from a GeoJSON file and add to the scene.
@@ -38,7 +39,10 @@ export async function loadLandmarks({
     const targetGroup = groups[cat] || groups.cultural;
 
     if (f.geometry?.type === 'Point') {
-      const [lon, lat] = f.geometry.coordinates;
+      const [lon, lat] = applyFeatureOffset(f.geometry.coordinates, {
+        properties: props,
+        fallbackName: name
+      });
       const pos = projector ? projector(lon, lat) : lonLatToLocal(lon, lat);
 
       const pin = makePinMesh(cat);

--- a/src/map/landmarks.js
+++ b/src/map/landmarks.js
@@ -1,5 +1,6 @@
 import { loadGeoJson } from '../geo/geoLoader.js';
 import { LocalEquirectangularProjection } from '../geo/projection.js';
+import { applyFeatureOffset } from '../geo/featureOffsets.js';
 import { AgoraLayer } from './agoraLayer.js';
 
 const LANDMARK_LABELS = {
@@ -456,9 +457,13 @@ export class LandmarkOverlay {
             }
 
             if (geometry.type === 'Point') {
-                const world = this.projection.projectGeoJsonPosition(geometry.coordinates);
-                this._extendBounds(world);
                 const canonicalName = properties.name || properties.id || properties.title || 'Unnamed landmark';
+                const adjustedCoords = applyFeatureOffset(geometry.coordinates, {
+                    properties,
+                    fallbackName: canonicalName
+                });
+                const world = this.projection.projectGeoJsonPosition(adjustedCoords);
+                this._extendBounds(world);
                 const displayTitle = properties.title || canonicalName;
                 const short = LANDMARK_LABELS[canonicalName]
                     || LANDMARK_LABELS[displayTitle]


### PR DESCRIPTION
## Summary
- add a GeoJSON feature offset helper that repositions the Parthenon away from the Acropolis
- use the offsets when building 3D meshes, placing landmark pins, and drawing the 2D overlay
- update location tracking to treat the Parthenon specially and cover the helper with unit tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d29098ed08832781936484c60be7f7