### PR TITLE
Add support for blue and golden hour photo skies

### DIFF
--- a/index.html
+++ b/index.html
@@ -415,7 +415,7 @@
         import { EffectComposer } from 'three/examples/jsm/postprocessing/EffectComposer.js';
         import { RenderPass } from 'three/examples/jsm/postprocessing/RenderPass.js';
         import { UnrealBloomPass } from 'three/examples/jsm/postprocessing/UnrealBloomPass.js';
-        import { createPhotoSkydome } from './src/sky/photoSkydome.js';
+        import { createPhotoSkydome, loadPhotoSkyTexture } from './src/sky/photoSkydome.js';
         import { nightSkyDataUrl } from './src/sky/nightSkyTextureData.js';
 
         const TONE_JS_URL = 'https://cdnjs.cloudflare.com/ajax/libs/tone/14.7.77/Tone.js';
@@ -1058,6 +1058,104 @@
         let bloomPass;
         let fogEnabled = true;
         let spaceNight = null;
+        let photoSky = null;
+        const photoSkyTextureCache = new Map();
+        const photoSkyTexturePromises = new Map();
+        let photoSkyTextureRequestId = 0;
+        const photoSkyTextureLoader = new THREE.TextureLoader();
+        const PHOTO_SKY_TIME_KEYS = {
+            'Golden Dawn': 'golden',
+            'Golden Dusk': 'golden',
+            'Blue Hour': 'blue',
+            'High Noon': 'high_noon',
+            'Starlit Night': 'starlit'
+        };
+        const getPhotoSkyCacheKey = (timeName) => PHOTO_SKY_TIME_KEYS[timeName] || timeName;
+        const sunsetFallbackSource = () => ({
+            url: new URL('./src/sky/sunset.jpg', import.meta.url).href,
+            label: 'Bundled sunset fallback',
+            isFallback: true
+        });
+        const photoSkySourceFactories = {
+            golden: () => [
+                { url: new URL('./assets/sky/golden_hour.jpg', import.meta.url).href, label: 'Golden Hour sky panorama' },
+                sunsetFallbackSource()
+            ],
+            blue: () => [
+                { url: new URL('./assets/sky/blue_hour.jpg', import.meta.url).href, label: 'Blue Hour sky panorama' },
+                sunsetFallbackSource()
+            ],
+            high_noon: () => [
+                { url: new URL('./assets/sky/high_noon.jpg', import.meta.url).href, label: 'High Noon sky panorama' },
+                sunsetFallbackSource()
+            ],
+            starlit: () => nightSkyTextureSources.map((source) => ({ ...source }))
+        };
+
+        function getPhotoSkySourcesForTime(timeName) {
+            const key = getPhotoSkyCacheKey(timeName);
+            let factory = photoSkySourceFactories[key];
+            if (typeof factory !== 'function') {
+                factory = photoSkySourceFactories.starlit;
+                if (typeof factory !== 'function') {
+                    return [];
+                }
+            }
+            const sources = factory();
+            return Array.isArray(sources) ? sources : [];
+        }
+
+        function loadPhotoSkyTextureForTime(timeName) {
+            const cacheKey = getPhotoSkyCacheKey(timeName);
+            if (photoSkyTextureCache.has(cacheKey)) {
+                return Promise.resolve(photoSkyTextureCache.get(cacheKey));
+            }
+            if (photoSkyTexturePromises.has(cacheKey)) {
+                return photoSkyTexturePromises.get(cacheKey);
+            }
+            const sources = getPhotoSkySourcesForTime(timeName);
+            if (!sources.length) {
+                return Promise.resolve(null);
+            }
+            const promise = loadPhotoSkyTexture({ sources, loader: photoSkyTextureLoader })
+                .then((result) => {
+                    photoSkyTexturePromises.delete(cacheKey);
+                    if (result?.texture) {
+                        photoSkyTextureCache.set(cacheKey, result);
+                    }
+                    return result;
+                })
+                .catch((error) => {
+                    photoSkyTexturePromises.delete(cacheKey);
+                    console.error(`Photo skydome texture load failed for ${timeName}:`, error);
+                    return null;
+                });
+            photoSkyTexturePromises.set(cacheKey, promise);
+            return promise;
+        }
+
+        function applyPhotoSkyTextureForTime(timeName) {
+            if (!photoSky) {
+                return;
+            }
+            const cacheKey = getPhotoSkyCacheKey(timeName);
+            const cached = photoSkyTextureCache.get(cacheKey);
+            if (cached?.texture) {
+                photoSky.setTexture(cached.texture, cached.source);
+                return;
+            }
+            const requestId = ++photoSkyTextureRequestId;
+            loadPhotoSkyTextureForTime(timeName)
+                .then((result) => {
+                    if (!result?.texture) return;
+                    if (photoSkyTextureRequestId !== requestId) return;
+                    photoSky.setTexture(result.texture, result.source);
+                })
+                .catch((error) => {
+                    console.error(`Failed to apply photo skydome texture for ${timeName}:`, error);
+                });
+        }
+
         let canChickenCluck = true;
         let lastCluckTime = 0;
         
