### PR TITLE
Add textured ground, sky environments, and building materials

### DIFF
--- a/index.html
+++ b/index.html
@@ -418,6 +418,9 @@
         import { UnrealBloomPass } from 'three/examples/jsm/postprocessing/UnrealBloomPass.js';
         import { createPhotoSkydome } from './src/sky/photoSkydome.js';
         import { nightSkyDataUrl } from './src/sky/nightSkyTextureData.js';
+        import { createGroundPlane } from './src/scene/ground.js';
+        import { setEnvironment } from './src/scene/sky.js';
+        import { loadBuildingTextures, retargetBuildingMaterials } from './src/scene/materials.js';
 
         const TONE_JS_URL = 'https://cdnjs.cloudflare.com/ajax/libs/tone/14.7.77/Tone.js';
         let toneLoadingPromise = null;
@@ -1357,6 +1360,22 @@
         // Declare texture and material variables globally
         let stoneTexture, marbleTexture, redTileTexture, groundTexture, pavedRoadTexture;
         let stoneMaterial, marbleMaterial, goldMaterial, redTileMaterial, groundMaterial, columnMaterial, waterMaterial, pavedRoadMaterial;
+
+        const buildingMaterialSet = loadBuildingTextures();
+        let groundMesh = null;
+        let currentEnvironmentMode = null;
+
+        const applyEnvironmentMode = (mode = 'day') => {
+            if (!renderer || !scene) {
+                return;
+            }
+            const normalized = mode === 'night' ? 'night' : (mode === 'sunset' ? 'sunset' : 'day');
+            if (currentEnvironmentMode === normalized) {
+                return;
+            }
+            currentEnvironmentMode = normalized;
+            setEnvironment(renderer, scene, normalized);
+        };
         
         const baseMapBounds = { xMin: -80, xMax: 80, zMin: -80, zMax: 80 };
         const mapBounds = scaleBounds(baseMapBounds);
@@ -1414,12 +1433,105 @@
             if ('outputColorSpace' in renderer) renderer.outputColorSpace = THREE.SRGBColorSpace;
             else renderer.outputEncoding = THREE.sRGBEncoding;
             renderer.toneMapping = THREE.ACESFilmicToneMapping;
-            renderer.toneMappingExposure = 1.0;
+            renderer.toneMappingExposure = 0.9;
             renderer.setSize(window.innerWidth, window.innerHeight);
             renderer.shadowMap.enabled = true;
             renderer.shadowMap.type = THREE.PCFSoftShadowMap;
             document.body.appendChild(renderer.domElement);
             window.renderer = renderer;
