### PR TITLE
Add high noon sky texture support with fallback

### DIFF
--- a/index.html
+++ b/index.html
@@ -1114,13 +1114,32 @@
             document.body.appendChild(renderer.domElement);
             window.renderer = renderer;
 
+            const photoSkyTextureSources = [
+                {
+                    url: new URL('./assets/sky/high_noon.jpg', import.meta.url).href,
+                    label: 'High Noon sky panorama'
+                },
+                {
+                    url: new URL('./src/sky/sunset.jpg', import.meta.url).href,
+                    label: 'Bundled sunset fallback',
+                    isFallback: true
+                }
+            ];
+
             const photoSky = await createPhotoSkydome({
                 scene,
                 renderer,
-                url: new URL('./src/sky/sunset.jpg', import.meta.url).href,
+                sources: photoSkyTextureSources,
                 radius: 5000,
                 initialYawDeg: 0
             });
+
+            if (photoSky?.source) {
+                const { label, url, isFallback } = photoSky.source;
+                const description = label || url;
+                const suffix = isFallback ? ' (fallback)' : '';
+                console.info(`Photo skydome texture loaded: ${description}${suffix}`);
+            }
 
             photoSky.setAmount(1);
             window.__AthensSky__ = photoSky;

--- a/public/assets/sky/README.md
+++ b/public/assets/sky/README.md
@@ -8,3 +8,14 @@ public/assets/sky/night_sky.jpg
 
 The runtime will attempt to load this file first. If it is not present, the bundled fallback texture (embedded as a data URL)
 will be used so the scene still renders with a night sky.
+
+## High Noon Photo Sky
+
+Drop the high-noon panorama (JPG) into:
+
+```
+public/assets/sky/high_noon.jpg
+```
+
+During startup the experience now tries to load this asset for the photographic skydome. If the file is missing, the engine
+falls back to the bundled `src/sky/sunset.jpg` texture so development builds still render.


### PR DESCRIPTION
## Summary
- allow the photo skydome loader to try multiple texture sources and fall back when needed
- update the main scene bootstrap to request the new high-noon sky texture before the bundled sunset fallback
- document where to drop the new high-noon panorama in the public assets directory

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d297620a988327af1243f87580f860