### PR TITLE
Fix BUILDING_MODEL_PATH reference for modular loader

### DIFF
--- a/index.html
+++ b/index.html
@@ -1154,6 +1154,9 @@
         };
 
         const BUILDING_MODEL_PATH = './public/assets/models/buildings/';
+        if (typeof window !== 'undefined') {
+            window.BUILDING_MODEL_PATH = BUILDING_MODEL_PATH;
+        }
 
         const AGORA_FEATURES = {
             templeOfHephaistos: {
@@ -6402,6 +6405,10 @@ function createBasicAgoraFallback() {
         }
 
         const gltfLoader = new GLTFLoader();
+        const BUILDING_MODEL_PATH =
+            typeof window !== 'undefined' && window.BUILDING_MODEL_PATH
+                ? window.BUILDING_MODEL_PATH
+                : './public/assets/models/buildings/';
 
         const loadModelWithFallback = (paths, onSuccess, onFailure) => {
             if (!Array.isArray(paths) || paths.length === 0) {


### PR DESCRIPTION
## Summary
- expose the building model base path on `window` so other modules can reuse it
- fall back to the shared model path when loading the Greek temple from the hoplite module

## Testing
- not run (HTML-only change)


------
https://chatgpt.com/codex/tasks/task_b_68d34a2b5dd08327a29f3f16e23c0805