+
+            const maxAnisotropy = renderer?.capabilities?.getMaxAnisotropy?.() ?? 8;
+            const textureLoader = new THREE.TextureLoader();
+            let groundBaseTexture = null;
+            let groundDustTexture = null;
+
+            try {
+                groundBaseTexture = textureLoader.load(
+                    '/assets/textures/grass.jpg',
+                    undefined,
+                    undefined,
+                    (error) => {
+                        console.warn('[ground] grass.jpg not found; using flat color.', error);
+                    }
+                );
+            } catch (error) {
+                console.warn('[ground] grass.jpg not found; using flat color.', error);
+            }
+
+            try {
+                groundDustTexture = textureLoader.load(
+                    '/assets/textures/athens_dust.jpg',
+                    undefined,
+                    undefined,
+                    (error) => {
+                        console.warn('[ground] athens_dust.jpg not found; alpha blend disabled.', error);
+                    }
+                );
+            } catch (error) {
+                console.warn('[ground] athens_dust.jpg not found; alpha blend disabled.', error);
+            }
+
+            groundMesh = createGroundPlane({
+                size: 10000,
+                repeats: 100,
+                textures: { base: groundBaseTexture, overlay: groundDustTexture }
+            });
+
+            if (groundMesh) {
+                const { map, alphaMap } = groundMesh.material;
+                if (map) {
+                    map.anisotropy = Math.max(map.anisotropy || 0, maxAnisotropy);
+                    map.needsUpdate = true;
+                }
+                if (alphaMap) {
+                    alphaMap.anisotropy = Math.max(alphaMap.anisotropy || 0, maxAnisotropy);
+                    alphaMap.needsUpdate = true;
+                }
+                scene.add(groundMesh);
+            }
+
+            if (!groundMaterial) {
+                groundMaterial = new THREE.MeshStandardMaterial({
+                    color: 0xb7b09a,
+                    roughness: 0.95,
+                    metalness: 0.0
+                });
+            }
+
+            if (groundBaseTexture) {
+                groundMaterial.map = groundBaseTexture;
+                groundMaterial.color.set(0xffffff);
+                groundMaterial.needsUpdate = true;
+                groundBaseTexture.anisotropy = Math.max(groundBaseTexture.anisotropy || 0, maxAnisotropy);
+                groundBaseTexture.needsUpdate = true;
+                groundTexture = groundBaseTexture;
+            }
+
+            groundMaterial.alphaMap = null;
+            groundMaterial.transparent = false;
+
+            if (buildingMaterialSet?.marbleMat?.map) {
+                buildingMaterialSet.marbleMat.map.anisotropy = Math.max(
+                    buildingMaterialSet.marbleMat.map.anisotropy || 0,
+                    maxAnisotropy
+                );
+                buildingMaterialSet.marbleMat.map.needsUpdate = true;
+            }
+            if (buildingMaterialSet?.roofMat?.map) {
+                buildingMaterialSet.roofMat.map.anisotropy = Math.max(
+                    buildingMaterialSet.roofMat.map.anisotropy || 0,
+                    maxAnisotropy
+                );
+                buildingMaterialSet.roofMat.map.needsUpdate = true;
+            }
+
+            applyEnvironmentMode('day');
+            window.setEnvironment = applyEnvironmentMode;
+            window.addEventListener('keydown', (event) => {
+                if (event.key === '1') applyEnvironmentMode('day');
+                if (event.key === '2') applyEnvironmentMode('sunset');
+                if (event.key === '3') applyEnvironmentMode('night');
+            });
 
             photoSkydome = await createPhotoSkydome({
                 scene,
@@ -1449,7 +1561,6 @@
                 });
             });
 
-            const textureLoader = new THREE.TextureLoader();
             spaceNight = initSpaceNight({
                 scene,
                 renderer,
@@ -1521,120 +1632,50 @@
                     ctx.fill();
                 }
             });
