### PR TITLE
Fix duplicate defaultSkyPrefixes declaration

### DIFF
--- a/index.html
+++ b/index.html
@@ -583,11 +583,6 @@ import { initDistrictHUD, watchPlayerPosition } from './src/scene/districts-hud.
             ...defaultSkyPrefixes
         ];
 
-        const nightSkyCubeSources = defaultSkyPrefixes.map(({ prefix, label }, index) => ({
-            url: resolveRelativeUrl(`${prefix}night_sky.jpg`),
-            label: `night_sky.jpg (${label})`,
-            isFallback: index > 0
-        }));
 
         const seenNightSkyTextureUrls = new Set();
         const nightSkyTextureSources = [];
@@ -782,29 +777,18 @@ import { initDistrictHUD, watchPlayerPosition } from './src/scene/districts-hud.
                 skydomeOpacity: 1.0,
                 spaceNightAmount: 1.0
             }};
-    // SAFETY: don't assume skyAssetLocations exists; fall back to bundled /src/sky files
-const skyAssetLocationsSafe =
-  (typeof window !== 'undefined' && Array.isArray(window.skyAssetLocations))
-    ? window.skyAssetLocations
-    : [];
-
-// if nothing configured, use local defaults so the app still starts
-const defaultSkyPrefixes = skyAssetLocationsSafe.length
-  ? skyAssetLocationsSafe
-  : [{ prefix: './src/sky/', label: 'bundled' }];
-
-const nightSkyCubeSources = defaultSkyPrefixes.map(({ prefix, label }, index) => ({
-  label: `cube map (${label})`,
-  urls: [
-    resolveRelativeUrl(`${prefix}night_sky_right.jpg`),
-    resolveRelativeUrl(`${prefix}night_sky_left.jpg`),
-    resolveRelativeUrl(`${prefix}night_sky_top.jpg`),
-    resolveRelativeUrl(`${prefix}night_sky_bottom.jpg`),
-    resolveRelativeUrl(`${prefix}night_sky_front.jpg`),
-    resolveRelativeUrl(`${prefix}night_sky_back.jpg`)
-  ],
-  isFallback: index > 0
-}));
+        const nightSkyCubeSources = defaultSkyPrefixes.map(({ prefix, label }, index) => ({
+            label: `cube map (${label})`,
+            urls: [
+                resolveRelativeUrl(`${prefix}night_sky_right.jpg`),
+                resolveRelativeUrl(`${prefix}night_sky_left.jpg`),
+                resolveRelativeUrl(`${prefix}night_sky_top.jpg`),
+                resolveRelativeUrl(`${prefix}night_sky_bottom.jpg`),
+                resolveRelativeUrl(`${prefix}night_sky_front.jpg`),
+                resolveRelativeUrl(`${prefix}night_sky_back.jpg`)
+            ],
+            isFallback: index > 0
+        }));
 
         let nightSkyTexture = null;
         let nightSkyCubeTexture = null;


### PR DESCRIPTION
## Summary
- remove the redundant cube source placeholder that redeclared `defaultSkyPrefixes`
- reuse the existing default sky prefix data when building cube map source URLs

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d3e7b4341c8327a69ca67b1f956872