### PR TITLE
Fix Tone.js loader syntax error

### DIFF
--- a/index.html
+++ b/index.html
@@ -455,6 +455,17 @@ import {
 } from './src/scene/districts.js';
 
 import { initDistrictHUD, watchPlayerPosition } from './src/scene/districts-hud.js';
+
+        const TONE_JS_URL = 'https://cdnjs.cloudflare.com/ajax/libs/tone/14.7.77/Tone.min.js';
+        let toneLoadingPromise = null;
+
+        async function loadToneLibrary() {
+            if (typeof window === 'undefined') {
+                return null;
+            }
+
+            if (window.Tone) {
+                return window.Tone;
             }
 
             if (!toneLoadingPromise) {


### PR DESCRIPTION
## Summary
- define the Tone.js loader helper in `index.html` to replace the stray closing brace that caused a syntax error
- ensure the loader safely returns an existing Tone instance and only appends the CDN script once

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d366e2b31c8327a9693d0668a43e79