### PR TITLE
Fix golden dawn sky preserving photo background

### DIFF
--- a/index.html
+++ b/index.html
@@ -1535,7 +1535,9 @@ import { initDistrictHUD, watchPlayerPosition } from './src/scene/districts-hud.
                 return;
             }
             currentEnvironmentMode = normalized;
-            setEnvironment(renderer, scene, normalized);
+            const hasPhotoSky = Boolean(photoSkydome || window.__AthensSky__);
+            const shouldPreserveBackground = hasPhotoSky && (normalized === 'sunset' || normalized === 'night');
+            setEnvironment(renderer, scene, normalized, { preserveBackground: shouldPreserveBackground });
         };
         
         const baseMapBounds = { xMin: -80, xMax: 80, zMin: -80, zMax: 80 };
@@ -4256,6 +4258,9 @@ function createBasicAgoraFallback() {
                 activeSkyController.setAmount(nextOpacity);
                 if (typeof skydomePreset?.yawDeg === 'number') {
                     activeSkyController.setYaw(skydomePreset.yawDeg);
+                }
+                if (scene && nextOpacity > 0) {
+                    scene.background = null;
                 }
             }
             __level = targetOpacity;


### PR DESCRIPTION
## Summary
- allow `setEnvironment` to skip updating the scene background so photographic sky textures can remain visible
- preserve the photo skydome background for sunset and night modes and clear the background once the skydome fades in

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d3928fabb88327922595d80a575b8a