### PR TITLE
Fix sky asset fallback initialization

### DIFF
--- a/index.html
+++ b/index.html
@@ -569,11 +569,21 @@ import { initDistrictHUD, watchPlayerPosition } from './src/scene/districts-hud.
                 return relativePath;
             }
         };
+
+        // SAFETY: don't assume skyAssetLocations exists; fall back to bundled /src/sky files
+        const windowSkyAssetLocations = Array.isArray(window.skyAssetLocations) ? window.skyAssetLocations : [];
+
+        // If nothing is configured, use local defaults so the app still starts
+        const defaultSkyPrefixes = windowSkyAssetLocations.length
+            ? windowSkyAssetLocations
+            : [{ prefix: './src/sky/', label: 'bundled' }];
+
         const skyAssetLocations = [
-            { prefix: resolveAssetUrl('assets/sky/'), label: 'assets/sky' }
+            { prefix: resolveAssetUrl('assets/sky/'), label: 'assets/sky' },
+            ...defaultSkyPrefixes
         ];
 
-        const nightSkyCubeSources = (window.skyAssetLocations || [{ prefix: './src/sky/', label: 'bundled' }]).map(({ prefix, label }, index) => ({
+        const nightSkyCubeSources = defaultSkyPrefixes.map(({ prefix, label }, index) => ({
             url: resolveRelativeUrl(`${prefix}night_sky.jpg`),
             label: `night_sky.jpg (${label})`,
             isFallback: index > 0
@@ -712,27 +722,7 @@ import { initDistrictHUD, watchPlayerPosition } from './src/scene/districts-hud.
                 skydomeOpacity: 1.0,
                 spaceNightAmount: 1.0
             }
-    // SAFETY: don't assume skyAssetLocations exists; fall back to bundled /src/sky files
-const skyAssetLocationsSafe = Array.isArray(window.skyAssetLocations) ? window.skyAssetLocations : [];
-
-// if nothing configured, use local defaults so the app still starts
-const defaultSkyPrefixes = skyAssetLocationsSafe.length
-  ? skyAssetLocationsSafe
-  : [{ prefix: './src/sky/', label: 'bundled' }];
-
-const __DUPLICATE_nightSkyCubeSources = defaultSkyPrefixes.map(({ prefix, label }, index) => ({
-  label: `cube map (${label})`,
-  urls: [
-    resolveRelativeUrl(`${prefix}night_sky_right.jpg`),
-    resolveRelativeUrl(`${prefix}night_sky_left.jpg`),
-    resolveRelativeUrl(`${prefix}night_sky_top.jpg`),
-    resolveRelativeUrl(`${prefix}night_sky_bottom.jpg`),
-    resolveRelativeUrl(`${prefix}night_sky_front.jpg`),
-    resolveRelativeUrl(`${prefix}night_sky_back.jpg`)
-  ],
-  isFallback: index > 0
-}));
-
+        };
 
         let nightSkyTexture = null;
         let nightSkyCubeTexture = null;


### PR DESCRIPTION
## Summary
- make the sky asset setup resilient when `window.skyAssetLocations` is absent by deriving defaults up front
- include bundled prefixes in the generated sky asset list and reuse them for the cube map fallbacks
- remove the stray duplicate cube-map configuration block that was breaking the inline script

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d3e37d204c832786aa87be550cd593