@@ -1167,22 +1265,12 @@
             document.body.appendChild(renderer.domElement);
             window.renderer = renderer;
 
-            const photoSkyTextureSources = [
-                {
-                    url: new URL('./assets/sky/high_noon.jpg', import.meta.url).href,
-                    label: 'High Noon sky panorama'
-                },
-                {
-                    url: new URL('./src/sky/sunset.jpg', import.meta.url).href,
-                    label: 'Bundled sunset fallback',
-                    isFallback: true
-                }
-            ];
-
-            const photoSky = await createPhotoSkydome({
+            const initialTimeName = timeNames[currentTimeOfDay] || 'Starlit Night';
+            const initialPhotoSkySources = getPhotoSkySourcesForTime(initialTimeName);
+            photoSky = await createPhotoSkydome({
                 scene,
                 renderer,
-                sources: photoSkyTextureSources,
+                sources: initialPhotoSkySources,
                 radius: 5000,
                 initialYawDeg: 0
             });
@@ -1193,6 +1281,20 @@
                 const suffix = isFallback ? ' (fallback)' : '';
                 console.info(`Photo skydome texture loaded: ${description}${suffix}`);
             }
+
+            const initialCacheKey = getPhotoSkyCacheKey(initialTimeName);
+            if (photoSky.texture) {
+                photoSkyTextureCache.set(initialCacheKey, {
+                    texture: photoSky.texture,
+                    source: photoSky.source
+                });
+            }
+
+            timeNames.forEach((name) => {
+                if (name !== initialTimeName) {
+                    loadPhotoSkyTextureForTime(name);
+                }
+            });
 
             photoSky.setAmount(1);
             window.__AthensSky__ = photoSky;
@@ -3278,6 +3380,8 @@ function createBasicAgoraFallback() {
                 timeInfo.textContent = name;
             }
 
+            applyPhotoSkyTextureForTime(name);
+
             const settings = {
                 elevation: 45,
                 azimuth: 180,
@@ -3439,13 +3543,34 @@ function createBasicAgoraFallback() {
                 }
             }
 
-            let night = 0;
-            if (name === 'Starlit Night') night = 1;
-            else if (name === 'Blue Hour') night = 0.4;
-            if (spaceNight) {
-                spaceNight.setAmount(night);
+            let starAmount = 0;
+            let photoSkyAmount = 0;
+
+            switch (name) {
+                case 'Starlit Night':
+                    starAmount = 1;
+                    photoSkyAmount = 1;
+                    break;
+                case 'Blue Hour':
+                    starAmount = 0.45;
+                    photoSkyAmount = 0.9;
+                    break;
+                case 'Golden Dawn':
+                case 'Golden Dusk':
+                    photoSkyAmount = 0.85;
+                    break;
+                default:
+                    break;
             }
-            window.__AthensSky__?.setAmount(night);
+
+            if (spaceNight) {
+                spaceNight.setAmount(starAmount);
+            }
+            if (photoSky) {
+                photoSky.setAmount(photoSkyAmount);
+            } else if (window.__AthensSky__) {
+                window.__AthensSky__.setAmount(photoSkyAmount);
+            }
         }
 
         function updateNightCycle(dt = 0.016) {

--- a/public/assets/sky/README.md
+++ b/public/assets/sky/README.md
@@ -19,3 +19,25 @@ public/assets/sky/high_noon.jpg
 
 During startup the experience now tries to load this asset for the photographic skydome. If the file is missing, the engine
 falls back to the bundled `src/sky/sunset.jpg` texture so development builds still render.
+
+## Golden Hour Photo Sky
+
+Drop the golden-hour panorama (JPG) into:
+
+```
+public/assets/sky/golden_hour.jpg
+```
+
+This texture is blended in for both the Golden Dawn and Golden Dusk lighting presets. When the file is absent, the runtime
+reuses the bundled sunset texture so the scene still has a warm fallback.
+
+## Blue Hour Photo Sky
+
+Place the blue-hour panorama (JPG) provided by the art team at:
+
+```
+public/assets/sky/blue_hour.jpg
+```
+
+It will be applied automatically whenever the experience switches to the Blue Hour ambience. Missing files fall back to the
+bundled sunset texture, ensuring development builds continue to render even without the photographic asset.

--- a/src/sky/photoSkydome.js
+++ b/src/sky/photoSkydome.js
@@ -1,6 +1,47 @@
 // src/sky/photoSkydome.js
 import THREE from '../three.js';
 
+function normalizeSources(sources) {
+  if (!Array.isArray(sources)) return [];
+  return sources
+    .map((source) => (source && typeof source.url === 'string' && source.url.length > 0 ? source : null))
+    .filter(Boolean);
+}
+
+export async function loadPhotoSkyTexture({ sources, loader = new THREE.TextureLoader() } = {}) {
+  const sourceList = normalizeSources(sources);
+
+  if (sourceList.length === 0) {
+    throw new Error('No sky texture source provided for photo skydome.');
+  }
+
+  let chosenSource = null;
+  let texture = null;
+  let lastError = null;
+
+  for (const source of sourceList) {
+    const label = source.label ? ` ("${source.label}")` : '';
+    try {
+      texture = await loader.loadAsync(source.url);
+      if ('colorSpace' in texture) texture.colorSpace = THREE.SRGBColorSpace;
+      else texture.encoding = THREE.sRGBEncoding;
+      chosenSource = source;
+      break;
+    } catch (err) {
+      lastError = err;
+      console.warn(`PhotoSkydome: failed to load texture${label} from ${source.url}`, err);
+    }
+  }
+
+  if (!texture) {
+    const error = lastError || new Error('Unable to load any photo skydome texture.');
+    error.sources = sourceList.map((source) => source.url);
+    throw error;
+  }
+
+  return { texture, source: chosenSource };
+}
+
 export async function createPhotoSkydome({
   scene,
   renderer,
@@ -9,7 +50,6 @@ export async function createPhotoSkydome({
   radius = 5000,
   initialYawDeg = 0
 }) {
-  const loader = new THREE.TextureLoader();
   const sourceList = Array.isArray(sources) && sources.length > 0
     ? sources
     : (url ? [{ url, label: 'default sky texture' }] : []);
@@ -18,32 +58,15 @@ export async function createPhotoSkydome({
     throw new Error('No sky texture source provided for photo skydome.');
   }
 
-  let chosenSource = null;
-  let tex = null;
-  let lastError = null;
-
-  for (const source of sourceList) {
-    try {
-      tex = await loader.loadAsync(source.url);
-      chosenSource = source;
-      break;
-    } catch (err) {
-      lastError = err;
-      const label = source.label ? ` ("${source.label}")` : '';
-      console.warn(`PhotoSkydome: failed to load texture${label} from ${source.url}`, err);
-    }
-  }
-
-  if (!tex) {
-    throw lastError || new Error('Unable to load any photo skydome texture.');
-  }
-  // three r150+: colorSpace; older three: encoding fallback
-  if ('colorSpace' in tex) tex.colorSpace = THREE.SRGBColorSpace;
-  else tex.encoding = THREE.sRGBEncoding;
+  const loader = new THREE.TextureLoader();
+  const { texture: initialTexture, source: initialSource } = await loadPhotoSkyTexture({
+    sources: sourceList,
+    loader
+  });
 
   const geo = new THREE.SphereGeometry(radius, 64, 64);
   const mat = new THREE.MeshBasicMaterial({
-    map: tex,
+    map: initialTexture,
     side: THREE.BackSide,     // view from inside
     transparent: true,
     opacity: 0.0,             // start hidden (day)
@@ -53,21 +76,61 @@ export async function createPhotoSkydome({
   dome.name = 'PhotoSkydome';
   dome.renderOrder = -1000;   // draw behind world
   dome.rotation.y = THREE.MathUtils.degToRad(initialYawDeg);
-  dome.userData.skyTextureSource = chosenSource;
+  dome.userData.skyTextureSource = initialSource;
   scene.add(dome);
+
+  let currentTexture = initialTexture;
+  let currentSource = initialSource;
 
   // Optional environment map for subtle night reflections
   let env = null;
-  if (renderer) {
-    const pmrem = new THREE.PMREMGenerator(renderer);
-    env = pmrem.fromEquirectangular(tex).texture;
-    pmrem.dispose();
-  }
 
-  return {
+  const updateEnvironmentFromTexture = (texture) => {
+    if (!renderer || !texture) return;
+    const pmrem = new THREE.PMREMGenerator(renderer);
+    const { texture: envTexture } = pmrem.fromEquirectangular(texture);
+    pmrem.dispose();
+    if (env && typeof env.dispose === 'function') {
+      env.dispose();
+    }
+    env = envTexture;
+    if (dome.material.opacity > 0.6) {
+      scene.environment = env;
+    }
+  };
+
+  updateEnvironmentFromTexture(currentTexture);
+
+  const setTexture = (texture, sourceInfo = null) => {
+    if (!texture) {
+      throw new Error('No texture provided for photo skydome.');
+    }
+
+    if ('colorSpace' in texture) texture.colorSpace = THREE.SRGBColorSpace;
+    else texture.encoding = THREE.sRGBEncoding;
+
+    if (dome.material.map !== texture) {
+      dome.material.map = texture;
+    }
+    dome.material.needsUpdate = true;
+
+    currentTexture = texture;
+    if (sourceInfo) {
+      currentSource = sourceInfo;
+      dome.userData.skyTextureSource = sourceInfo;
+    }
+
+    updateEnvironmentFromTexture(texture);
+  };
+
+  const api = {
     mesh: dome,
-    texture: tex,
-    source: chosenSource,
+    get texture() {
+      return currentTexture;
+    },
+    get source() {
+      return currentSource;
+    },
     setAmount(a) {
       const t = THREE.MathUtils.clamp(a, 0, 1);
       dome.material.opacity = t;
@@ -75,6 +138,9 @@ export async function createPhotoSkydome({
     },
     setYaw(deg) {
       dome.rotation.y = THREE.MathUtils.degToRad(deg);
-    }
+    },
+    setTexture
   };
+
+  return api;
 }


### PR DESCRIPTION
## Summary
- add a reusable loader for photographic skydome textures and allow swapping textures at runtime
- preload and cache golden-hour and blue-hour panoramas while updating time-of-day logic to use them
- document the new photographic sky asset drop locations for blue and golden hour imagery

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d29a2a0d488327931845f53cc2336c