### PR TITLE
Fix sky texture color space handling

### DIFF
--- a/src/scene/sky.js
+++ b/src/scene/sky.js
@@ -19,7 +19,11 @@ export function loadEquirectSky(renderer, scene, path, onDone) {
     path,
     (texture) => {
       texture.mapping = THREE.EquirectangularReflectionMapping;
-      texture.colorSpace = THREE.SRGBColorSpace;
+      if ('colorSpace' in texture && THREE.SRGBColorSpace) {
+        texture.colorSpace = THREE.SRGBColorSpace;
+      } else if ('encoding' in texture && THREE.sRGBEncoding) {
+        texture.encoding = THREE.sRGBEncoding;
+      }
 
       const pmrem = new THREE.PMREMGenerator(renderer);
       const envTarget = pmrem.fromEquirectangular(texture);


### PR DESCRIPTION
## Summary
- ensure equirectangular sky textures fall back to sRGBEncoding when colorSpace is unavailable
- keep generated environment maps consistent across Three.js versions

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d39592c9fc8327bc556ade67653115