### PR TITLE
Fix ground textures using available assets

### DIFF
--- a/src/ground/dirt.js
+++ b/src/ground/dirt.js
@@ -17,11 +17,9 @@ export function createDirtGround({
 
   const texLoader = new THREE.TextureLoader();
 
-  const color = texLoader.load(resolveAssetUrl('assets/textures/dirt/color.jpg'));
-  const rough  = texLoader.load(resolveAssetUrl('assets/textures/dirt/rough.jpg'));
-  const normal = texLoader.load(resolveAssetUrl('assets/textures/dirt/normal.jpg'));
+  const color = texLoader.load(resolveAssetUrl('assets/textures/athens_dust.jpg'));
 
-  [color, rough, normal].forEach(t => {
+  [color].forEach(t => {
     t.wrapS = t.wrapT = THREE.RepeatWrapping;
     t.repeat.set(repeat, repeat);
     t.anisotropy = Math.max(t.anisotropy || 0, anisotropy);
@@ -32,8 +30,6 @@ export function createDirtGround({
 
   const mat = new THREE.MeshStandardMaterial({
     map: color,
-    roughnessMap: rough,
-    normalMap: normal,
     roughness: 1.0,
   });
 

--- a/src/ground/grass.js
+++ b/src/ground/grass.js
@@ -17,11 +17,9 @@ export function createGrassGround({
 
   const texLoader = new THREE.TextureLoader();
 
-  const color = texLoader.load(resolveAssetUrl('assets/textures/grass/color.jpg'));
-  const rough  = texLoader.load(resolveAssetUrl('assets/textures/grass/rough.jpg'));
-  const normal = texLoader.load(resolveAssetUrl('assets/textures/grass/normal.jpg'));
+  const color = texLoader.load(resolveAssetUrl('assets/textures/grass.jpg'));
 
-  [color, rough, normal].forEach(t => {
+  [color].forEach(t => {
     t.wrapS = t.wrapT = THREE.RepeatWrapping;
     t.repeat.set(repeat, repeat);
     t.anisotropy = Math.max(t.anisotropy || 0, anisotropy);
@@ -32,8 +30,6 @@ export function createGrassGround({
 
   const mat = new THREE.MeshStandardMaterial({
     map: color,
-    roughnessMap: rough,
-    normalMap: normal,
     roughness: 0.9,
   });
 

--- a/src/scene/dirt.js
+++ b/src/scene/dirt.js
@@ -17,11 +17,9 @@ export function createDirtGround({
 
   const texLoader = new THREE.TextureLoader();
 
-  const color = texLoader.load(resolveAssetUrl('assets/textures/dirt/color.jpg'));
-  const rough  = texLoader.load(resolveAssetUrl('assets/textures/dirt/rough.jpg'));
-  const normal = texLoader.load(resolveAssetUrl('assets/textures/dirt/normal.jpg'));
+  const color = texLoader.load(resolveAssetUrl('assets/textures/athens_dust.jpg'));
 
-  [color, rough, normal].forEach(t => {
+  [color].forEach(t => {
     t.wrapS = t.wrapT = THREE.RepeatWrapping;
     t.repeat.set(repeat, repeat);
     t.anisotropy = Math.max(t.anisotropy || 0, anisotropy);
@@ -32,8 +30,6 @@ export function createDirtGround({
 
   const mat = new THREE.MeshStandardMaterial({
     map: color,
-    roughnessMap: rough,
-    normalMap: normal,
     roughness: 1.0,
   });
 

--- a/src/scene/grass.js
+++ b/src/scene/grass.js
@@ -17,11 +17,9 @@ export function createGrassGround({
 
   const texLoader = new THREE.TextureLoader();
 
-  const color = texLoader.load(resolveAssetUrl('assets/textures/grass/color.jpg'));
-  const rough  = texLoader.load(resolveAssetUrl('assets/textures/grass/rough.jpg'));
-  const normal = texLoader.load(resolveAssetUrl('assets/textures/grass/normal.jpg'));
+  const color = texLoader.load(resolveAssetUrl('assets/textures/grass.jpg'));
 
-  [color, rough, normal].forEach(t => {
+  [color].forEach(t => {
     t.wrapS = t.wrapT = THREE.RepeatWrapping;
     t.repeat.set(repeat, repeat);
     t.anisotropy = Math.max(t.anisotropy || 0, anisotropy);
@@ -32,8 +30,6 @@ export function createGrassGround({
 
   const mat = new THREE.MeshStandardMaterial({
     map: color,
-    roughnessMap: rough,
-    normalMap: normal,
     roughness: 0.9,
   });
 


### PR DESCRIPTION
## Summary
- point the grass and dirt ground helpers at the texture files that ship with the project
- remove references to missing roughness and normal maps so the meshes render again

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d3eccf56c4832790598c6d7eb80b87