### PR TITLE
Add district overlays with HUD and ground dust bias

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,10 @@
             "three/examples/jsm/postprocessing/EffectComposer.js": "https://cdn.jsdelivr.net/npm/three@0.128.0/examples/jsm/postprocessing/EffectComposer.js",
             "three/examples/jsm/postprocessing/RenderPass.js": "https://cdn.jsdelivr.net/npm/three@0.128.0/examples/jsm/postprocessing/RenderPass.js",
             "three/examples/jsm/postprocessing/UnrealBloomPass.js": "https://cdn.jsdelivr.net/npm/three@0.128.0/examples/jsm/postprocessing/UnrealBloomPass.js",
-            "three/examples/jsm/utils/SkeletonUtils.js": "https://cdn.jsdelivr.net/npm/three@0.128.0/examples/jsm/utils/SkeletonUtils.js"
+            "three/examples/jsm/utils/SkeletonUtils.js": "https://cdn.jsdelivr.net/npm/three@0.128.0/examples/jsm/utils/SkeletonUtils.js",
+            "three/examples/jsm/lines/Line2.js": "https://cdn.jsdelivr.net/npm/three@0.128.0/examples/jsm/lines/Line2.js",
+            "three/examples/jsm/lines/LineGeometry.js": "https://cdn.jsdelivr.net/npm/three@0.128.0/examples/jsm/lines/LineGeometry.js",
+            "three/examples/jsm/lines/LineMaterial.js": "https://cdn.jsdelivr.net/npm/three@0.128.0/examples/jsm/lines/LineMaterial.js"
         }
     }
     </script>
@@ -130,7 +133,14 @@
             font-weight: 300;
             text-shadow: 0 2px 8px rgba(0,0,0,0.5);
         }
