### PR TITLE
Add placement planning pipeline for GeoJSON buildings

### DIFF
--- a/src/buildings-from-geojson.js
+++ b/src/buildings-from-geojson.js
@@ -4,6 +4,8 @@ import {
   makePropylon, makeBlock, makeAltar, makeExedra
 } from './building-kit.js';
 import { applyFeatureOffset } from './geo/featureOffsets.js';
+import { getDistrictAt, getDistricts } from './scene/districts.js';
+import DEFAULT_PLACEMENT_OPTIONS from './scene/placement-options.js';
 
 const deg = (d)=> THREE.MathUtils.degToRad(d);
 
@@ -135,65 +137,752 @@ for (const [key, value] of normalizedRegistryEntries) {
   }
 }
 
-/**
- * Build monuments from GeoJSON Points & Long Walls from LineStrings.
- * Expects features with `properties.name` (or `title`), optional `rotation_deg`.
- * If a name matches REGISTRY, we drop the corresponding building.
- * If a LineString has name including 'Long Wall' we build a wall path.
- */
-export async function buildFromGeoJSON({ scene, geoJsonUrl, projector }) {
+const radToDeg = (r) => THREE.MathUtils.radToDeg(r);
+const DEFAULT_PATH_SEARCH_RADIUS = 30;
+const DEFAULT_MAX_NUDGE_ATTEMPTS = 12;
+
+const ACROPOLIS_PRIORITY = [
+  'Parthenon',
+  'Erechtheion',
+  'Propylaea',
+  'Temple of Athena Nike'
+].map((label) => normalizeName(label));
+
+const AGORA_PRIORITY = [
+  'Stoa of Attalos',
+  'Bouleuterion',
+  'Tholos'
+].map((label) => normalizeName(label));
+
+const ACROPOLIS_PRIORITY_MAP = new Map(ACROPOLIS_PRIORITY.map((name, index) => [name, index]));
+const AGORA_PRIORITY_MAP = new Map(AGORA_PRIORITY.map((name, index) => [name, index]));
+
+let lastCollectionContext = null;
+
+function ensureContext() {
+  if (!lastCollectionContext) {
+    lastCollectionContext = {
+      namedPaths: [],
+      longWalls: [],
+      projector: null,
+      toWorld: null
+    };
+  }
+  return lastCollectionContext;
+}
+
+function cloneVector3(v) {
+  const out = new THREE.Vector3();
+  if (v && typeof v.x === 'number' && typeof v.y === 'number' && typeof v.z === 'number') {
+    out.set(v.x, v.y, v.z);
+  }
+  return out;
+}
+
+function createToWorld(projector) {
+  if (projector) {
+    return (lon, lat) => {
+      const projected = projector(lon, lat);
+      return cloneVector3(projected instanceof THREE.Vector3 ? projected : new THREE.Vector3(projected.x, projected.y, projected.z));
+    };
+  }
+  return (lon, lat) => new THREE.Vector3(lon * 1000, 0, -lat * 1000);
+}
+
+function isFiniteNumber(v) {
+  return Number.isFinite(v);
+}
+
+function getClearanceForKind(kind, map) {
+  if (!map) {
+    return 0;
+  }
+  if (isFiniteNumber(map[kind])) {
+    return Number(map[kind]);
+  }
+  if (isFiniteNumber(map.default)) {
+    return Number(map.default);
+  }
+  return 0;
+}
+
+function computeFootprint(candidate) {
+  const dims = candidate?.dims ?? {};
+  const kind = candidate?.kind ?? '';
+
+  const radius = (value, fallback = 0) => {
+    const r = Number(dims[value]);
+    if (Number.isFinite(r) && r > 0) return r;
+    return fallback;
+  };
+
+  const size = (value, fallback = 0) => {
+    const s = Number(dims[value]);
+    if (Number.isFinite(s) && s > 0) return s;
+    return fallback;
+  };
+
+  let width = 12;
+  let depth = 12;
+  let area = width * depth;
+  let axis = 'z';
+
+  switch (kind) {
+    case 'temple':
+      width = size('width', width);
+      depth = size('length', depth);
+      area = width * depth;
+      axis = depth >= width ? 'z' : 'x';
+      break;
+    case 'stoa':
+      width = size('depth', width);
+      depth = size('length', depth);
+      area = width * depth;
+      axis = depth >= width ? 'z' : 'x';
+      break;
+    case 'theatre': {
+      const r = radius('radius', 18);
+      width = depth = r * 2;
+      const openAngle = Number(dims.openAngleDeg);
+      const angleFactor = Number.isFinite(openAngle) ? Math.max(0, Math.min(360, openAngle)) / 360 : 0.5;
+      area = Math.PI * r * r * Math.max(0.5, angleFactor);
+      axis = 'z';
+      break;
+    }
+    case 'tholos': {
+      const r = radius('radius', 6);
+      width = depth = r * 2;
+      area = Math.PI * r * r;
+      axis = 'z';
+      break;
+    }
+    case 'propylon':
+      width = size('span', width);
+      depth = size('depth', depth);
+      area = width * depth;
+      axis = depth >= width ? 'z' : 'x';
+      break;
+    case 'altar':
+    case 'block':
+      width = size('width', width);
+      depth = size('depth', depth);
+      area = width * depth;
+      axis = depth >= width ? 'z' : 'x';
+      break;
+    case 'exedra': {
+      const r = radius('radius', 6);
+      width = depth = r * 2;
+      area = Math.PI * r * r * 0.5;
+      axis = 'z';
+      break;
+    }
+    default:
+      width = size('width', width) || size('span', width) || width;
+      depth = size('length', depth) || size('depth', depth) || depth;
+      area = width * depth;
+      axis = depth >= width ? 'z' : 'x';
+      break;
+  }
+
+  width = Math.max(width, 4);
+  depth = Math.max(depth, 4);
+
+  return { width, depth, area, longAxis: axis };
+}
+
+function computeAabb({ position, width, depth, rotationDeg, clearance = 0 }) {
+  const hw = width * 0.5 + clearance;
+  const hd = depth * 0.5 + clearance;
+  const angle = deg(rotationDeg);
+  const cos = Math.cos(angle);
+  const sin = Math.sin(angle);
+  const halfX = Math.abs(hw * cos) + Math.abs(hd * sin);
+  const halfZ = Math.abs(hw * sin) + Math.abs(hd * cos);
+
+  return {
+    minX: position.x - halfX,
+    maxX: position.x + halfX,
+    minZ: position.z - halfZ,
+    maxZ: position.z + halfZ
+  };
+}
+
+function aabbOverlap(a, b) {
+  return a.minX < b.maxX && a.maxX > b.minX && a.minZ < b.maxZ && a.maxZ > b.minZ;
+}
+
+function getGridRange(min, max, cellSize) {
+  const start = Math.floor(min / cellSize);
+  const end = Math.floor(max / cellSize);
+  return { start, end };
+}
+
+function forEachCell(aabb, cellSize, callback) {
+  const rangeX = getGridRange(aabb.minX, aabb.maxX, cellSize);
+  const rangeZ = getGridRange(aabb.minZ, aabb.maxZ, cellSize);
+  for (let ix = rangeX.start; ix <= rangeX.end; ix += 1) {
+    for (let iz = rangeZ.start; iz <= rangeZ.end; iz += 1) {
+      callback(ix, iz);
+    }
+  }
+}
+
+function getCellKey(ix, iz) {
+  return `${ix},${iz}`;
+}
+
+function collectCandidatesFromCells(grid, aabb, cellSize) {
+  const seen = new Set();
+  const candidates = [];
+  forEachCell(aabb, cellSize, (ix, iz) => {
+    const cellKey = getCellKey(ix, iz);
+    const cellEntries = grid.get(cellKey);
+    if (!cellEntries) return;
+    for (const entry of cellEntries) {
+      if (!seen.has(entry.index)) {
+        seen.add(entry.index);
+        candidates.push(entry);
+      }
+    }
+  });
+  return candidates;
+}
+
+function addPlacementToGrid(grid, index, aabb, cellSize) {
+  forEachCell(aabb, cellSize, (ix, iz) => {
+    const cellKey = getCellKey(ix, iz);
+    let cell = grid.get(cellKey);
+    if (!cell) {
+      cell = [];
+      grid.set(cellKey, cell);
+    }
+    cell.push({ index, aabb });
+  });
+}
+
+function length2D(dx, dz) {
+  return Math.hypot(dx, dz);
+}
+
+function shortestAngleDeltaDeg(fromDeg, toDeg) {
+  let delta = (toDeg - fromDeg) % 360;
+  if (delta > 180) delta -= 360;
+  if (delta < -180) delta += 360;
+  return delta;
+}
+
+function normalizeAngleDeg(angle) {
+  let a = angle % 360;
+  if (a < 0) a += 360;
+  return a;
+}
+
+function findNearestPathDirection(position, paths, maxDistance = DEFAULT_PATH_SEARCH_RADIUS) {
+  if (!Array.isArray(paths) || !paths.length) {
+    return null;
+  }
+
+  let best = null;
+
+  const checkSegment = (p0, p1, path) => {
+    const vx = p1.x - p0.x;
+    const vz = p1.z - p0.z;
+    const segmentLenSq = vx * vx + vz * vz;
+    if (segmentLenSq <= 1e-4) {
+      return;
+    }
+    const t = THREE.MathUtils.clamp(((position.x - p0.x) * vx + (position.z - p0.z) * vz) / segmentLenSq, 0, 1);
+    const projX = p0.x + vx * t;
+    const projZ = p0.z + vz * t;
+    const dx = position.x - projX;
+    const dz = position.z - projZ;
+    const dist = length2D(dx, dz);
+    if (dist > maxDistance) {
+      return;
+    }
+    if (best && dist >= best.distance) {
+      return;
+    }
+    const len = Math.sqrt(segmentLenSq);
+    best = {
+      distance: dist,
+      direction: { x: vx / len, z: vz / len },
+      path
+    };
+  };
+
+  for (const path of paths) {
+    const pts = Array.isArray(path?.points) ? path.points : [];
+    if (pts.length < 2) {
+      continue;
+    }
+    for (let i = 1; i < pts.length; i += 1) {
+      checkSegment(pts[i - 1], pts[i], path);
+    }
+    if (path.closed) {
+      checkSegment(pts[pts.length - 1], pts[0], path);
+    }
+  }
+
+  return best;
+}
+
+function computeBiasDirection(position, containingDistrict, districts) {
+  if (containingDistrict && containingDistrict.centroid) {
+    const dx = containingDistrict.centroid.x - position.x;
+    const dz = containingDistrict.centroid.z - position.z;
+    const len = length2D(dx, dz);
+    if (len > 1e-4) {
+      return { x: dx / len, z: dz / len, keepInside: true };
+    }
+  }
+
+  if (Array.isArray(districts) && districts.length) {
+    let nearest = null;
+    for (const district of districts) {
+      const cx = district.centroid?.x ?? 0;
+      const cz = district.centroid?.z ?? 0;
+      const dx = cx - position.x;
+      const dz = cz - position.z;
+      const dist = length2D(dx, dz);
+      if (!nearest || dist < nearest.dist) {
+        nearest = { dist, dx, dz };
+      }
+    }
+    if (nearest && nearest.dist > 1e-4) {
+      return { x: -nearest.dx / nearest.dist, z: -nearest.dz / nearest.dist, keepInside: false };
+    }
+  }
+
+  return null;
+}
+
+function generateOffsets(maxRadius, biasDir, maxAttempts = DEFAULT_MAX_NUDGE_ATTEMPTS) {
+  const offsets = [{ x: 0, z: 0, radius: 0 }];
+  if (maxAttempts <= 1 || maxRadius <= 0) {
+    return offsets.slice(0, maxAttempts);
+  }
+
+  const baseDirections = [
+    { x: 1, z: 0 },
+    { x: -1, z: 0 },
+    { x: 0, z: 1 },
+    { x: 0, z: -1 },
+    { x: 1, z: 1 },
+    { x: -1, z: 1 },
+    { x: 1, z: -1 },
+    { x: -1, z: -1 }
+  ];
+
+  const dirs = [];
+  if (biasDir) {
+    dirs.push({ x: biasDir.x, z: biasDir.z });
+    dirs.push({ x: -biasDir.x, z: -biasDir.z });
+  }
+  for (const dir of baseDirections) {
+    if (!dirs.some((existing) => Math.abs(existing.x - dir.x) < 1e-6 && Math.abs(existing.z - dir.z) < 1e-6)) {
+      dirs.push(dir);
+    }
+  }
+
+  const ringCount = Math.max(1, Math.ceil((maxAttempts - 1) / Math.max(1, dirs.length)));
+  for (let ring = 1; offsets.length < maxAttempts && ring <= ringCount; ring += 1) {
+    const radius = (maxRadius * ring) / ringCount;
+    for (const dir of dirs) {
+      const len = length2D(dir.x, dir.z);
+      if (len < 1e-4) continue;
+      offsets.push({ x: (dir.x / len) * radius, z: (dir.z / len) * radius, radius });
+      if (offsets.length >= maxAttempts) break;
+    }
+  }
+
+  return offsets.slice(0, maxAttempts);
+}
+
+function resolvePlacementOptions(userOptions = {}, contextNamedPaths = []) {
+  const defaults = DEFAULT_PLACEMENT_OPTIONS || {};
+  const minClearance = {
+    ...(defaults.minClearanceByKind || {}),
+    ...(userOptions.minClearanceByKind || {})
+  };
+  const namedPaths = Array.isArray(userOptions.namedPaths)
+    ? userOptions.namedPaths
+    : contextNamedPaths;
+  const collisionGeometry = userOptions.collisionGeometry
+    ?? defaults.collisionGeometry
+    ?? globalThis?.collisionGeometry
+    ?? null;
+
+  return {
+    ...defaults,
+    ...userOptions,
+    minClearanceByKind: minClearance,
+    namedPaths,
+    collisionGeometry
+  };
+}
+
+function prioritizeCandidates(candidates) {
+  const enriched = candidates.map((candidate, index) => {
+    const normalized = normalizeName(candidate.rawName || candidate.name || '');
+    const footprint = computeFootprint(candidate);
+    const priority = ACROPOLIS_PRIORITY_MAP.has(normalized)
+      ? { tier: 0, order: ACROPOLIS_PRIORITY_MAP.get(normalized) }
+      : AGORA_PRIORITY_MAP.has(normalized)
+        ? { tier: 1, order: AGORA_PRIORITY_MAP.get(normalized) }
+        : { tier: 2, order: -footprint.area };
+    return { candidate, normalized, footprint, priority, index };
+  });
+
+  enriched.sort((a, b) => {
+    if (a.priority.tier !== b.priority.tier) {
+      return a.priority.tier - b.priority.tier;
+    }
+    if (a.priority.tier <= 1) {
+      if (a.priority.order !== b.priority.order) {
+        return a.priority.order - b.priority.order;
+      }
+      return a.index - b.index;
+    }
+    if (a.priority.order !== b.priority.order) {
+      return b.priority.order - a.priority.order;
+    }
+    return a.index - b.index;
+  });
+
+  return enriched;
+}
+
+function buildPlacement(candidate, position, rotationDeg) {
+  return {
+    name: candidate.rawName || candidate.name,
+    meshKind: candidate.kind,
+    dims: candidate.dims,
+    position,
+    rotationY: deg(rotationDeg)
+  };
+}
+
+function extractLinePoints(coordinates, toWorld) {
+  return coordinates.map(([lon, lat]) => {
+    const v = toWorld(lon, lat);
+    return new THREE.Vector3(v.x, v.y, v.z);
+  });
+}
+
+function extractPathPoints(coordinates, toWorld) {
+  return coordinates.map(([lon, lat]) => {
+    const v = toWorld(lon, lat);
+    return { x: v.x, z: v.z };
+  });
+}
+
+export async function collectCandidatesFromGeo({ geoJsonUrl, projector }) {
+  if (!geoJsonUrl) {
+    throw new Error('collectCandidatesFromGeo requires a geoJsonUrl');
+  }
+
   const res = await fetch(geoJsonUrl);
-  if (!res.ok) throw new Error(`Failed to load ${geoJsonUrl}`);
+  if (!res.ok) {
+    throw new Error(`Failed to load ${geoJsonUrl}`);
+  }
   const geo = await res.json();
 
-  const root = new THREE.Group(); root.name = 'Buildings';
-  scene.add(root);
+  const context = ensureContext();
+  context.projector = projector || null;
+  context.toWorld = createToWorld(projector);
+  context.namedPaths = [];
+  context.longWalls = [];
 
-  const toWorld = (lon, lat) => projector ? projector(lon, lat) : new THREE.Vector3(lon * 1000, 0, -lat * 1000);
+  const candidates = [];
 
-  for (const f of geo.features ?? []) {
-    const props = f.properties ?? {};
-    const rawName = props.title || props.name || '';
-    const name = normalizeName(rawName);
-    const cfgDirect = REGISTRY[rawName] || REGISTRY[name];
-    const rotDeg = props.rotation_deg ?? cfgDirect?.defaultRotationDeg ?? 0;
+  for (const feature of geo.features ?? []) {
+    const geometry = feature.geometry;
+    if (!geometry) continue;
 
-    if (f.geometry?.type === 'Point') {
-      const [lon, lat] = applyFeatureOffset(
-        f.geometry.coordinates,
-        { properties: props, fallbackName: rawName }
-      );
-      const pos = toWorld(lon, lat);
+    const properties = feature.properties ?? {};
+    const rawName = properties.title || properties.name || '';
+    const normalized = normalizeName(rawName);
+    const registryEntry = REGISTRY[rawName] || REGISTRY[normalized];
 
-      const cfg = cfgDirect;
-      if (!cfg) continue; // unknown names are skipped for buildings (but still in pins/labels)
+    if (geometry.type === 'Point') {
+      const cfg = registryEntry;
+      if (!cfg) {
+        continue;
+      }
+      const [lon, lat] = applyFeatureOffset(geometry.coordinates, { properties, fallbackName: rawName });
+      const pos = context.toWorld(lon, lat);
+      const rotationExplicit = isFiniteNumber(properties.rotation_deg);
+      const baseRotation = rotationExplicit ? Number(properties.rotation_deg) : (cfg.defaultRotationDeg ?? 0);
 
-      let mesh;
-      if (cfg.kind === 'temple')        mesh = makeTemple(cfg.dims);
-      else if (cfg.kind === 'stoa')     mesh = makeStoa(cfg.dims);
-      else if (cfg.kind === 'theatre')  mesh = makeTheatre(cfg.dims);
-      else if (cfg.kind === 'tholos')   mesh = makeTholos(cfg.dims);
-      else if (cfg.kind === 'propylon') mesh = makePropylon(cfg.dims);
-      else if (cfg.kind === 'block')    mesh = makeBlock(cfg.dims);
-      else if (cfg.kind === 'altar')    mesh = makeAltar(cfg.dims);
-      else if (cfg.kind === 'exedra')   mesh = makeExedra(cfg.dims);
+      candidates.push({
+        name: rawName || normalized,
+        rawName,
+        kind: cfg.kind,
+        dims: { ...cfg.dims },
+        worldPos: pos,
+        rotDeg: baseRotation,
+        defaultRotDeg: cfg.defaultRotationDeg ?? baseRotation,
+        rotationLocked: rotationExplicit,
+        normalizedName: normalized
+      });
+    } else if (geometry.type === 'LineString' || geometry.type === 'MultiLineString') {
+      const coordinateSets = geometry.type === 'MultiLineString' ? geometry.coordinates : [geometry.coordinates];
+      const isLongWall = /long wall|phaler|piraeus/i.test(normalized) || /long wall|phaler|piraeus/i.test(rawName) || properties.kind === 'wall_corridor';
+      for (const coordinates of coordinateSets) {
+        if (!Array.isArray(coordinates) || coordinates.length < 2) {
+          continue;
+        }
+        if (isLongWall) {
+          context.longWalls.push(extractLinePoints(coordinates, context.toWorld));
+        } else {
+          context.namedPaths.push({
+            name: rawName || properties.name || 'Path',
+            points: extractPathPoints(coordinates, context.toWorld),
+            closed: false
+          });
+        }
+      }
+    } else if (geometry.type === 'Polygon' || geometry.type === 'MultiPolygon') {
+      const polygonSets = geometry.type === 'MultiPolygon' ? geometry.coordinates : [geometry.coordinates];
+      const isCityWall = properties.kind === 'city_wall';
+      for (const polygon of polygonSets) {
+        if (!Array.isArray(polygon) || !polygon.length) {
+          continue;
+        }
+        const outer = polygon[0];
+        if (!isCityWall && Array.isArray(outer) && outer.length >= 3) {
+          context.namedPaths.push({
+            name: rawName || properties.name || 'Path Area',
+            points: extractPathPoints(outer, context.toWorld),
+            closed: true
+          });
+        }
+      }
+    }
+  }
 
-      mesh.position.copy(pos);
-      mesh.rotation.y = deg(rotDeg);
-      mesh.traverse(o => (o.castShadow = o.receiveShadow = true));
-      mesh.userData.monument = rawName || name;
+  return candidates;
+}
 
-      root.add(mesh);
+export function planPlacements(candidates, placementOptions = {}) {
+  const context = ensureContext();
+  const options = resolvePlacementOptions(placementOptions, context.namedPaths);
+  const prioritized = prioritizeCandidates(candidates);
+  const districts = options.snapToDistricts ? getDistricts() : [];
+  const collisionGeometry = options.collisionGeometry;
+  const maxAdjustRadius = Number.isFinite(options.maxAdjustRadius) ? Math.max(0, options.maxAdjustRadius) : DEFAULT_PLACEMENT_OPTIONS.maxAdjustRadius ?? 12;
+  const maxRotationAdjustDeg = Number.isFinite(options.maxRotationAdjustDeg) ? Math.max(0, options.maxRotationAdjustDeg) : 0;
+  const maxAttempts = Number.isInteger(options.maxNudgeAttempts) ? Math.max(1, options.maxNudgeAttempts) : DEFAULT_MAX_NUDGE_ATTEMPTS;
+
+  const placements = [];
+  const placementAabbs = [];
+  const grid = new Map();
+  let maxSpan = 0;
+
+  for (const item of prioritized) {
+    const clearance = getClearanceForKind(item.candidate.kind, options.minClearanceByKind);
+    const span = Math.max(item.footprint.width, item.footprint.depth) + clearance * 2;
+    if (span > maxSpan) {
+      maxSpan = span;
+    }
+  }
+
+  const baseCellSize = Number.isFinite(options.gridCellSize) ? options.gridCellSize : DEFAULT_PLACEMENT_OPTIONS.gridCellSize ?? 25;
+  const cellSize = Math.max(baseCellSize, maxSpan || baseCellSize);
+
+  const stats = {
+    total: prioritized.length,
+    placed: 0,
+    movedCount: 0,
+    maxMoveDistance: 0,
+    skippedOverlap: 0,
+    pathAligned: 0,
+    exceededAdjustRadius: []
+  };
+
+  for (const item of prioritized) {
+    const candidate = item.candidate;
+    const basePosition = candidate.worldPos.clone();
+    let rotationDeg = candidate.rotDeg ?? candidate.defaultRotDeg ?? 0;
+
+    if (options.alignToPaths && !candidate.rotationLocked) {
+      const nearestPath = findNearestPathDirection(basePosition, options.namedPaths, DEFAULT_PATH_SEARCH_RADIUS);
+      if (nearestPath) {
+        const axis = item.footprint.longAxis;
+        let pathAngle;
+        if (axis === 'x') {
+          pathAngle = radToDeg(Math.atan2(-nearestPath.direction.z, nearestPath.direction.x));
+        } else {
+          pathAngle = radToDeg(Math.atan2(nearestPath.direction.x, nearestPath.direction.z));
+        }
+        pathAngle = normalizeAngleDeg(pathAngle);
+        const baseAngle = normalizeAngleDeg(candidate.defaultRotDeg ?? rotationDeg);
+        let delta = shortestAngleDeltaDeg(baseAngle, pathAngle);
+        if (maxRotationAdjustDeg > 0 && Math.abs(delta) > maxRotationAdjustDeg) {
+          delta = Math.sign(delta) * maxRotationAdjustDeg;
+        }
+        rotationDeg = normalizeAngleDeg(baseAngle + delta);
+        if (Math.abs(delta) > 1e-3) {
+          stats.pathAligned += 1;
+        }
+      }
     }
 
-    // Long Walls (LineStrings) → wall modules
-    if (f.geometry?.type === 'LineString') {
-      const isLongWall = /long wall|phaler|piraeus/i.test(name);
-      if (!isLongWall) continue;
+    const clearance = getClearanceForKind(candidate.kind, options.minClearanceByKind);
+    const containingDistrict = options.snapToDistricts ? getDistrictAt(basePosition.x, basePosition.z) : null;
+    const biasDir = computeBiasDirection(basePosition, containingDistrict, districts);
+    const offsets = generateOffsets(maxAdjustRadius, biasDir, maxAttempts);
 
-      const pts = f.geometry.coordinates.map(([lon, lat]) => toWorld(lon, lat));
-      const wall = makeWallPath(pts, { segment: 10, height: 4, width: 2.5 });
-      root.add(wall);
+    let acceptedPlacement = null;
+    for (const offset of offsets) {
+      const testPosition = new THREE.Vector3(basePosition.x + offset.x, basePosition.y, basePosition.z + offset.z);
+      if (options.snapToDistricts) {
+        if (containingDistrict) {
+          const districtHere = getDistrictAt(testPosition.x, testPosition.z);
+          if (!districtHere || districtHere.id !== containingDistrict.id) {
+            continue;
+          }
+        } else {
+          const districtHere = getDistrictAt(testPosition.x, testPosition.z);
+          if (districtHere) {
+            continue;
+          }
+        }
+      }
+
+      if (collisionGeometry && typeof collisionGeometry.isWalkable === 'function') {
+        if (!collisionGeometry.isWalkable(testPosition.x, testPosition.z)) {
+          continue;
+        }
+      }
+
+      const aabb = computeAabb({
+        position: testPosition,
+        width: item.footprint.width,
+        depth: item.footprint.depth,
+        rotationDeg,
+        clearance
+      });
+
+      const conflicts = collectCandidatesFromCells(grid, aabb, cellSize);
+      let intersects = false;
+      for (const existing of conflicts) {
+        if (aabbOverlap(aabb, existing.aabb)) {
+          intersects = true;
+          break;
+        }
+      }
+      if (intersects) {
+        continue;
+      }
+
+      acceptedPlacement = {
+        position: testPosition,
+        aabb,
+        distance: length2D(offset.x, offset.z)
+      };
+      break;
+    }
+
+    if (!acceptedPlacement) {
+      stats.skippedOverlap += 1;
+      if (maxAdjustRadius > 0) {
+        stats.exceededAdjustRadius.push(candidate.rawName || candidate.name);
+      }
+      continue;
+    }
+
+    const placement = buildPlacement(candidate, acceptedPlacement.position, rotationDeg);
+    placements.push(placement);
+    placementAabbs.push(acceptedPlacement.aabb);
+    addPlacementToGrid(grid, placementAabbs.length - 1, acceptedPlacement.aabb, cellSize);
+    stats.placed += 1;
+    if (acceptedPlacement.distance > 1e-3) {
+      stats.movedCount += 1;
+      if (acceptedPlacement.distance > stats.maxMoveDistance) {
+        stats.maxMoveDistance = acceptedPlacement.distance;
+      }
+    }
+  }
+
+  planPlacements.lastReport = {
+    ...stats,
+    cellSize
+  };
+
+  return placements;
+}
+
+export function instantiateMeshes(placements, scene) {
+  if (!scene) {
+    throw new Error('instantiateMeshes requires a scene');
+  }
+
+  const context = ensureContext();
+  const existing = scene.getObjectByName('Buildings');
+  if (existing) {
+    scene.remove(existing);
+  }
+
+  const root = new THREE.Group();
+  root.name = 'Buildings';
+  scene.add(root);
+
+  for (const placement of placements) {
+    let mesh = null;
+    if (placement.meshKind === 'temple')        mesh = makeTemple(placement.dims);
+    else if (placement.meshKind === 'stoa')     mesh = makeStoa(placement.dims);
+    else if (placement.meshKind === 'theatre')  mesh = makeTheatre(placement.dims);
+    else if (placement.meshKind === 'tholos')   mesh = makeTholos(placement.dims);
+    else if (placement.meshKind === 'propylon') mesh = makePropylon(placement.dims);
+    else if (placement.meshKind === 'block')    mesh = makeBlock(placement.dims);
+    else if (placement.meshKind === 'altar')    mesh = makeAltar(placement.dims);
+    else if (placement.meshKind === 'exedra')   mesh = makeExedra(placement.dims);
+
+    if (!mesh) {
+      continue;
+    }
+
+    mesh.position.copy(placement.position);
+    mesh.rotation.y = placement.rotationY;
+    mesh.traverse((o) => { o.castShadow = o.receiveShadow = true; });
+    mesh.userData.monument = placement.name;
+    root.add(mesh);
+  }
+
+  for (const points of context.longWalls ?? []) {
+    if (!Array.isArray(points) || points.length < 2) {
+      continue;
+    }
+    const wall = makeWallPath(points, { segment: 10, height: 4, width: 2.5 });
+    root.add(wall);
+  }
+
+  return root;
+}
+
+export async function buildFromGeoJSON({ scene, geoJsonUrl, projector, placementOptions } = {}) {
+  const candidates = await collectCandidatesFromGeo({ geoJsonUrl, projector });
+  const placements = planPlacements(candidates, placementOptions);
+  const root = instantiateMeshes(placements, scene);
+
+  const report = planPlacements.lastReport;
+  if (report && (placementOptions?.logReport ?? DEFAULT_PLACEMENT_OPTIONS.logReport ?? true)) {
+    const movedInfo = report.movedCount
+      ? `${report.movedCount} moved (max ${report.maxMoveDistance.toFixed(1)}m)`
+      : 'no moves';
+    const skippedInfo = report.skippedOverlap
+      ? `${report.skippedOverlap} skipped`
+      : 'none skipped';
+    const alignedInfo = report.pathAligned
+      ? `${report.pathAligned} aligned to paths`
+      : 'no path aligns';
+    console.info(
+      `[buildings] placed ${report.placed}/${report.total} (${movedInfo}); overlaps: ${skippedInfo}; ${alignedInfo}.`
+    );
+    if (report.exceededAdjustRadius?.length) {
+      console.info('[buildings] placement radius exceeded for:', report.exceededAdjustRadius.join(', '));
     }
   }
 

--- a/src/scene/placement-options.js
+++ b/src/scene/placement-options.js
@@ -1,0 +1,21 @@
+const DEFAULT_PLACEMENT_OPTIONS = {
+  minClearanceByKind: {
+    temple: 12,
+    stoa: 10,
+    theatre: 16,
+    tholos: 8,
+    propylon: 6,
+    altar: 4,
+    block: 3,
+    exedra: 4
+  },
+  gridCellSize: 25,
+  maxAdjustRadius: 12,
+  maxRotationAdjustDeg: 20,
+  alignToPaths: true,
+  snapToDistricts: true,
+  logReport: true
+};
+
+export default DEFAULT_PLACEMENT_OPTIONS;
+export { DEFAULT_PLACEMENT_OPTIONS };


### PR DESCRIPTION
## Summary
- refactor the GeoJSON building loader into explicit collection, placement planning, and instantiation stages
- introduce grid-based placement planning with district, path alignment, and walkability heuristics plus reporting
- add a shared placement options module to hold default clearances and behavior flags

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d3ef7df9b08327966c0640ea708e30