### PR TITLE
Fix ground overlay shader alpha map error

### DIFF
--- a/src/scene/ground.js
+++ b/src/scene/ground.js
@@ -13,6 +13,9 @@ function configureRepeatingTexture(texture, repeats, anisotropy, colorSpace) {
   texture.repeat.set(repeats, repeats);
   texture.anisotropy = Math.max(texture.anisotropy ?? 0, anisotropy);
   texture.colorSpace = colorSpace;
+  if (typeof texture.updateMatrix === 'function') {
+    texture.updateMatrix();
+  }
   texture.needsUpdate = true;
 }
 
@@ -32,39 +35,100 @@ function loadTexture(loader, url, warningMessage) {
   });
 }
 
+function updateOverlayUniforms(material) {
+  const uniforms = material.userData?.overlayUniforms;
+
+  if (!uniforms) return;
+
+  const texture = material.userData.overlayTexture ?? null;
+  const opacity = material.userData.overlayOpacity ?? (texture ? OVERLAY_OPACITY : 0);
+
+  if (uniforms.overlayOpacity) {
+    uniforms.overlayOpacity.value = opacity;
+  }
+
+  if (uniforms.overlayMap) {
+    uniforms.overlayMap.value = texture;
+  }
+
+  if (uniforms.overlayMapTransform?.value) {
+    if (texture) {
+      if (typeof texture.updateMatrix === 'function') {
+        texture.updateMatrix();
+      }
+      uniforms.overlayMapTransform.value.copy(texture.matrix);
+    } else {
+      uniforms.overlayMapTransform.value.identity();
+    }
+  }
+}
+
 function injectOverlayShader(material) {
   material.userData = material.userData || {};
 
   if (material.userData.overlayShaderApplied) {
-    const uniforms = material.userData.overlayUniforms;
-    if (uniforms?.overlayOpacity) {
-      uniforms.overlayOpacity.value = material.userData.overlayOpacity ?? OVERLAY_OPACITY;
-    }
+    updateOverlayUniforms(material);
     return;
   }
 
-  const existingCacheKey = material.customProgramCacheKey?.();
+  if (!material.userData.baseCustomProgramCacheKey) {
+    material.userData.baseCustomProgramCacheKey = material.customProgramCacheKey;
+  }
+
+  const baseCustomProgramCacheKey = material.userData.baseCustomProgramCacheKey;
 
   material.onBeforeCompile = (shader) => {
+    const overlayTexture = material.userData.overlayTexture ?? null;
+
     shader.uniforms.overlayOpacity = {
       value: material.userData.overlayOpacity ?? OVERLAY_OPACITY
     };
+    shader.uniforms.overlayMap = {
+      value: overlayTexture
+    };
+    shader.uniforms.overlayMapTransform = {
+      value: new THREE.Matrix3()
+    };
+
+    shader.vertexShader = shader.vertexShader
+      .replace(
+        '#include <uv_pars_vertex>',
+        '#include <uv_pars_vertex>\n#ifdef USE_OVERLAY_TEXTURE\nvarying vec2 vOverlayUv;\nuniform mat3 overlayMapTransform;\n#endif\n'
+      )
+      .replace(
+        '#include <uv_vertex>',
+        `#include <uv_vertex>\n#ifdef USE_OVERLAY_TEXTURE\n  #ifdef USE_UV\n    vec3 overlayUv = vec3( uv, 1.0 );\n    vOverlayUv = ( overlayMapTransform * overlayUv ).xy;\n  #else\n    vOverlayUv = vec2( 0.0 );\n  #endif\n#endif\n`
+      );
 
     shader.fragmentShader = shader.fragmentShader
       .replace(
-        '#include <alphamap_pars_fragment>',
-        '#include <alphamap_pars_fragment>\nuniform float overlayOpacity;\n'
+        '#include <map_pars_fragment>',
+        '#include <map_pars_fragment>\n#ifdef USE_OVERLAY_TEXTURE\nuniform sampler2D overlayMap;\nuniform float overlayOpacity;\nvarying vec2 vOverlayUv;\n#endif\n'
       )
       .replace(
-        '#include <alphamap_fragment>',
-        `#ifdef USE_ALPHAMAP\n  vec4 overlayColor = texture2D( alphaMap, vAlphaMapUv );\n  diffuseColor.rgb = mix( diffuseColor.rgb, overlayColor.rgb, overlayOpacity );\n  diffuseColor.a = 1.0;\n#endif`
+        '#include <map_fragment>',
+        `#include <map_fragment>\n#ifdef USE_OVERLAY_TEXTURE\n  vec4 overlayColor = texture2D( overlayMap, vOverlayUv );\n  diffuseColor.rgb = mix( diffuseColor.rgb, overlayColor.rgb, overlayOpacity );\n  diffuseColor.a = 1.0;\n#endif\n`
       );
 
+    shader.defines = shader.defines || {};
+
+    if (overlayTexture) {
+      shader.defines.USE_OVERLAY_TEXTURE = 1;
+    } else {
+      delete shader.defines.USE_OVERLAY_TEXTURE;
+    }
+
     material.userData.overlayUniforms = shader.uniforms;
+    updateOverlayUniforms(material);
   };
 
-  material.customProgramCacheKey = () =>
-    `${existingCacheKey ?? 'ground'}-overlay-${material.userData.overlayOpacity ?? OVERLAY_OPACITY}`;
+  material.customProgramCacheKey = function () {
+    const baseKey = typeof baseCustomProgramCacheKey === 'function'
+      ? baseCustomProgramCacheKey.call(this)
+      : baseCustomProgramCacheKey ?? 'ground';
+    const overlayState = this.userData?.overlayTexture ? 'overlay-on' : 'overlay-off';
+    return `${baseKey}-overlay-${overlayState}`;
+  };
 
   material.userData.overlayShaderApplied = true;
   material.needsUpdate = true;
@@ -75,26 +139,14 @@ function applyOverlayTexture(material, texture, opacity) {
 
   material.userData = material.userData || {};
   material.userData.overlayOpacity = opacity;
+  material.userData.overlayTexture = texture ?? null;
 
-  if (!texture) {
-    material.alphaMap = null;
-    const uniforms = material.userData.overlayUniforms;
-    if (uniforms?.overlayOpacity) {
-      uniforms.overlayOpacity.value = 0;
-    }
-    return;
-  }
-
-  material.alphaMap = texture;
   material.transparent = false;
   material.opacity = 1;
 
   injectOverlayShader(material);
 
-  const uniforms = material.userData.overlayUniforms;
-  if (uniforms?.overlayOpacity) {
-    uniforms.overlayOpacity.value = opacity;
-  }
+  updateOverlayUniforms(material);
 
   material.needsUpdate = true;
 }


### PR DESCRIPTION
## Summary
- refresh repeating textures after tweaking wrap/repeat values so shader transforms stay in sync
- replace the custom alphaMap shader hack with an overlay-specific uniform pipeline that defines its own varyings
- keep overlay uniforms up to date when the texture or opacity changes to avoid recompilation issues

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d33e8697ec83278e73deb2075d4aef