### PR TITLE
Fix asset path resolution for texture loaders

### DIFF
--- a/index.html
+++ b/index.html
@@ -1447,7 +1447,7 @@
 
             try {
                 groundBaseTexture = textureLoader.load(
-                    '/assets/textures/grass.jpg',
+                    'assets/textures/grass.jpg',
                     undefined,
                     undefined,
                     (error) => {
@@ -1460,7 +1460,7 @@
 
             try {
                 groundDustTexture = textureLoader.load(
-                    '/assets/textures/athens_dust.jpg',
+                    'assets/textures/athens_dust.jpg',
                     undefined,
                     undefined,
                     (error) => {

--- a/src/scene/ground.js
+++ b/src/scene/ground.js
@@ -59,7 +59,7 @@ export function createGroundPlane({ size = 8000, repeats = 80, textures = {} } =
     applyBaseTexture(baseTexture);
   } else {
     loader.load(
-      '/assets/textures/grass.jpg',
+      'assets/textures/grass.jpg',
       (texture) => {
         applyBaseTexture(texture);
       },
@@ -74,7 +74,7 @@ export function createGroundPlane({ size = 8000, repeats = 80, textures = {} } =
     applyOverlayTexture(overlayTexture);
   } else {
     loader.load(
-      '/assets/textures/athens_dust.jpg',
+      'assets/textures/athens_dust.jpg',
       (texture) => {
         applyOverlayTexture(texture);
       },

--- a/src/scene/materials.js
+++ b/src/scene/materials.js
@@ -16,7 +16,7 @@ export function loadBuildingTextures() {
   });
 
   loader.load(
-    '/assets/textures/marble.jpg',
+    'assets/textures/marble.jpg',
     (texture) => {
       texture.wrapS = THREE.RepeatWrapping;
       texture.wrapT = THREE.RepeatWrapping;
@@ -41,7 +41,7 @@ export function loadBuildingTextures() {
   });
 
   loader.load(
-    '/assets/textures/roof_tiles.jpg',
+    'assets/textures/roof_tiles.jpg',
     (texture) => {
       texture.wrapS = THREE.RepeatWrapping;
       texture.wrapT = THREE.RepeatWrapping;

--- a/src/scene/sky.js
+++ b/src/scene/sky.js
@@ -1,8 +1,8 @@
 import * as THREE from 'three';
 
 const SKY_PATHS = {
-  sunset: '/assets/textures/sunset_4k.jpg',
-  night: '/assets/textures/night_sky_4k.jpg'
+  sunset: 'assets/textures/sunset_4k.jpg',
+  night: 'assets/textures/night_sky_4k.jpg'
 };
 
 const environmentCache = new Map();


### PR DESCRIPTION
## Summary
- update texture loader fallbacks to use relative asset paths so textures resolve when the site is hosted from a subdirectory
- adjust ground initialization to request the same relative resources
- keep sky texture configuration consistent with the updated path approach

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d3192979088327b886b78e49e929f4