### PR TITLE
Fix asset paths to use public directory

### DIFF
--- a/index.html
+++ b/index.html
@@ -481,8 +481,7 @@
 
         const resolveRelativeUrl = (relativePath) => new URL(relativePath, import.meta.url).href;
         const skyAssetLocations = [
-            { prefix: './public/assets/sky/', label: 'public/assets/sky' },
-            { prefix: './assets/sky/', label: 'assets/sky (legacy)' }
+            { prefix: './public/assets/sky/', label: 'public/assets/sky' }
         ];
 
         const nightSkyTextureSources = skyAssetLocations.map(({ prefix, label }, index) => ({
@@ -1154,7 +1153,7 @@
             };
         };
 
-        const BUILDING_MODEL_PATH = './assets/models/buildings/';
+        const BUILDING_MODEL_PATH = './public/assets/models/buildings/';
 
         const AGORA_FEATURES = {
             templeOfHephaistos: {


### PR DESCRIPTION
## Summary
- remove the legacy `./assets/sky` fallback so the loader only targets files under `public/assets/sky`
- point the building model base path at `public/assets/models/buildings` so geometry loads from the public assets directory

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d3371c92088327bf689197efa88ca1