-            marbleTexture = generateTexture(512, 512, (ctx, w, h) => {
-                ctx.fillStyle = '#F0F0F0';
-                ctx.fillRect(0, 0, w, h);
-                ctx.lineWidth = Math.random() * 2 + 1;
-                ctx.strokeStyle = `rgba(128, 128, 128, 0.3)`;
-                for(let i=0; i<10; i++) {
-                     ctx.beginPath();
-                     ctx.moveTo(Math.random() * w, Math.random() * h);
-                     ctx.bezierCurveTo(Math.random() * w, Math.random() * h, Math.random() * w, Math.random() * h, Math.random() * w, Math.random() * h);
-                     ctx.stroke();
-                }
-            });
-            redTileTexture = generateTexture(256, 256, (ctx, w, h) => {
-                ctx.fillStyle = '#8B4513';
-                ctx.fillRect(0, 0, w, h);
-                ctx.strokeStyle = 'rgba(0,0,0,0.3)';
-                ctx.lineWidth = 2;
-                for(let i = 0; i < w; i += 32) {
-                    ctx.beginPath();
-                    ctx.moveTo(i, 0);
-                    ctx.lineTo(i, h);
-                    ctx.stroke();
-                    ctx.beginPath();
-                    ctx.moveTo(0, i);
-                    ctx.lineTo(w, i);
-                    ctx.stroke();
-                }
-            });
-            groundTexture = generateTexture(1024, 1024, (ctx, w, h) => {
-                const baseGradient = ctx.createLinearGradient(0, 0, w, h);
-                baseGradient.addColorStop(0, '#d5c48b');
-                baseGradient.addColorStop(0.5, '#c3ad6f');
-                baseGradient.addColorStop(1, '#e0d2a0');
-                ctx.fillStyle = baseGradient;
-                ctx.fillRect(0, 0, w, h);
-
-                const addDustLayer = (count, color, alpha, minSize, maxSize) => {
-                    ctx.fillStyle = color;
-                    ctx.globalAlpha = alpha;
-                    for (let i = 0; i < count; i++) {
-                        const x = Math.random() * w;
-                        const y = Math.random() * h;
-                        const radiusX = minSize + Math.random() * (maxSize - minSize);
-                        const radiusY = radiusX * (0.4 + Math.random() * 0.6);
-                        ctx.save();
-                        ctx.translate(x, y);
-                        ctx.rotate(Math.random() * Math.PI * 2);
+            if (buildingMaterialSet?.marbleMat?.map) {
+                marbleTexture = buildingMaterialSet.marbleMat.map;
+            } else {
+                marbleTexture = generateTexture(512, 512, (ctx, w, h) => {
+                    ctx.fillStyle = '#F0F0F0';
+                    ctx.fillRect(0, 0, w, h);
+                    ctx.lineWidth = Math.random() * 2 + 1;
+                    ctx.strokeStyle = `rgba(128, 128, 128, 0.3)`;
+                    for(let i=0; i<10; i++) {
                         ctx.beginPath();
-                        ctx.ellipse(0, 0, radiusX, radiusY, 0, 0, Math.PI * 2);
-                        ctx.fill();
-                        ctx.restore();
+                        ctx.moveTo(Math.random() * w, Math.random() * h);
+                        ctx.bezierCurveTo(
+                            Math.random() * w,
+                            Math.random() * h,
+                            Math.random() * w,
+                            Math.random() * h,
+                            Math.random() * w,
+                            Math.random() * h
+                        );
+                        ctx.stroke();
                     }
-                    ctx.globalAlpha = 1;
-                };
+                });
+            }
 
-                addDustLayer(260, '#b7995d', 0.12, 18, 42);
-                addDustLayer(340, '#e7d7a3', 0.09, 12, 28);
-                addDustLayer(180, '#a88d55', 0.1, 30, 60);
-
-                const addPebbles = (count, baseColorFn) => {
-                    for (let i = 0; i < count; i++) {
-                        const x = Math.random() * w;
-                        const y = Math.random() * h;
-                        const radius = Math.random() * 1.8 + 0.2;
-                        ctx.fillStyle = baseColorFn();
+            if (buildingMaterialSet?.roofMat?.map) {
+                redTileTexture = buildingMaterialSet.roofMat.map;
+            } else {
+                redTileTexture = generateTexture(256, 256, (ctx, w, h) => {
+                    ctx.fillStyle = '#8B4513';
+                    ctx.fillRect(0, 0, w, h);
+                    ctx.strokeStyle = 'rgba(0,0,0,0.3)';
+                    ctx.lineWidth = 2;
+                    for(let i = 0; i < w; i += 32) {
                         ctx.beginPath();
-                        ctx.arc(x, y, radius, 0, Math.PI * 2);
-                        ctx.fill();
+                        ctx.moveTo(i, 0);
+                        ctx.lineTo(i, h);
+                        ctx.stroke();
+                        ctx.beginPath();
+                        ctx.moveTo(0, i);
+                        ctx.lineTo(w, i);
+                        ctx.stroke();
                     }
-                };
-
-                addPebbles(2600, () => {
-                    const shade = 150 + Math.random() * 45;
-                    return `rgba(${shade - 25}, ${shade - 5}, ${shade - 45}, ${0.22 + Math.random() * 0.35})`;
                 });
-                addPebbles(1600, () => {
-                    const shade = 205 + Math.random() * 25;
-                    return `rgba(${shade}, ${shade - 20}, ${shade - 70}, ${0.16 + Math.random() * 0.25})`;
-                });
-
-                ctx.lineWidth = 0.8;
-                for (let i = 0; i < 260; i++) {
-                    const x = Math.random() * w;
-                    const y = Math.random() * h;
-                    const length = Math.random() * 70 + 20;
-                    ctx.save();
-                    ctx.translate(x, y);
-                    ctx.rotate(Math.random() * Math.PI * 2);
-                    ctx.strokeStyle = 'rgba(117, 94, 58, 0.1)';
-                    ctx.beginPath();
-                    ctx.moveTo(-length / 2, 0);
-                    ctx.lineTo(length / 2, 0);
-                    ctx.stroke();
-                    ctx.restore();
-                }
-
-                ctx.globalAlpha = 0.25;
-                for (let i = 0; i < 90; i++) {
-                    const x = Math.random() * w;
-                    const y = Math.random() * h;
-                    const radius = Math.random() * 50 + 25;
-                    ctx.save();
-                    ctx.translate(x, y);
-                    const gradient = ctx.createRadialGradient(0, 0, 0, 0, 0, radius);
-                    gradient.addColorStop(0, 'rgba(255, 245, 210, 0.18)');
-                    gradient.addColorStop(1, 'rgba(140, 110, 60, 0)');
-                    ctx.fillStyle = gradient;
-                    ctx.beginPath();
-                    ctx.arc(0, 0, radius, 0, Math.PI * 2);
-                    ctx.fill();
-                    ctx.restore();
-                }
-                ctx.globalAlpha = 1;
-            });
+            }
             pavedRoadTexture = generateTexture(256, 256, (ctx, w, h) => {
                 ctx.fillStyle = '#A9A9A9';
                 ctx.fillRect(0, 0, w, h);
@@ -1648,22 +1689,60 @@
                 }
             });
 
-            stoneTexture.wrapS = stoneTexture.wrapT = THREE.RepeatWrapping;
-            marbleTexture.wrapS = marbleTexture.wrapT = THREE.RepeatWrapping; 
-            redTileTexture.wrapS = redTileTexture.wrapT = THREE.RepeatWrapping;
-            groundTexture.wrapS = groundTexture.wrapT = THREE.RepeatWrapping; 
-            pavedRoadTexture.wrapS = pavedRoadTexture.wrapT = THREE.RepeatWrapping;
-            
+            if (stoneTexture) {
+                stoneTexture.wrapS = stoneTexture.wrapT = THREE.RepeatWrapping;
+            }
+            if (marbleTexture) {
+                marbleTexture.wrapS = marbleTexture.wrapT = THREE.RepeatWrapping;
+            }
+            if (redTileTexture) {
+                redTileTexture.wrapS = redTileTexture.wrapT = THREE.RepeatWrapping;
+            }
+            if (pavedRoadTexture) {
+                pavedRoadTexture.wrapS = pavedRoadTexture.wrapT = THREE.RepeatWrapping;
+            }
+
             stoneMaterial = new THREE.MeshStandardMaterial({ map: stoneTexture, roughness: 0.85, metalness: 0.05 });
-            marbleMaterial = new THREE.MeshStandardMaterial({ map: marbleTexture, roughness: 0.4, metalness: 0.1 });
+
+            marbleMaterial = buildingMaterialSet?.marbleMat?.clone
+                ? buildingMaterialSet.marbleMat.clone()
+                : new THREE.MeshStandardMaterial({ color: 0xffffff, roughness: 0.75, metalness: 0.0 });
+            if (!marbleMaterial.map && marbleTexture) {
+                marbleMaterial.map = marbleTexture;
+                marbleMaterial.needsUpdate = true;
+            }
+
             goldMaterial = createEnhancedMaterial(0xFFD700, 0.2, 0.9);
-            redTileMaterial = new THREE.MeshStandardMaterial({ map: redTileTexture, roughness: 0.7, metalness: 0.0 });
-            groundMaterial = new THREE.MeshStandardMaterial({ map: groundTexture, roughness: 0.95, metalness: 0.0 });
-            columnMaterial = new THREE.MeshStandardMaterial({ map: marbleTexture, roughness: 0.5, metalness: 0.15 });
+
+            redTileMaterial = buildingMaterialSet?.roofMat?.clone
+                ? buildingMaterialSet.roofMat.clone()
+                : new THREE.MeshStandardMaterial({ color: 0x8b3a2f, roughness: 0.9, metalness: 0.0 });
+            if (!redTileMaterial.map && redTileTexture) {
+                redTileMaterial.map = redTileTexture;
+                redTileMaterial.needsUpdate = true;
+            }
+
+            columnMaterial = buildingMaterialSet?.marbleMat?.clone
+                ? buildingMaterialSet.marbleMat.clone()
+                : marbleMaterial.clone();
+            if (!columnMaterial.map && marbleTexture) {
+                columnMaterial.map = marbleTexture;
+                columnMaterial.needsUpdate = true;
+            }
+
             waterMaterial = createEnhancedMaterial(0x5f9ea0, 0.2, 0.1);
             waterMaterial.transparent = true;
             waterMaterial.opacity = 0.7;
             pavedRoadMaterial = new THREE.MeshStandardMaterial({ map: pavedRoadTexture, roughness: 0.8, metalness: 0.1 });
+
+            if (buildingMaterialSet?.marbleMat) {
+                MAT.marble.copy(buildingMaterialSet.marbleMat);
+                MAT.marble.needsUpdate = true;
+            }
+            if (buildingMaterialSet?.roofMat) {
+                MAT.roof.copy(buildingMaterialSet.roofMat);
+                MAT.roof.needsUpdate = true;
+            }
 
 
             // Build Scene
@@ -1739,15 +1818,9 @@
         // --- WORLD BUILDING ---
         function buildWorld() {
             // Ground
-            const groundGeometry = new THREE.PlaneGeometry(scaleValue(400), scaleValue(400));
-            const ground = new THREE.Mesh(groundGeometry, groundMaterial);
-            if (ground.material.map) {
-                ground.material.map.repeat.set(16 * CITY_SCALE, 16 * CITY_SCALE);
+            if (groundMesh && !scene.children.includes(groundMesh)) {
+                scene.add(groundMesh);
             }
-            ground.rotation.x = -Math.PI / 2;
-            ground.receiveShadow = true;
-            scene.add(ground);
-            
             const groundPhysMat = new CANNON.Material("groundMaterial");
             const groundBody = new CANNON.Body({ mass: 0, material: groundPhysMat });
             groundBody.addShape(new CANNON.Plane());
@@ -3952,7 +4025,8 @@ function createBasicAgoraFallback() {
             }
 
             if (renderer) {
-                renderer.toneMappingExposure = settings.exposure;
+                const targetExposure = Math.min(settings.exposure, 0.9);
+                renderer.toneMappingExposure = targetExposure;
                 const fogCol = new THREE.Color(settings.fogColor);
                 if (fogEnabled) {
                     if (!scene.fog) {
@@ -4043,6 +4117,14 @@ function createBasicAgoraFallback() {
                     }
                 }
             }
+
+            let environmentMode = 'day';
+            if (name === 'Starlit Night' || name === 'Blue Hour') {
+                environmentMode = 'night';
+            } else if (name === 'Golden Dawn' || name === 'Golden Dusk') {
+                environmentMode = 'sunset';
+            }
+            applyEnvironmentMode(environmentMode);
         }
 
         function updateNightCycle(dt = 0.016) {
@@ -6433,6 +6515,7 @@ function createBasicAgoraFallback() {
                     const temple = gltf.scene || new THREE.Group();
                     temple.scale.set(3, 3, 3);
                     templeGroup.add(temple);
+                    retargetBuildingMaterials(templeGroup, buildingMaterialSet);
                     applyMeshEnhancements(templeGroup, renderer);
                     placeObject(templeGroup, 90, 0, 35);
                     scene.add(templeGroup);

--- a/src/buildings-from-geojson.js
+++ b/src/buildings-from-geojson.js
@@ -180,7 +180,7 @@ export async function buildFromGeoJSON({ scene, geoJsonUrl, projector }) {
 
       mesh.position.copy(pos);
       mesh.rotation.y = deg(rotDeg);
-      mesh.traverse(o => (o.castShadow = o.receiveShadow = false));
+      mesh.traverse(o => (o.castShadow = o.receiveShadow = true));
       mesh.userData.monument = rawName || name;
 
       root.add(mesh);

--- a/src/scene/ground.js
+++ b/src/scene/ground.js
@@ -1,0 +1,89 @@
+import * as THREE from 'three';
+
+function configureBaseTexture(texture, repeats) {
+  if (!texture) return;
+  texture.wrapS = THREE.RepeatWrapping;
+  texture.wrapT = THREE.RepeatWrapping;
+  texture.repeat.set(repeats, repeats);
+  texture.anisotropy = Math.max(texture.anisotropy || 0, 8);
+  texture.colorSpace = THREE.SRGBColorSpace;
+  texture.needsUpdate = true;
+}
+
+function configureOverlayTexture(texture, repeats) {
+  if (!texture) return;
+  texture.wrapS = THREE.RepeatWrapping;
+  texture.wrapT = THREE.RepeatWrapping;
+  texture.repeat.set(repeats, repeats);
+  texture.anisotropy = Math.max(texture.anisotropy || 0, 8);
+  texture.colorSpace = THREE.LinearSRGBColorSpace;
+  texture.needsUpdate = true;
+}
+
+export function createGroundPlane({ size = 8000, repeats = 80, textures = {} } = {}) {
+  const loader = new THREE.TextureLoader();
+  const material = new THREE.MeshStandardMaterial({
+    color: 0xb7b09a,
+    roughness: 1.0,
+    metalness: 0.0,
+    transparent: false
+  });
+
+  const mesh = new THREE.Mesh(new THREE.PlaneGeometry(size, size), material);
+  mesh.rotation.x = -Math.PI / 2;
+  mesh.receiveShadow = true;
+
+  const { base: baseTexture, overlay: overlayTexture } = textures;
+
+  const applyBaseTexture = (texture) => {
+    if (!texture) {
+      return;
+    }
+    configureBaseTexture(texture, repeats);
+    material.map = texture;
+    material.color.set(0xffffff);
+    material.needsUpdate = true;
+  };
+
+  const applyOverlayTexture = (texture) => {
+    if (!texture) {
+      return;
+    }
+    configureOverlayTexture(texture, repeats);
+    material.alphaMap = texture;
+    material.transparent = true;
+    material.needsUpdate = true;
+  };
+
+  if (baseTexture) {
+    applyBaseTexture(baseTexture);
+  } else {
+    loader.load(
+      '/assets/textures/grass.jpg',
+      (texture) => {
+        applyBaseTexture(texture);
+      },
+      undefined,
+      (error) => {
+        console.warn('[ground] grass.jpg not found; using flat color.', error);
+      }
+    );
+  }
+
+  if (overlayTexture) {
+    applyOverlayTexture(overlayTexture);
+  } else {
+    loader.load(
+      '/assets/textures/athens_dust.jpg',
+      (texture) => {
+        applyOverlayTexture(texture);
+      },
+      undefined,
+      (error) => {
+        console.warn('[ground] athens_dust.jpg not found; alpha blend disabled.', error);
+      }
+    );
+  }
+
+  return mesh;
+}

--- a/src/scene/materials.js
+++ b/src/scene/materials.js
@@ -1,0 +1,107 @@
+import * as THREE from 'three';
+
+const fallbackMaterial = new THREE.MeshStandardMaterial({
+  color: 0xbfbfbf,
+  roughness: 0.85,
+  metalness: 0.0
+});
+
+export function loadBuildingTextures() {
+  const loader = new THREE.TextureLoader();
+
+  const marbleMat = new THREE.MeshStandardMaterial({
+    color: 0xdedede,
+    roughness: 0.75,
+    metalness: 0.0
+  });
+
+  loader.load(
+    '/assets/textures/marble.jpg',
+    (texture) => {
+      texture.wrapS = THREE.RepeatWrapping;
+      texture.wrapT = THREE.RepeatWrapping;
+      texture.repeat.set(2, 2);
+      texture.anisotropy = Math.max(texture.anisotropy || 0, 8);
+      texture.colorSpace = THREE.SRGBColorSpace;
+      texture.needsUpdate = true;
+      marbleMat.map = texture;
+      marbleMat.color.set(0xffffff);
+      marbleMat.needsUpdate = true;
+    },
+    undefined,
+    (error) => {
+      console.warn('[materials] marble.jpg missing; will use color.', error);
+    }
+  );
+
+  const roofMat = new THREE.MeshStandardMaterial({
+    color: 0x8b3a2f,
+    roughness: 0.9,
+    metalness: 0.0
+  });
+
+  loader.load(
+    '/assets/textures/roof_tiles.jpg',
+    (texture) => {
+      texture.wrapS = THREE.RepeatWrapping;
+      texture.wrapT = THREE.RepeatWrapping;
+      texture.repeat.set(2, 2);
+      texture.anisotropy = Math.max(texture.anisotropy || 0, 8);
+      texture.colorSpace = THREE.SRGBColorSpace;
+      texture.needsUpdate = true;
+      roofMat.map = texture;
+      roofMat.color.set(0xffffff);
+      roofMat.needsUpdate = true;
+    },
+    undefined,
+    (error) => {
+      console.warn('[materials] roof_tiles.jpg missing; will use color.', error);
+    }
+  );
+
+  return { marbleMat, roofMat };
+}
+
+export function retargetBuildingMaterials(root, { marbleMat, roofMat } = {}) {
+  if (!root || typeof root.traverse !== 'function') {
+    return;
+  }
+
+  const marbleMaterial = marbleMat ?? fallbackMaterial;
+  const roofMaterial = roofMat ?? fallbackMaterial;
+
+  root.traverse((obj) => {
+    if (!obj.isMesh) {
+      return;
+    }
+
+    obj.castShadow = true;
+    obj.receiveShadow = true;
+
+    const label = `${obj.name ?? ''} ${(obj.material && obj.material.name) || ''}`.toLowerCase();
+    let nextMaterial = null;
+
+    if (label.includes('roof') || label.includes('tile')) {
+      nextMaterial = roofMaterial;
+    } else if (
+      label.includes('column') ||
+      label.includes('colonnade') ||
+      label.includes('wall') ||
+      label.includes('marble') ||
+      label.includes('temple') ||
+      label.includes('stoa')
+    ) {
+      nextMaterial = marbleMaterial;
+    } else {
+      nextMaterial = fallbackMaterial;
+    }
+
+    if (Array.isArray(obj.material)) {
+      obj.material.forEach((material) => material?.dispose?.());
+    } else {
+      obj.material?.dispose?.();
+    }
+
+    obj.material = nextMaterial;
+  });
+}

--- a/src/scene/sky.js
+++ b/src/scene/sky.js
@@ -1,0 +1,83 @@
+import * as THREE from 'three';
+
+const SKY_PATHS = {
+  sunset: '/assets/textures/sunset_4k.jpg',
+  night: '/assets/textures/night_sky_4k.jpg'
+};
+
+const environmentCache = new Map();
+const DAY_COLOR = new THREE.Color('#87c5eb');
+
+export function loadEquirectSky(renderer, scene, path, onDone) {
+  if (!renderer || !scene) {
+    onDone?.(null);
+    return;
+  }
+
+  const loader = new THREE.TextureLoader();
+  loader.load(
+    path,
+    (texture) => {
+      texture.mapping = THREE.EquirectangularReflectionMapping;
+      texture.colorSpace = THREE.SRGBColorSpace;
+
+      const pmrem = new THREE.PMREMGenerator(renderer);
+      const envTarget = pmrem.fromEquirectangular(texture);
+      pmrem.dispose();
+
+      const environmentTexture = envTarget.texture;
+      scene.background = texture;
+      scene.environment = environmentTexture;
+
+      onDone?.({ background: texture, environment: environmentTexture });
+    },
+    undefined,
+    (error) => {
+      console.warn(`[sky] Failed to load sky texture: ${path}`, error);
+      onDone?.(null);
+    }
+  );
+}
+
+export function setEnvironment(renderer, scene, mode = 'day') {
+  if (!renderer || !scene) {
+    return;
+  }
+
+  if (mode === 'day') {
+    scene.background = DAY_COLOR.clone();
+    scene.environment = null;
+    return;
+  }
+
+  const key = mode === 'night' ? 'night' : (mode === 'sunset' ? 'sunset' : 'day');
+  if (key === 'day') {
+    scene.background = DAY_COLOR.clone();
+    scene.environment = null;
+    return;
+  }
+
+  const cached = environmentCache.get(key);
+  if (cached) {
+    scene.background = cached.background;
+    scene.environment = cached.environment;
+    return;
+  }
+
+  const texturePath = SKY_PATHS[key];
+  if (!texturePath) {
+    console.warn(`[sky] Unknown mode "${mode}", defaulting to day.`);
+    scene.background = DAY_COLOR.clone();
+    scene.environment = null;
+    return;
+  }
+
+  loadEquirectSky(renderer, scene, texturePath, (result) => {
+    if (result) {
+      environmentCache.set(key, result);
+    } else if (!environmentCache.has(key)) {
+      scene.background = DAY_COLOR.clone();
+      scene.environment = null;
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- add reusable scene helpers for the ground plane, sky environment maps, and building materials with graceful fallbacks
- update the main Athens bootstrap to apply the new textures, tone-mapping tweaks, and keyboard-accessible environment switching
- ensure procedural and GLTF buildings receive the new marble and roof materials while keeping shadow support

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d30b2dc4288327815d2814168d4d2c