### PR TITLE
Soften golden hour color balance

### DIFF
--- a/index.html
+++ b/index.html
@@ -681,7 +681,7 @@ import { initDistrictHUD, watchPlayerPosition } from './src/scene/districts-hud.
             'Golden Dawn': {
                 textureKey: 'golden-hour',
                 sources: goldenHourPhotoSources,
-                skydomeOpacity: 0.75,
+                skydomeOpacity: 0.6,
                 spaceNightAmount: 0.35
             },
             'Blue Hour': {
@@ -699,7 +699,7 @@ import { initDistrictHUD, watchPlayerPosition } from './src/scene/districts-hud.
             'Golden Dusk': {
                 textureKey: 'golden-hour',
                 sources: goldenHourPhotoSources,
-                skydomeOpacity: 0.78,
+                skydomeOpacity: 0.6,
                 spaceNightAmount: 0.45
             },
             'Starlit Night': {
@@ -4109,15 +4109,15 @@ function createBasicAgoraFallback() {
                     settings.elevation = 6;
                     settings.azimuth = 95;
                     settings.ambientIntensity = 0.26;
-                    settings.ambientColor = 0xffe5b0;
+                    settings.ambientColor = 0xffeecc;
                     settings.directionalIntensity = 0.65;
-                    settings.directionalColor = 0xffdfa3;
+                    settings.directionalColor = 0xffeac3;
                     settings.hemisphereIntensity = 0.32;
-                    settings.hemiSkyColor = 0xffc371;
-                    settings.hemiGroundColor = 0x8b4513;
+                    settings.hemiSkyColor = 0xffd8a3;
+                    settings.hemiGroundColor = 0xb48666;
                     settings.exposure = 0.94;
                     settings.bloomStrength = 0.28;
-                    settings.fogColor = 0xffd9b0;
+                    settings.fogColor = 0xffe6cc;
                     settings.skyTurbidity = 8.0;
                     settings.skyRayleigh = 2.2;
                     settings.skyMie = 0.0065;
@@ -4161,15 +4161,15 @@ function createBasicAgoraFallback() {
                     settings.elevation = 4;
                     settings.azimuth = 265;
                     settings.ambientIntensity = 0.24;
-                    settings.ambientColor = 0xffcba5;
+                    settings.ambientColor = 0xffddc4;
                     settings.directionalIntensity = 0.6;
-                    settings.directionalColor = 0xffa85a;
+                    settings.directionalColor = 0xffc694;
                     settings.hemisphereIntensity = 0.3;
-                    settings.hemiSkyColor = 0xff8c3f;
-                    settings.hemiGroundColor = 0x5a3928;
+                    settings.hemiSkyColor = 0xffb482;
+                    settings.hemiGroundColor = 0x947e73;
                     settings.exposure = 0.9;
                     settings.bloomStrength = 0.3;
-                    settings.fogColor = 0xffc7a1;
+                    settings.fogColor = 0xffdbc2;
                     settings.skyTurbidity = 9.0;
                     settings.skyRayleigh = 2.0;
                     settings.skyMie = 0.0065;


### PR DESCRIPTION
## Summary
- lower the golden dawn/dusk photo skydome opacity so the warm textures no longer overpower the scene
- retune golden hour lighting and fog colors to keep warmth without the heavy orange cast

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d3c88bd0488327867f8d570b77f61c