### PR TITLE
Fix material texture URLs

### DIFF
--- a/src/scene/materials.js
+++ b/src/scene/materials.js
@@ -16,7 +16,7 @@ export function loadBuildingTextures() {
   });
 
   loader.load(
-    'assets/textures/marble.jpg',
+    new URL('../../public/assets/textures/marble.jpg', import.meta.url).href,
     (texture) => {
       texture.wrapS = THREE.RepeatWrapping;
       texture.wrapT = THREE.RepeatWrapping;
@@ -41,7 +41,7 @@ export function loadBuildingTextures() {
   });
 
   loader.load(
-    'assets/textures/roof_tiles.jpg',
+    new URL('../../public/assets/textures/roof_tiles.jpg', import.meta.url).href,
     (texture) => {
       texture.wrapS = THREE.RepeatWrapping;
       texture.wrapT = THREE.RepeatWrapping;


### PR DESCRIPTION
## Summary
- load the marble and roof textures via import.meta.url-based URLs so bundlers resolve them correctly

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d3352bb9c88327ab13e00053080d99