-        
+        #current-district,
+        .hud-district-label {
+            margin-top: 4px;
+            font-size: 14px;
+            color: rgba(255, 255, 255, 0.85);
+            text-shadow: 0 1px 4px rgba(0,0,0,0.4);
+        }
+
         .control-key {
             background: linear-gradient(145deg, rgba(255, 215, 0, 0.2), rgba(255, 215, 0, 0.1));
             padding: 2px 6px;
@@ -358,6 +368,20 @@
         .map-icon-democracy { background-color: #4dabf7; }
         .map-icon-cultural { background-color: #FFD700; }
         .map-icon-natural { background-color: #28a745; }
+        .map-icon-district {
+            background-color: rgba(255, 215, 0, 0.85);
+            border: 1px solid rgba(255, 255, 255, 0.7);
+            width: 12px;
+            height: 12px;
+            border-radius: 50%;
+            font-size: 7px;
+            font-weight: 700;
+            color: #1a1a1a;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            box-shadow: 0 0 6px rgba(255, 215, 0, 0.4);
+        }
     </style>
 </head>
 <body>
@@ -418,9 +442,18 @@
         import { UnrealBloomPass } from 'three/examples/jsm/postprocessing/UnrealBloomPass.js';
         import { createPhotoSkydome } from './src/sky/photoSkydome.js';
         import { nightSkyDataUrl } from './src/sky/nightSkyTextureData.js';
-        import { setupGround } from './src/main.js';
+        import { setupGround, configureGround } from './src/main.js';
         import { setEnvironment } from './src/scene/sky.js';
         import { loadBuildingTextures, retargetBuildingMaterials } from './src/scene/materials.js';
+        import {
+            createDistrictsLayer,
+            setDistricts,
+            getDistrictAt,
+            onDistrictsChanged,
+            setDistrictFillsVisible,
+            setDistrictOutlinesVisible
+        } from './src/scene/districts.js';
+        import { initDistrictHUD, watchPlayerPosition } from './src/scene/districts-hud.js';
 
         const TONE_JS_URL = 'https://cdnjs.cloudflare.com/ajax/libs/tone/14.7.77/Tone.js';
         let toneLoadingPromise = null;
@@ -1191,6 +1224,73 @@
         const PHALERON_POSITION = applyGeoToScene(PROJECTED_GEO_POINTS.phaleron);
         const PEIRAEUS_POSITION = applyGeoToScene(PROJECTED_GEO_POINTS.peiraeus);
 
+        const createOffsetDistrictPolygon = (origin, offsets) => offsets.map(([dx, dz]) => [
+            scaleValue(origin.x + dx),
+            scaleValue(origin.z + dz)
+        ]);
+        const createDistrictDefinitions = () => [
+            {
+                id: 'agora',
+                name: 'Agora',
+                color: 0xffc15e,
+                polygon: createOffsetDistrictPolygon(AGORA_ANCHOR_SCENE, [
+                    [-150, -110],
+                    [150, -120],
+                    [160, 140],
+                    [-160, 130]
+                ]),
+                dustBias: 0.35
+            },
+            {
+                id: 'acropolis',
+                name: 'Acropolis',
+                color: 0xd6c1b5,
+                polygon: createOffsetDistrictPolygon(ACROPOLIS_POSITION, [
+                    [-110, -80],
+                    [120, -70],
+                    [130, 100],
+                    [-120, 110]
+                ]),
+                dustBias: 0.2
+            },
+            {
+                id: 'pnyx',
+                name: 'Pnyx Hill',
+                color: 0x7db0d6,
+                polygon: createOffsetDistrictPolygon(PNYX_POSITION, [
+                    [-140, -70],
+                    [110, -80],
+                    [130, 100],
+                    [-160, 90]
+                ]),
+                dustBias: 0.3
+            },
+            {
+                id: 'kerameikos',
+                name: 'Kerameikos',
+                color: 0xb894a6,
+                polygon: createOffsetDistrictPolygon(KERAMEIKOS_POSITION, [
+                    [-110, -160],
+                    [150, -150],
+                    [160, 80],
+                    [-130, 90]
+                ]),
+                dustBias: 0.45
+            },
+            {
+                id: 'areopagus',
+                name: 'Areopagus',
+                color: 0x9ec48d,
+                polygon: createOffsetDistrictPolygon(AREOPAGUS_POSITION, [
+                    [-90, -70],
+                    [90, -60],
+                    [100, 80],
+                    [-100, 90]
+                ]),
+                dustBias: 0.25
+            }
+        ];
+
         const transformAgoraOffset = (offset) => {
             const delta = applyGeoOffsetToScene(offset);
             return {
@@ -1411,6 +1511,14 @@
 
         const buildingMaterialSet = loadBuildingTextures();
         let groundMesh = null;
+        let districtsLayer = null;
+        let districtChangeUnsubscribe = null;
+        let districtMiniMapIcons = [];
+        let stopDistrictWatch = null;
+        let currentDistricts = [];
+        let districtFillsVisible = true;
+        let districtOutlinesVisible = true;
+        let districtDustBiasEnabled = true;
         let currentEnvironmentMode = null;
 
         const applyEnvironmentMode = (mode = 'day') => {
@@ -1427,6 +1535,55 @@
         
         const baseMapBounds = { xMin: -80, xMax: 80, zMin: -80, zMax: 80 };
         const mapBounds = scaleBounds(baseMapBounds);
+        const clearDistrictMiniMapIcons = () => {
+            districtMiniMapIcons.forEach((icon) => {
+                if (icon && icon.parentElement) {
+                    icon.parentElement.removeChild(icon);
+                }
+            });
+            districtMiniMapIcons = [];
+        };
+        function updateDistrictMiniMapIcons(districts = currentDistricts) {
+            const container = document.getElementById('mini-map-container');
+            if (!container) {
+                return;
+            }
+
+            clearDistrictMiniMapIcons();
+
+            if (!Array.isArray(districts) || districts.length === 0) {
+                return;
+            }
+
+            const mapWidth = container.clientWidth || 200;
+            const mapHeight = container.clientHeight || 200;
+            const worldWidth = mapBounds.xMax - mapBounds.xMin;
+            const worldDepth = mapBounds.zMax - mapBounds.zMin;
+
+            if (worldWidth === 0 || worldDepth === 0) {
+                return;
+            }
+
+            districts.forEach((district) => {
+                if (!district || !district.centroid) {
+                    return;
+                }
+
+                const { centroid, name, id } = district;
+                const percentX = THREE.MathUtils.clamp((centroid.x - mapBounds.xMin) / worldWidth, 0, 1);
+                const percentZ = THREE.MathUtils.clamp((centroid.z - mapBounds.zMin) / worldDepth, 0, 1);
+
+                const icon = document.createElement('div');
+                icon.className = 'map-icon map-icon-district';
+                icon.textContent = (name || id || '?').charAt(0).toUpperCase();
+                icon.title = name || id || 'District';
+                icon.style.left = `${percentX * mapWidth}px`;
+                icon.style.top = `${percentZ * mapHeight}px`;
+
+                container.appendChild(icon);
+                districtMiniMapIcons.push(icon);
+            });
+        }
         const getRandomWorldXZ = (padding = 0) => ({
             x: THREE.MathUtils.randFloat(mapBounds.xMin + padding, mapBounds.xMax - padding),
             z: THREE.MathUtils.randFloat(mapBounds.zMin + padding, mapBounds.zMax - padding)
@@ -1487,6 +1644,28 @@
             renderer.shadowMap.type = THREE.PCFSoftShadowMap;
             document.body.appendChild(renderer.domElement);
             window.renderer = renderer;
+
+            districtsLayer = createDistrictsLayer({ scene });
+            if (typeof districtChangeUnsubscribe === 'function') {
+                districtChangeUnsubscribe();
+            }
+            districtChangeUnsubscribe = onDistrictsChanged((districts) => {
+                currentDistricts = districts;
+                updateDistrictMiniMapIcons(districts);
+                if (groundMesh?.userData?.refreshDistrictDustBiasTexture) {
+                    groundMesh.userData.refreshDistrictDustBiasTexture();
+                }
+            });
+            currentDistricts = setDistricts(createDistrictDefinitions());
+            setDistrictFillsVisible(districtFillsVisible);
+            setDistrictOutlinesVisible(districtOutlinesVisible);
+
+            configureGround({
+                getDustBiasAt: (x, z) => {
+                    const district = getDistrictAt(x, z);
+                    return district?.dustBias ?? 0;
+                }
+            });
 
             const maxAnisotropy = renderer?.capabilities?.getMaxAnisotropy?.() ?? 8;
             const textureLoader = new THREE.TextureLoader();
@@ -1592,6 +1771,13 @@
             scene.add(hemisphereLight);
 
             groundMesh = await setupGround(scene, renderer);
+
+            if (groundMesh?.userData?.refreshDistrictDustBiasTexture) {
+                groundMesh.userData.refreshDistrictDustBiasTexture();
+            }
+            if (groundMesh?.userData?.setDistrictDustBiasEnabled) {
+                groundMesh.userData.setDistrictDustBiasEnabled(districtDustBiasEnabled);
+            }
 
             if (groundMesh) {
                 groundMaterial = groundMesh.material;
@@ -1736,8 +1922,19 @@
             // Build Scene
             buildWorld();
             createInteractables();
+            initDistrictHUD();
+            if (typeof stopDistrictWatch === 'function') {
+                stopDistrictWatch();
+            }
+            stopDistrictWatch = watchPlayerPosition(() => {
+                if (player?.body) {
+                    return [player.body.position.x, player.body.position.z];
+                }
+                return [null, null];
+            });
             createInteractiveObjects();
             createMapIcons();
+            updateDistrictMiniMapIcons(currentDistricts);
             // Load the temple model (GLB)
             loadGreekTemple();
 
@@ -5919,6 +6116,23 @@ function createBasicAgoraFallback() {
 
             window.addEventListener('keydown', (e) => {
                 if (e.repeat) return;
+                if (e.key === ';') {
+                    districtFillsVisible = !districtFillsVisible;
+                    setDistrictFillsVisible(districtFillsVisible);
+                    return;
+                }
+                if (e.key === "'") {
+                    districtOutlinesVisible = !districtOutlinesVisible;
+                    setDistrictOutlinesVisible(districtOutlinesVisible);
+                    return;
+                }
+                if (e.key === '/') {
+                    districtDustBiasEnabled = !districtDustBiasEnabled;
+                    if (groundMesh?.userData?.setDistrictDustBiasEnabled) {
+                        groundMesh.userData.setDistrictDustBiasEnabled(districtDustBiasEnabled);
+                    }
+                    return;
+                }
                 const sky = window.__AthensSky__;
                 if (!sky) return;
                 if (e.key === '[' || e.key === ']') {

--- a/src/main.js
+++ b/src/main.js
@@ -1,7 +1,17 @@
 import { loadGround } from './scene/ground.js';
 
+let groundOptions = {};
+
+export function configureGround(options = {}) {
+  if (!options || typeof options !== 'object') {
+    return;
+  }
+
+  groundOptions = { ...groundOptions, ...options };
+}
+
 export async function setupGround(scene, renderer) {
-  const ground = await loadGround(scene, renderer);
+  const ground = await loadGround(scene, renderer, groundOptions);
 
   if (ground && scene && !scene.children.includes(ground)) {
     scene.add(ground);

--- a/src/scene/districts-hud.js
+++ b/src/scene/districts-hud.js
@@ -1,0 +1,138 @@
+import { getDistrictAt, onDistrictsChanged } from './districts.js';
+
+let districtLabel = null;
+let activeWatcherStopper = null;
+
+function ensureLabel() {
+  if (districtLabel && districtLabel.isConnected) {
+    return districtLabel;
+  }
+
+  if (typeof document === 'undefined') {
+    return null;
+  }
+
+  const existing = document.getElementById('current-district');
+  if (existing) {
+    districtLabel = existing;
+    return districtLabel;
+  }
+
+  const timeElement = document.getElementById('current-time');
+  if (!timeElement) {
+    return null;
+  }
+
+  const label = document.createElement('div');
+  label.id = 'current-district';
+  label.className = 'hud-district-label';
+  label.textContent = 'Current District: Wilderness';
+
+  const parent = timeElement.parentElement;
+  if (parent) {
+    if (timeElement.nextSibling) {
+      parent.insertBefore(label, timeElement.nextSibling);
+    } else {
+      parent.appendChild(label);
+    }
+  } else {
+    timeElement.insertAdjacentElement('afterend', label);
+  }
+
+  districtLabel = label;
+  return districtLabel;
+}
+
+function updateLabel(district) {
+  const label = ensureLabel();
+  if (!label) {
+    return;
+  }
+
+  const name = district?.name ?? 'Wilderness';
+  label.textContent = `Current District: ${name}`;
+  if (district?.id) {
+    label.dataset.districtId = district.id;
+  } else {
+    delete label.dataset.districtId;
+  }
+}
+
+export function initDistrictHUD() {
+  return ensureLabel();
+}
+
+export function watchPlayerPosition(getWorldXZ, { intervalMs = 200 } = {}) {
+  if (typeof window === 'undefined' || typeof getWorldXZ !== 'function') {
+    return () => {};
+  }
+
+  if (typeof activeWatcherStopper === 'function') {
+    activeWatcherStopper();
+  }
+
+  ensureLabel();
+
+  let lastDistrictId = null;
+  let stopped = false;
+
+  const safeInterval = Math.max(50, Math.floor(intervalMs ?? 200));
+
+  const evaluate = () => {
+    if (stopped) {
+      return;
+    }
+
+    let coords;
+    try {
+      coords = getWorldXZ();
+    } catch (error) {
+      return;
+    }
+
+    let x = null;
+    let z = null;
+
+    if (Array.isArray(coords)) {
+      [x, z] = coords;
+    } else if (coords && typeof coords === 'object') {
+      if (typeof coords.x === 'number' && typeof coords.z === 'number') {
+        ({ x, z } = coords);
+      } else if (typeof coords[0] === 'number' && typeof coords[1] === 'number') {
+        x = coords[0];
+        z = coords[1];
+      }
+    }
+
+    if (typeof x === 'number' && typeof z === 'number') {
+      const district = getDistrictAt(x, z);
+      const nextId = district?.id ?? null;
+      if (nextId !== lastDistrictId) {
+        lastDistrictId = nextId;
+        updateLabel(district);
+      }
+    } else if (lastDistrictId !== null) {
+      lastDistrictId = null;
+      updateLabel(null);
+    }
+  };
+
+  const intervalHandle = window.setInterval(evaluate, safeInterval);
+  const unsubscribe = onDistrictsChanged(() => {
+    lastDistrictId = null;
+    evaluate();
+  });
+
+  evaluate();
+
+  activeWatcherStopper = () => {
+    if (!stopped) {
+      stopped = true;
+      window.clearInterval(intervalHandle);
+      unsubscribe();
+      activeWatcherStopper = null;
+    }
+  };
+
+  return activeWatcherStopper;
+}

--- a/src/scene/districts.js
+++ b/src/scene/districts.js
@@ -1,0 +1,348 @@
+import * as THREE from 'three';
+import { Line2 } from 'three/examples/jsm/lines/Line2.js';
+import { LineMaterial } from 'three/examples/jsm/lines/LineMaterial.js';
+import { LineGeometry } from 'three/examples/jsm/lines/LineGeometry.js';
+
+let districtsGroup = null;
+let districtFillGroup = null;
+let districtOutlineGroup = null;
+let fillsVisible = true;
+let outlinesVisible = true;
+let resizeListenerAttached = false;
+const outlineMaterials = new Set();
+const districtChangeHandlers = new Set();
+let currentDistricts = [];
+
+function ensureDistrictLayer() {
+  if (districtsGroup) {
+    return;
+  }
+
+  districtsGroup = new THREE.Group();
+  districtsGroup.name = 'DistrictsLayer';
+  districtsGroup.position.y = 0.02;
+
+  districtFillGroup = new THREE.Group();
+  districtFillGroup.name = 'DistrictFills';
+  districtFillGroup.renderOrder = 1;
+
+  districtOutlineGroup = new THREE.Group();
+  districtOutlineGroup.name = 'DistrictOutlines';
+  districtOutlineGroup.renderOrder = 2;
+
+  districtsGroup.add(districtFillGroup);
+  districtsGroup.add(districtOutlineGroup);
+}
+
+function updateLineMaterialResolution() {
+  if (typeof window === 'undefined' || !outlineMaterials.size) {
+    return;
+  }
+
+  const width = Math.max(1, window.innerWidth || 1);
+  const height = Math.max(1, window.innerHeight || 1);
+
+  outlineMaterials.forEach((material) => {
+    if (material && material.resolution) {
+      material.resolution.set(width, height);
+    }
+  });
+}
+
+function attachResizeListener() {
+  if (resizeListenerAttached || typeof window === 'undefined') {
+    return;
+  }
+
+  window.addEventListener('resize', updateLineMaterialResolution);
+  resizeListenerAttached = true;
+}
+
+function disposeMaterial(material) {
+  if (!material) {
+    return;
+  }
+
+  if (Array.isArray(material)) {
+    material.forEach(disposeMaterial);
+    return;
+  }
+
+  if (material instanceof LineMaterial) {
+    outlineMaterials.delete(material);
+  }
+
+  if (typeof material.dispose === 'function') {
+    material.dispose();
+  }
+}
+
+function clearGroup(group) {
+  if (!group) {
+    return;
+  }
+
+  for (let i = group.children.length - 1; i >= 0; i -= 1) {
+    const child = group.children[i];
+    group.remove(child);
+
+    if (child.geometry && typeof child.geometry.dispose === 'function') {
+      child.geometry.dispose();
+    }
+
+    disposeMaterial(child.material);
+  }
+}
+
+function computePolygonCentroid(polygon) {
+  let area = 0;
+  let cx = 0;
+  let cz = 0;
+
+  const count = polygon.length;
+  if (count === 0) {
+    return { x: 0, z: 0 };
+  }
+
+  for (let i = 0; i < count; i += 1) {
+    const [x1, z1] = polygon[i];
+    const [x2, z2] = polygon[(i + 1) % count];
+    const cross = x1 * z2 - x2 * z1;
+    area += cross;
+    cx += (x1 + x2) * cross;
+    cz += (z1 + z2) * cross;
+  }
+
+  area *= 0.5;
+
+  if (Math.abs(area) < 1e-5) {
+    let sumX = 0;
+    let sumZ = 0;
+    polygon.forEach(([x, z]) => {
+      sumX += x;
+      sumZ += z;
+    });
+    return { x: sumX / count, z: sumZ / count };
+  }
+
+  const factor = 1 / (6 * area);
+  return { x: cx * factor, z: cz * factor };
+}
+
+function pointOnSegment(px, pz, x1, z1, x2, z2) {
+  const epsilon = 1e-6;
+  const cross = (pz - z1) * (x2 - x1) - (px - x1) * (z2 - z1);
+  if (Math.abs(cross) > epsilon) {
+    return false;
+  }
+
+  const dot = (px - x1) * (px - x2) + (pz - z1) * (pz - z2);
+  return dot <= epsilon;
+}
+
+function isPointInPolygon(x, z, polygon) {
+  let inside = false;
+
+  for (let i = 0, j = polygon.length - 1; i < polygon.length; j = i, i += 1) {
+    const [xi, zi] = polygon[i];
+    const [xj, zj] = polygon[j];
+
+    if (pointOnSegment(x, z, xi, zi, xj, zj)) {
+      return true;
+    }
+
+    const intersects = ((zi > z) !== (zj > z))
+      && (x < ((xj - xi) * (z - zi)) / ((zj - zi) || 1e-7) + xi);
+
+    if (intersects) {
+      inside = !inside;
+    }
+  }
+
+  return inside;
+}
+
+function notifyDistrictsChanged() {
+  if (!districtChangeHandlers.size) {
+    return;
+  }
+
+  const snapshot = currentDistricts.map((district) => ({ ...district }));
+  districtChangeHandlers.forEach((handler) => {
+    try {
+      handler(snapshot);
+    } catch (error) {
+      console.warn('[districts] change handler error', error);
+    }
+  });
+}
+
+export function createDistrictsLayer({ scene } = {}) {
+  ensureDistrictLayer();
+  attachResizeListener();
+
+  if (scene && !scene.children.includes(districtsGroup)) {
+    scene.add(districtsGroup);
+  }
+
+  return districtsGroup;
+}
+
+export function setDistricts(districtDefs = []) {
+  ensureDistrictLayer();
+  clearGroup(districtFillGroup);
+  clearGroup(districtOutlineGroup);
+  outlineMaterials.clear();
+
+  const processed = [];
+
+  districtDefs.forEach((def, index) => {
+    if (!def || !Array.isArray(def.polygon) || def.polygon.length < 3) {
+      return;
+    }
+
+    const id = def.id || `district-${index}`;
+    const name = def.name || id;
+    const dustBias = typeof def.dustBias === 'number' ? THREE.MathUtils.clamp(def.dustBias, 0, 1) : 0;
+    const baseColor = new THREE.Color(def.color !== undefined ? def.color : 0xffd700);
+
+    const polygon = def.polygon.map((vertex) => {
+      if (!Array.isArray(vertex) || vertex.length < 2) {
+        return [0, 0];
+      }
+      const [vx, vz] = vertex;
+      return [Number(vx) || 0, Number(vz) || 0];
+    });
+
+    const centroid = computePolygonCentroid(polygon);
+
+    const shape = new THREE.Shape(polygon.map(([vx, vz]) => new THREE.Vector2(vx, vz)));
+    const shapeGeometry = new THREE.ShapeGeometry(shape);
+    const fillColor = baseColor.clone().lerp(new THREE.Color(0xffffff), 0.7);
+    const fillMaterial = new THREE.MeshBasicMaterial({
+      color: fillColor,
+      transparent: true,
+      opacity: 0.08,
+      side: THREE.DoubleSide,
+      depthWrite: true
+    });
+
+    const fillMesh = new THREE.Mesh(shapeGeometry, fillMaterial);
+    fillMesh.rotation.x = -Math.PI / 2;
+    fillMesh.name = `district-fill-${id}`;
+    fillMesh.renderOrder = districtFillGroup.renderOrder;
+    fillMesh.userData.districtId = id;
+    districtFillGroup.add(fillMesh);
+
+    const outlinePositions = [];
+    polygon.forEach(([vx, vz]) => {
+      outlinePositions.push(vx, 0, vz);
+    });
+    outlinePositions.push(polygon[0][0], 0, polygon[0][1]);
+
+    const lineGeometry = new LineGeometry();
+    lineGeometry.setPositions(outlinePositions);
+
+    const lineColor = baseColor.clone().lerp(new THREE.Color(0xffffff), 0.3);
+    const lineMaterial = new LineMaterial({
+      color: lineColor.getHex(),
+      linewidth: 3,
+      transparent: true,
+      opacity: 0.6,
+      depthWrite: true,
+      depthTest: true,
+      alphaToCoverage: true
+    });
+
+    if (typeof window !== 'undefined' && lineMaterial.resolution) {
+      lineMaterial.resolution.set(Math.max(1, window.innerWidth || 1), Math.max(1, window.innerHeight || 1));
+    }
+
+    const line = new Line2(lineGeometry, lineMaterial);
+    line.computeLineDistances();
+    line.name = `district-outline-${id}`;
+    line.renderOrder = districtOutlineGroup.renderOrder;
+    line.position.y = 0.001;
+    line.userData.districtId = id;
+    districtOutlineGroup.add(line);
+    outlineMaterials.add(lineMaterial);
+
+    processed.push({
+      id,
+      name,
+      color: baseColor.getHex(),
+      polygon,
+      centroid,
+      dustBias
+    });
+  });
+
+  currentDistricts = processed;
+  districtFillGroup.visible = fillsVisible;
+  districtOutlineGroup.visible = outlinesVisible;
+
+  updateLineMaterialResolution();
+  notifyDistrictsChanged();
+
+  return currentDistricts;
+}
+
+export function getDistrictAt(x, z) {
+  if (!currentDistricts.length || typeof x !== 'number' || typeof z !== 'number') {
+    return null;
+  }
+
+  for (const district of currentDistricts) {
+    if (isPointInPolygon(x, z, district.polygon)) {
+      return district;
+    }
+  }
+
+  return null;
+}
+
+export function onDistrictsChanged(handler) {
+  if (typeof handler !== 'function') {
+    return () => {};
+  }
+
+  districtChangeHandlers.add(handler);
+
+  if (currentDistricts.length) {
+    try {
+      handler(currentDistricts.map((district) => ({ ...district })));
+    } catch (error) {
+      console.warn('[districts] change handler error', error);
+    }
+  }
+
+  return () => {
+    districtChangeHandlers.delete(handler);
+  };
+}
+
+export function setDistrictFillsVisible(visible) {
+  fillsVisible = Boolean(visible);
+  if (districtFillGroup) {
+    districtFillGroup.visible = fillsVisible;
+  }
+}
+
+export function setDistrictOutlinesVisible(visible) {
+  outlinesVisible = Boolean(visible);
+  if (districtOutlineGroup) {
+    districtOutlineGroup.visible = outlinesVisible;
+  }
+}
+
+export function areDistrictFillsVisible() {
+  return fillsVisible;
+}
+
+export function areDistrictOutlinesVisible() {
+  return outlinesVisible;
+}
+
+export function getDistricts() {
+  return currentDistricts.map((district) => ({ ...district }));
+}

--- a/src/scene/ground.js
+++ b/src/scene/ground.js
@@ -4,6 +4,35 @@ const GROUND_SIZE = 10000;
 const TEXTURE_REPEAT = 100;
 const OVERLAY_OPACITY = 0.4;
 const FALLBACK_COLOR = 0x808040;
+const DISTRICT_BIAS_TEXTURE_SIZE = 1024;
+const DISTRICT_BIAS_STRENGTH = 0.5;
+
+function clamp01(value) {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+
+  return Math.min(1, Math.max(0, value));
+}
+
+function ensureOverlayBiasState(material) {
+  if (!material) {
+    return;
+  }
+
+  material.userData = material.userData || {};
+
+  if (typeof material.userData.overlayBiasToggle !== 'number') {
+    material.userData.overlayBiasToggle = 1;
+  }
+
+  if (
+    !material.userData.overlayBiasWorldSize ||
+    !(material.userData.overlayBiasWorldSize instanceof THREE.Vector2)
+  ) {
+    material.userData.overlayBiasWorldSize = new THREE.Vector2(GROUND_SIZE, GROUND_SIZE);
+  }
+}
 
 function configureRepeatingTexture(texture, repeats, anisotropy, colorSpace) {
   if (!texture) return;
@@ -35,13 +64,120 @@ function loadTexture(loader, url, warningMessage) {
   });
 }
 
+function createDistrictBiasSampler({
+  getDustBiasAt,
+  size = DISTRICT_BIAS_TEXTURE_SIZE,
+  worldSize = GROUND_SIZE
+} = {}) {
+  if (typeof document === 'undefined' || typeof getDustBiasAt !== 'function') {
+    return null;
+  }
+
+  const canvas = document.createElement('canvas');
+  canvas.width = canvas.height = size;
+  const context = canvas.getContext('2d');
+
+  if (!context) {
+    return null;
+  }
+
+  const imageData = context.createImageData(size, size);
+  const texture = new THREE.CanvasTexture(canvas);
+  texture.wrapS = THREE.ClampToEdgeWrapping;
+  texture.wrapT = THREE.ClampToEdgeWrapping;
+  texture.magFilter = THREE.LinearFilter;
+  texture.minFilter = THREE.LinearFilter;
+  texture.generateMipmaps = false;
+  if (texture.colorSpace !== undefined && THREE.LinearSRGBColorSpace !== undefined) {
+    texture.colorSpace = THREE.LinearSRGBColorSpace;
+  }
+
+  const sampler = {
+    size,
+    canvas,
+    context,
+    imageData,
+    texture,
+    worldSize,
+    getDustBiasAt
+  };
+
+  sampler.refresh = () => {
+    if (typeof sampler.getDustBiasAt !== 'function') {
+      return;
+    }
+
+    const data = imageData.data;
+    let index = 0;
+
+    for (let y = 0; y < size; y++) {
+      const v = size > 1 ? y / (size - 1) : 0;
+      const worldZ = (v - 0.5) * worldSize;
+
+      for (let x = 0; x < size; x++) {
+        const u = size > 1 ? x / (size - 1) : 0;
+        const worldX = (u - 0.5) * worldSize;
+        const bias = clamp01(sampler.getDustBiasAt(worldX, worldZ));
+        const value = Math.round(bias * 255);
+        data[index++] = value;
+        data[index++] = value;
+        data[index++] = value;
+        data[index++] = 255;
+      }
+    }
+
+    context.putImageData(imageData, 0, 0);
+    texture.needsUpdate = true;
+  };
+
+  sampler.rebuild = (fn) => {
+    if (typeof fn === 'function') {
+      sampler.getDustBiasAt = fn;
+    }
+
+    sampler.refresh();
+  };
+
+  sampler.dispose = () => {
+    if (sampler.texture) {
+      sampler.texture.dispose();
+    }
+  };
+
+  sampler.refresh();
+
+  return sampler;
+}
+
+function applyOverlayBiasSampler(material, sampler, { worldSize = GROUND_SIZE } = {}) {
+  if (!material) {
+    return;
+  }
+
+  ensureOverlayBiasState(material);
+
+  material.userData.overlayBiasSampler = sampler ?? null;
+  material.userData.overlayBiasTexture = sampler?.texture ?? null;
+
+  const targetSize = material.userData.overlayBiasWorldSize;
+  if (targetSize) {
+    targetSize.set(worldSize, worldSize);
+  }
+
+  updateOverlayUniforms(material);
+  material.needsUpdate = true;
+}
+
 function updateOverlayUniforms(material) {
   const uniforms = material.userData?.overlayUniforms;
 
   if (!uniforms) return;
 
+  ensureOverlayBiasState(material);
+
   const texture = material.userData.overlayTexture ?? null;
   const opacity = material.userData.overlayOpacity ?? (texture ? OVERLAY_OPACITY : 0);
+  const biasTexture = material.userData.overlayBiasTexture ?? null;
 
   if (uniforms.overlayOpacity) {
     uniforms.overlayOpacity.value = opacity;
@@ -61,10 +197,32 @@ function updateOverlayUniforms(material) {
       uniforms.overlayMapTransform.value.identity();
     }
   }
+
+  if (uniforms.overlayBiasMap) {
+    uniforms.overlayBiasMap.value = biasTexture;
+  }
+
+  if (uniforms.overlayBiasMapTransform?.value) {
+    if (biasTexture && typeof biasTexture.updateMatrix === 'function') {
+      biasTexture.updateMatrix();
+      uniforms.overlayBiasMapTransform.value.copy(biasTexture.matrix);
+    } else {
+      uniforms.overlayBiasMapTransform.value.identity();
+    }
+  }
+
+  if (uniforms.overlayBiasWorldSize && material.userData.overlayBiasWorldSize) {
+    uniforms.overlayBiasWorldSize.value.copy(material.userData.overlayBiasWorldSize);
+  }
+
+  if (uniforms.overlayBiasToggle) {
+    uniforms.overlayBiasToggle.value = material.userData.overlayBiasToggle ?? 1;
+  }
 }
 
 function injectOverlayShader(material) {
   material.userData = material.userData || {};
+  ensureOverlayBiasState(material);
 
   if (material.userData.overlayShaderApplied) {
     updateOverlayUniforms(material);
@@ -79,6 +237,11 @@ function injectOverlayShader(material) {
 
   material.onBeforeCompile = (shader) => {
     const overlayTexture = material.userData.overlayTexture ?? null;
+    const overlayBiasTexture = material.userData.overlayBiasTexture ?? null;
+    const biasWorldSize = (material.userData.overlayBiasWorldSize instanceof THREE.Vector2)
+      ? material.userData.overlayBiasWorldSize.clone()
+      : new THREE.Vector2(GROUND_SIZE, GROUND_SIZE);
+    const biasStrength = DISTRICT_BIAS_STRENGTH.toFixed(3);
 
     shader.uniforms.overlayOpacity = {
       value: material.userData.overlayOpacity ?? OVERLAY_OPACITY
@@ -89,25 +252,37 @@ function injectOverlayShader(material) {
     shader.uniforms.overlayMapTransform = {
       value: new THREE.Matrix3()
     };
+    shader.uniforms.overlayBiasMap = {
+      value: overlayBiasTexture
+    };
+    shader.uniforms.overlayBiasMapTransform = {
+      value: new THREE.Matrix3()
+    };
+    shader.uniforms.overlayBiasWorldSize = {
+      value: biasWorldSize
+    };
+    shader.uniforms.overlayBiasToggle = {
+      value: material.userData.overlayBiasToggle ?? 1
+    };
 
     shader.vertexShader = shader.vertexShader
       .replace(
         '#include <uv_pars_vertex>',
-        '#include <uv_pars_vertex>\n#ifdef USE_OVERLAY_TEXTURE\nvarying vec2 vOverlayUv;\nuniform mat3 overlayMapTransform;\n#endif\n'
+        '#include <uv_pars_vertex>\n#ifdef USE_OVERLAY_TEXTURE\nvarying vec2 vOverlayUv;\nuniform mat3 overlayMapTransform;\n#endif\n#ifdef USE_OVERLAY_BIAS_TEXTURE\nvarying vec2 vOverlayBiasUv;\nuniform mat3 overlayBiasMapTransform;\nuniform vec2 overlayBiasWorldSize;\n#endif\n'
       )
       .replace(
         '#include <uv_vertex>',
-        `#include <uv_vertex>\n#ifdef USE_OVERLAY_TEXTURE\n  #ifdef USE_UV\n    vec3 overlayUv = vec3( uv, 1.0 );\n    vOverlayUv = ( overlayMapTransform * overlayUv ).xy;\n  #else\n    vOverlayUv = vec2( 0.0 );\n  #endif\n#endif\n`
+        `#include <uv_vertex>\n#ifdef USE_OVERLAY_TEXTURE\n  #ifdef USE_UV\n    vec3 overlayUv = vec3( uv, 1.0 );\n    vOverlayUv = ( overlayMapTransform * overlayUv ).xy;\n  #else\n    vOverlayUv = vec2( 0.0 );\n  #endif\n#endif\n#ifdef USE_OVERLAY_BIAS_TEXTURE\n  vec4 worldPos = modelMatrix * vec4( position, 1.0 );\n  vec2 biasUv = ( worldPos.xz / overlayBiasWorldSize ) + 0.5;\n  biasUv = clamp( biasUv, 0.0, 1.0 );\n  vec3 biasUv3 = vec3( biasUv, 1.0 );\n  vOverlayBiasUv = ( overlayBiasMapTransform * biasUv3 ).xy;\n#endif\n`
       );
 
     shader.fragmentShader = shader.fragmentShader
       .replace(
         '#include <map_pars_fragment>',
-        '#include <map_pars_fragment>\n#ifdef USE_OVERLAY_TEXTURE\nuniform sampler2D overlayMap;\nuniform float overlayOpacity;\nvarying vec2 vOverlayUv;\n#endif\n'
+        '#include <map_pars_fragment>\n#ifdef USE_OVERLAY_TEXTURE\nuniform sampler2D overlayMap;\nuniform float overlayOpacity;\nvarying vec2 vOverlayUv;\n#endif\n#ifdef USE_OVERLAY_BIAS_TEXTURE\nuniform sampler2D overlayBiasMap;\nuniform float overlayBiasToggle;\nvarying vec2 vOverlayBiasUv;\n#endif\n'
       )
       .replace(
         '#include <map_fragment>',
-        `#include <map_fragment>\n#ifdef USE_OVERLAY_TEXTURE\n  vec4 overlayColor = texture2D( overlayMap, vOverlayUv );\n  diffuseColor.rgb = mix( diffuseColor.rgb, overlayColor.rgb, overlayOpacity );\n  diffuseColor.a = 1.0;\n#endif\n`
+        `#include <map_fragment>\n#ifdef USE_OVERLAY_TEXTURE\n  vec4 overlayColor = texture2D( overlayMap, vOverlayUv );\n  float overlayStrength = overlayOpacity;\n  #ifdef USE_OVERLAY_BIAS_TEXTURE\n    float biasSample = clamp( texture2D( overlayBiasMap, vOverlayBiasUv ).r, 0.0, 1.0 );\n    overlayStrength *= mix( 1.0, 1.0 + biasSample * ${biasStrength}, overlayBiasToggle );\n  #endif\n  diffuseColor.rgb = mix( diffuseColor.rgb, overlayColor.rgb, overlayStrength );\n  diffuseColor.a = 1.0;\n#endif\n`
       );
 
     shader.defines = shader.defines || {};
@@ -116,6 +291,12 @@ function injectOverlayShader(material) {
       shader.defines.USE_OVERLAY_TEXTURE = 1;
     } else {
       delete shader.defines.USE_OVERLAY_TEXTURE;
+    }
+
+    if (overlayBiasTexture) {
+      shader.defines.USE_OVERLAY_BIAS_TEXTURE = 1;
+    } else {
+      delete shader.defines.USE_OVERLAY_BIAS_TEXTURE;
     }
 
     material.userData.overlayUniforms = shader.uniforms;
@@ -127,7 +308,8 @@ function injectOverlayShader(material) {
       ? baseCustomProgramCacheKey.call(this)
       : baseCustomProgramCacheKey ?? 'ground';
     const overlayState = this.userData?.overlayTexture ? 'overlay-on' : 'overlay-off';
-    return `${baseKey}-overlay-${overlayState}`;
+    const biasState = this.userData?.overlayBiasTexture ? 'bias-on' : 'bias-off';
+    return `${baseKey}-overlay-${overlayState}-bias-${biasState}`;
   };
 
   material.userData.overlayShaderApplied = true;
@@ -138,6 +320,7 @@ function applyOverlayTexture(material, texture, opacity) {
   if (!material) return;
 
   material.userData = material.userData || {};
+  ensureOverlayBiasState(material);
   material.userData.overlayOpacity = opacity;
   material.userData.overlayTexture = texture ?? null;
 
@@ -151,15 +334,17 @@ function applyOverlayTexture(material, texture, opacity) {
   material.needsUpdate = true;
 }
 
-export async function loadGround(scene, renderer) {
+export async function loadGround(scene, renderer, options = {}) {
   const loader = new THREE.TextureLoader();
   const anisotropy = renderer?.capabilities?.getMaxAnisotropy?.() ?? 1;
+  const { getDustBiasAt } = options ?? {};
 
   const material = new THREE.MeshStandardMaterial({
     color: FALLBACK_COLOR,
     roughness: 1,
     metalness: 0
   });
+  ensureOverlayBiasState(material);
 
   const ground = new THREE.Mesh(new THREE.PlaneGeometry(GROUND_SIZE, GROUND_SIZE), material);
   ground.rotation.x = -Math.PI / 2;
@@ -187,7 +372,78 @@ export async function loadGround(scene, renderer) {
     applyOverlayTexture(material, null, 0);
   }
 
+  let districtBiasSampler = null;
+  let activeDustBias = typeof getDustBiasAt === 'function' ? getDustBiasAt : null;
+
+  if (typeof activeDustBias === 'function') {
+    districtBiasSampler = createDistrictBiasSampler({
+      getDustBiasAt: activeDustBias,
+      worldSize: GROUND_SIZE
+    });
+  }
+
+  if (districtBiasSampler) {
+    applyOverlayBiasSampler(material, districtBiasSampler, { worldSize: GROUND_SIZE });
+  } else {
+    applyOverlayBiasSampler(material, null, { worldSize: GROUND_SIZE });
+  }
+
   material.needsUpdate = true;
+
+  ground.userData = ground.userData || {};
+
+  const setDistrictBiasSampler = (fn) => {
+    if (typeof fn !== 'function') {
+      activeDustBias = null;
+      if (districtBiasSampler) {
+        districtBiasSampler.dispose();
+      }
+      districtBiasSampler = null;
+      applyOverlayBiasSampler(material, null, { worldSize: GROUND_SIZE });
+      return;
+    }
+
+    activeDustBias = fn;
+
+    if (districtBiasSampler) {
+      districtBiasSampler.rebuild(activeDustBias);
+      applyOverlayBiasSampler(material, districtBiasSampler, { worldSize: GROUND_SIZE });
+      return;
+    }
+
+    const sampler = createDistrictBiasSampler({
+      getDustBiasAt: activeDustBias,
+      worldSize: GROUND_SIZE
+    });
+
+    if (sampler) {
+      districtBiasSampler = sampler;
+      applyOverlayBiasSampler(material, districtBiasSampler, { worldSize: GROUND_SIZE });
+    }
+  };
+
+  const refreshDistrictBiasTexture = (fn) => {
+    if (typeof fn === 'function') {
+      setDistrictBiasSampler(fn);
+      return;
+    }
+
+    if (districtBiasSampler) {
+      districtBiasSampler.rebuild();
+      applyOverlayBiasSampler(material, districtBiasSampler, { worldSize: GROUND_SIZE });
+    } else if (typeof activeDustBias === 'function') {
+      setDistrictBiasSampler(activeDustBias);
+    }
+  };
+
+  ground.userData.refreshDistrictDustBiasTexture = refreshDistrictBiasTexture;
+  ground.userData.setDistrictDustBiasEnabled = (enabled) => {
+    material.userData.overlayBiasToggle = enabled ? 1 : 0;
+    updateOverlayUniforms(material);
+    material.needsUpdate = true;
+  };
+  ground.userData.isDistrictDustBiasEnabled = () => (material.userData.overlayBiasToggle ?? 1) !== 0;
+  ground.userData.setDistrictDustBiasSampler = setDistrictBiasSampler;
 
   if (scene && !scene.children.includes(ground)) {
     scene.add(ground);


### PR DESCRIPTION
## Summary
- add a districts rendering module that builds faint fill meshes, crisp outlines, change notifications, and visibility toggles for polygonal regions
- expose a HUD watcher that injects the current-district label and polls the player location to keep it in sync with the scene
- extend the ground shader to support district-biased dust blending with runtime toggles and integrate the new systems, HUD styling, mini-map markers, and keyboard shortcuts into index.html

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d350aafea08327a3374668c719bec1