### PR TITLE
Add runtime texture swapping for the photo skydome

### DIFF
--- a/index.html
+++ b/index.html
@@ -452,7 +452,7 @@
             return toneLoadingPromise;
         }
 
-        let __level = 1; // start at night since we call setAmount(1)
+        let __level = 0; // updated whenever setTimeOfDay applies a new preset
         window.addEventListener('keydown', (e) => {
             if (!window.__AthensSky__) return;
             if (e.key.toLowerCase() === 'n') {
@@ -500,6 +500,127 @@
                 isFallback: true
             });
         }
+
+        const photoSkyTexturesByKey = new Map();
+
+        const makePhotoSkySources = (fileName, labelPrefix, fallbackEntries = []) => {
+            const sources = [];
+            const seen = new Set();
+
+            const pushSource = (entry) => {
+                const url = entry?.url;
+                if (!url || seen.has(url)) {
+                    return;
+                }
+                seen.add(url);
+                sources.push(entry);
+            };
+
+            skyAssetLocations.forEach(({ prefix, label }, index) => {
+                const url = resolveRelativeUrl(`${prefix}${fileName}`);
+                pushSource({
+                    url,
+                    label: `${labelPrefix} (${label})`,
+                    isFallback: index > 0
+                });
+            });
+
+            fallbackEntries.forEach((entry) => {
+                if (!entry?.url) {
+                    return;
+                }
+                const shouldResolve = entry.resolve !== false;
+                const resolvedUrl = shouldResolve ? resolveRelativeUrl(entry.url) : entry.url;
+                pushSource({
+                    url: resolvedUrl,
+                    label: entry.label || entry.url,
+                    isFallback: true
+                });
+            });
+
+            return sources;
+        };
+
+        const registerPhotoSkySources = (key, fileName, labelPrefix, fallbackEntries = []) => {
+            if (photoSkyTexturesByKey.has(key)) {
+                return photoSkyTexturesByKey.get(key);
+            }
+            const sources = makePhotoSkySources(fileName, labelPrefix, fallbackEntries);
+            photoSkyTexturesByKey.set(key, sources);
+            return sources;
+        };
+
+        const goldenHourPhotoSources = registerPhotoSkySources(
+            'golden-hour',
+            'golden_hour.jpg',
+            'Golden hour sky panorama',
+            [
+                { url: './src/sky/sunset.jpg', label: 'Bundled sunset fallback' }
+            ]
+        );
+
+        const blueHourPhotoSources = registerPhotoSkySources(
+            'blue-hour',
+            'blue_hour.jpg',
+            'Blue hour sky panorama',
+            [
+                { url: './src/sky/night_sky.jpg', label: 'Bundled night sky fallback' }
+            ]
+        );
+
+        const highNoonPhotoSources = registerPhotoSkySources(
+            'high-noon',
+            'high_noon.jpg',
+            'High Noon sky panorama',
+            [
+                { url: './src/sky/sunset.jpg', label: 'Bundled sunset fallback' }
+            ]
+        );
+
+        const starlitNightPhotoSources = registerPhotoSkySources(
+            'starlit-night',
+            'night_sky.jpg',
+            'Night sky panorama',
+            [
+                { url: './src/sky/night_sky.jpg', label: 'Bundled night sky fallback' },
+                ...(typeof nightSkyDataUrl === 'string' && nightSkyDataUrl.length > 0
+                    ? [{ url: nightSkyDataUrl, label: 'embedded fallback night sky', resolve: false }]
+                    : [])
+            ]
+        );
+
+        const photoSkyTimeConfig = {
+            'Golden Dawn': {
+                textureKey: 'golden-hour',
+                sources: goldenHourPhotoSources,
+                skydomeOpacity: 0.75,
+                spaceNightAmount: 0.35
+            },
+            'Blue Hour': {
+                textureKey: 'blue-hour',
+                sources: blueHourPhotoSources,
+                skydomeOpacity: 0.9,
+                spaceNightAmount: 0.6
+            },
+            'High Noon': {
+                textureKey: 'high-noon',
+                sources: highNoonPhotoSources,
+                skydomeOpacity: 0.2,
+                spaceNightAmount: 0.0
+            },
+            'Golden Dusk': {
+                textureKey: 'golden-hour',
+                sources: goldenHourPhotoSources,
+                skydomeOpacity: 0.78,
+                spaceNightAmount: 0.45
+            },
+            'Starlit Night': {
+                textureKey: 'starlit-night',
+                sources: starlitNightPhotoSources,
+                skydomeOpacity: 1.0,
+                spaceNightAmount: 1.0
+            }
+        };
 
         const nightSkyCubeSources = skyAssetLocations.map(({ prefix, label }, index) => ({
             label: `cube map (${label})`,
@@ -1089,6 +1210,8 @@
         let bloomPass;
         let fogEnabled = true;
         let spaceNight = null;
+        let photoSkydome = null;
+        let currentPhotoSkyKey = null;
         let canChickenCluck = true;
         let lastCluckTime = 0;
         
@@ -1198,36 +1321,33 @@
             document.body.appendChild(renderer.domElement);
             window.renderer = renderer;
 
-            const photoSkyTextureSources = skyAssetLocations.map(({ prefix, label }, index) => ({
-                url: resolveRelativeUrl(`${prefix}high_noon.jpg`),
-                label: `High Noon sky panorama (${label})`,
-                isFallback: index > 0
-            }));
-
-            photoSkyTextureSources.push({
-                url: resolveRelativeUrl('./src/sky/sunset.jpg'),
-                label: 'Bundled sunset fallback',
-                isFallback: true
-            });
-
-            const photoSky = await createPhotoSkydome({
+            photoSkydome = await createPhotoSkydome({
                 scene,
                 renderer,
-                sources: photoSkyTextureSources,
+                sources: highNoonPhotoSources,
                 radius: 5000,
                 initialYawDeg: 0
             });
 
-            if (photoSky?.source) {
-                const { label, url, isFallback } = photoSky.source;
+            if (photoSkydome?.source) {
+                const { label, url, isFallback } = photoSkydome.source;
                 const description = label || url;
                 const suffix = isFallback ? ' (fallback)' : '';
                 console.info(`Photo skydome texture loaded: ${description}${suffix}`);
             }
 
-            photoSky.setAmount(1);
-            window.__AthensSky__ = photoSky;
-            __level = 1;
+            window.__AthensSky__ = photoSkydome;
+            currentPhotoSkyKey = 'high-noon';
+            __level = 0;
+
+            photoSkyTexturesByKey.forEach((sources, key) => {
+                if (!photoSkydome || key === currentPhotoSkyKey) {
+                    return;
+                }
+                photoSkydome.prefetchSources(sources).catch((error) => {
+                    console.debug(`Photo skydome prefetch skipped for ${key}:`, error);
+                });
+            });
 
             const textureLoader = new THREE.TextureLoader();
             spaceNight = initSpaceNight({
@@ -3399,6 +3519,8 @@ function createBasicAgoraFallback() {
                 skyMieDirectional: 0.8
             };
 
+            const skydomePreset = photoSkyTimeConfig[name];
+
             switch (name) {
                 case 'Golden Dawn':
                     settings.elevation = 6;
@@ -3540,13 +3662,63 @@ function createBasicAgoraFallback() {
                 }
             }
 
-            let night = 0;
-            if (name === 'Starlit Night') night = 1;
-            else if (name === 'Blue Hour') night = 0.4;
+            const fallbackNightLevel = name === 'Starlit Night' ? 1 : (name === 'Blue Hour' ? 0.4 : 0);
+            const targetNightAmount = typeof skydomePreset?.spaceNightAmount === 'number'
+                ? THREE.MathUtils.clamp(skydomePreset.spaceNightAmount, 0, 1)
+                : fallbackNightLevel;
             if (spaceNight) {
-                spaceNight.setAmount(night);
+                spaceNight.setAmount(targetNightAmount);
             }
-            window.__AthensSky__?.setAmount(night);
+
+            const targetOpacity = typeof skydomePreset?.skydomeOpacity === 'number'
+                ? THREE.MathUtils.clamp(skydomePreset.skydomeOpacity, 0, 1)
+                : fallbackNightLevel;
+            const shouldDelaySkydome = Boolean(
+                photoSkydome && skydomePreset?.textureKey && currentPhotoSkyKey !== skydomePreset.textureKey
+            );
+            const activeSkyController = photoSkydome || window.__AthensSky__;
+            if (activeSkyController) {
+                const currentOpacityValue = typeof activeSkyController.opacity === 'number'
+                    ? activeSkyController.opacity
+                    : 0;
+                const nextOpacity = shouldDelaySkydome
+                    ? Math.min(currentOpacityValue, targetOpacity)
+                    : targetOpacity;
+                activeSkyController.setAmount(nextOpacity);
+                if (typeof skydomePreset?.yawDeg === 'number') {
+                    activeSkyController.setYaw(skydomePreset.yawDeg);
+                }
+            }
+            __level = targetOpacity;
+
+            if (photoSkydome && skydomePreset?.textureKey && Array.isArray(skydomePreset.sources)) {
+                if (currentPhotoSkyKey !== skydomePreset.textureKey) {
+                    const targetKey = skydomePreset.textureKey;
+                    const targetName = name;
+                    photoSkydome.swapTexture({ sources: skydomePreset.sources })
+                        .then((result) => {
+                            if (!result) {
+                                return;
+                            }
+                            const activeName = timeNames[currentTimeOfDay];
+                            if (activeName !== targetName) {
+                                return;
+                            }
+                            currentPhotoSkyKey = targetKey;
+                            const controller = photoSkydome || window.__AthensSky__;
+                            controller?.setAmount(targetOpacity);
+                            if (result.source) {
+                                const { label, url, isFallback } = result.source;
+                                const description = label || url;
+                                const suffix = isFallback ? ' (fallback)' : '';
+                                console.info(`Photo skydome texture loaded for ${targetName}: ${description}${suffix}`);
+                            }
+                        })
+                        .catch((error) => {
+                            console.warn(`Photo skydome texture swap failed for ${targetName}:`, error);
+                        });
+                }
+            }
         }
 
         function updateNightCycle(dt = 0.016) {

--- a/public/assets/sky/README.md
+++ b/public/assets/sky/README.md
@@ -19,3 +19,25 @@ public/assets/sky/high_noon.jpg
 
 During startup the experience now tries to load this asset for the photographic skydome. If the file is missing, the engine
 falls back to the bundled `src/sky/sunset.jpg` texture so development builds still render.
+
+## Golden Hour Photo Sky
+
+Place the golden-hour panorama used for both sunrise and sunset moods at:
+
+```
+public/assets/sky/golden_hour.jpg
+```
+
+The loader reuses this texture for the "Golden Dawn" and "Golden Dusk" presets, with runtime fallbacks to the bundled
+`src/sky/sunset.jpg` image when necessary.
+
+## Blue Hour Photo Sky
+
+Drop the blue-hour panorama into:
+
+```
+public/assets/sky/blue_hour.jpg
+```
+
+This file is prefetched during initialization so the skydome can swap immediately when entering the "Blue Hour" preset. If
+it's absent the experience will fall back to the built-in dusk assets.

--- a/src/sky/photoSkydome.js
+++ b/src/sky/photoSkydome.js
@@ -1,80 +1,230 @@
 // src/sky/photoSkydome.js
 import THREE from '../three.js';
 
+const sharedTextureLoader = new THREE.TextureLoader();
+const textureCache = new Map();
+const ENVIRONMENT_OPACITY_THRESHOLD = 0.6;
+
+function normalizeSources(list) {
+  const seen = new Set();
+  const normalized = [];
+  (Array.isArray(list) ? list : []).forEach((entry) => {
+    if (!entry) return;
+    const item = typeof entry === 'string' ? { url: entry } : entry;
+    const url = item?.url;
+    if (!url || seen.has(url)) {
+      return;
+    }
+    seen.add(url);
+    normalized.push({ ...item });
+  });
+  return normalized;
+}
+
+async function loadTextureWithCache(url, loader = sharedTextureLoader) {
+  if (!url) {
+    throw new Error('PhotoSkydome: invalid texture URL.');
+  }
+  if (!textureCache.has(url)) {
+    const promise = loader.loadAsync(url)
+      .then((texture) => {
+        if ('colorSpace' in texture && THREE.SRGBColorSpace) {
+          texture.colorSpace = THREE.SRGBColorSpace;
+        } else if ('encoding' in texture) {
+          texture.encoding = THREE.sRGBEncoding;
+        }
+        return texture;
+      })
+      .catch((error) => {
+        textureCache.delete(url);
+        throw error;
+      });
+    textureCache.set(url, promise);
+  }
+  return textureCache.get(url);
+}
+
+async function loadTextureSequence(sources, loader) {
+  let lastError = null;
+  for (const source of sources) {
+    if (!source?.url) {
+      continue;
+    }
+    try {
+      const texture = await loadTextureWithCache(source.url, loader);
+      return { texture, source };
+    } catch (error) {
+      lastError = error;
+      const label = source.label ? ` ("${source.label}")` : '';
+      console.warn(`PhotoSkydome: failed to load texture${label} from ${source.url}`, error);
+    }
+  }
+  throw lastError || new Error('Unable to load any photo skydome texture.');
+}
+
+async function prefetchTextureSources(sources, loader) {
+  const normalized = normalizeSources(sources);
+  await Promise.all(normalized.map(async (source) => {
+    try {
+      await loadTextureWithCache(source.url, loader);
+    } catch (error) {
+      const label = source.label ? ` ("${source.label}")` : '';
+      console.debug(`PhotoSkydome: prefetch skipped for${label} ${source.url}`, error);
+    }
+  }));
+}
+
 export async function createPhotoSkydome({
   scene,
   renderer,
-  url = new URL('./milkyway.jpg', import.meta.url).href, // resolves /src/sky/milkyway.jpg
+  url = new URL('./milkyway.jpg', import.meta.url).href,
   sources = null,
   radius = 5000,
-  initialYawDeg = 0
+  initialYawDeg = 0,
+  loader = null
 }) {
-  const loader = new THREE.TextureLoader();
-  const sourceList = Array.isArray(sources) && sources.length > 0
-    ? sources
-    : (url ? [{ url, label: 'default sky texture' }] : []);
+  const textureLoader = loader instanceof THREE.Loader ? loader : sharedTextureLoader;
+  const initialSources = Array.isArray(sources) && sources.length > 0
+    ? normalizeSources(sources)
+    : normalizeSources(url ? [{ url, label: 'default sky texture' }] : []);
 
-  if (sourceList.length === 0) {
+  if (initialSources.length === 0) {
     throw new Error('No sky texture source provided for photo skydome.');
   }
 
-  let chosenSource = null;
-  let tex = null;
-  let lastError = null;
+  const { texture: initialTexture, source: initialSource } = await loadTextureSequence(initialSources, textureLoader);
 
-  for (const source of sourceList) {
-    try {
-      tex = await loader.loadAsync(source.url);
-      chosenSource = source;
-      break;
-    } catch (err) {
-      lastError = err;
-      const label = source.label ? ` ("${source.label}")` : '';
-      console.warn(`PhotoSkydome: failed to load texture${label} from ${source.url}`, err);
-    }
-  }
-
-  if (!tex) {
-    throw lastError || new Error('Unable to load any photo skydome texture.');
-  }
-  // three r150+: colorSpace; older three: encoding fallback
-  if ('colorSpace' in tex) tex.colorSpace = THREE.SRGBColorSpace;
-  else tex.encoding = THREE.sRGBEncoding;
-
-  const geo = new THREE.SphereGeometry(radius, 64, 64);
-  const mat = new THREE.MeshBasicMaterial({
-    map: tex,
-    side: THREE.BackSide,     // view from inside
+  const geometry = new THREE.SphereGeometry(radius, 64, 64);
+  const material = new THREE.MeshBasicMaterial({
+    map: initialTexture,
+    side: THREE.BackSide,
     transparent: true,
-    opacity: 0.0,             // start hidden (day)
+    opacity: 0.0,
     depthWrite: false
   });
-  const dome = new THREE.Mesh(geo, mat);
+  const dome = new THREE.Mesh(geometry, material);
   dome.name = 'PhotoSkydome';
-  dome.renderOrder = -1000;   // draw behind world
+  dome.renderOrder = -1000;
   dome.rotation.y = THREE.MathUtils.degToRad(initialYawDeg);
-  dome.userData.skyTextureSource = chosenSource;
+  dome.userData.skyTextureSource = initialSource;
   scene.add(dome);
 
-  // Optional environment map for subtle night reflections
-  let env = null;
-  if (renderer) {
+  let defaultSources = initialSources;
+  let currentTexture = initialTexture;
+  let currentSource = initialSource;
+  let currentOpacity = 0;
+  let envRenderTarget = null;
+  let envTexture = null;
+  let loadToken = 0;
+
+  const updateEnvironmentVisibility = () => {
+    if (!scene) return;
+    if (currentOpacity >= ENVIRONMENT_OPACITY_THRESHOLD && envTexture) {
+      scene.environment = envTexture;
+    } else if (scene.environment === envTexture) {
+      scene.environment = null;
+    }
+  };
+
+  const refreshEnvironment = () => {
+    if (!renderer || !currentTexture) {
+      if (envRenderTarget) {
+        envRenderTarget.dispose();
+        envRenderTarget = null;
+      }
+      envTexture = null;
+      updateEnvironmentVisibility();
+      return null;
+    }
+
     const pmrem = new THREE.PMREMGenerator(renderer);
-    env = pmrem.fromEquirectangular(tex).texture;
+    const target = pmrem.fromEquirectangular(currentTexture);
     pmrem.dispose();
-  }
+
+    if (envRenderTarget) {
+      envRenderTarget.dispose();
+    }
+    envRenderTarget = target;
+    envTexture = target.texture;
+    updateEnvironmentVisibility();
+    return envTexture;
+  };
+
+  const applyTexture = (texture, source) => {
+    currentTexture = texture;
+    currentSource = source;
+    material.map = texture;
+    if (texture) {
+      texture.needsUpdate = true;
+    }
+    material.needsUpdate = true;
+    dome.userData.skyTextureSource = source;
+    refreshEnvironment();
+  };
+
+  const setOpacity = (amount) => {
+    const clamped = THREE.MathUtils.clamp(amount, 0, 1);
+    currentOpacity = clamped;
+    material.opacity = clamped;
+    updateEnvironmentVisibility();
+  };
+
+  applyTexture(initialTexture, initialSource);
+  setOpacity(0);
 
   return {
     mesh: dome,
-    texture: tex,
-    source: chosenSource,
-    setAmount(a) {
-      const t = THREE.MathUtils.clamp(a, 0, 1);
-      dome.material.opacity = t;
-      if (env) scene.environment = t > 0.6 ? env : null;
+    get texture() {
+      return currentTexture;
+    },
+    get source() {
+      return currentSource;
+    },
+    get opacity() {
+      return currentOpacity;
+    },
+    setAmount(amount) {
+      setOpacity(amount);
     },
     setYaw(deg) {
       dome.rotation.y = THREE.MathUtils.degToRad(deg);
+    },
+    async swapTexture({ url: overrideUrl, sources: overrideSources = [], label } = {}) {
+      const combined = [];
+      if (overrideUrl) {
+        combined.push({ url: overrideUrl, label });
+      }
+      if (Array.isArray(overrideSources)) {
+        combined.push(...overrideSources);
+      }
+      const candidateSources = normalizeSources(combined.length > 0 ? combined : defaultSources);
+      if (candidateSources.length === 0) {
+        throw new Error('Photo skydome swapTexture called without any sources.');
+      }
+
+      const requestId = ++loadToken;
+      const { texture, source } = await loadTextureSequence(candidateSources, textureLoader);
+      if (requestId !== loadToken) {
+        return null;
+      }
+      defaultSources = candidateSources;
+      applyTexture(texture, source);
+      return { texture, source };
+    },
+    async prefetchSources(list = []) {
+      await prefetchTextureSources(list, textureLoader);
+    },
+    refreshEnvironmentMap() {
+      return refreshEnvironment();
+    },
+    dispose() {
+      scene.remove(dome);
+      geometry.dispose();
+      material.dispose();
+      if (envRenderTarget) {
+        envRenderTarget.dispose();
+        envRenderTarget = null;
+      }
     }
   };
 }


### PR DESCRIPTION
## Summary
- add a shared texture loader with caching, runtime swap and prefetch helpers for the photographic skydome
- wire time-of-day presets to golden-hour, blue-hour, and night panoramas with opacity tuning and environment refreshes
- document the placement for the new golden-hour and blue-hour sky assets alongside existing instructions

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d2a0d8652483279ed9534b8047f3f1