### PR TITLE
Fix sky texture URLs

### DIFF
--- a/src/scene/sky.js
+++ b/src/scene/sky.js
@@ -1,8 +1,8 @@
 import * as THREE from 'three';
 
 const SKY_PATHS = {
-  sunset: 'assets/textures/sunset_4k.jpg',
-  night: 'assets/textures/night_sky_4k.jpg'
+  sunset: new URL('../../public/assets/sky/sunset_4k.jpg', import.meta.url).href,
+  night: new URL('../../public/assets/sky/night_sky_4k.jpg', import.meta.url).href
 };
 
 const environmentCache = new Map();


### PR DESCRIPTION
## Summary
- resolve sky texture paths to absolute URLs using `import.meta.url`

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d3348b60f48327a3af387cf3ab30c4