### PR TITLE
Expand ground coverage with tiled grass and dust

### DIFF
--- a/src/ground/dirt.js
+++ b/src/ground/dirt.js
@@ -1,6 +1,38 @@
 import * as THREE from 'three';
 import { resolveAssetUrl } from '../utils/asset-paths.js';
 
+const textureLoader = new THREE.TextureLoader();
+let cachedBaseTexture = null;
+
+function loadBaseTexture() {
+  if (!cachedBaseTexture) {
+    cachedBaseTexture = textureLoader.load(resolveAssetUrl('assets/textures/athens_dust.jpg'));
+
+    if ('SRGBColorSpace' in THREE) cachedBaseTexture.colorSpace = THREE.SRGBColorSpace;
+    else if ('sRGBEncoding' in THREE) cachedBaseTexture.encoding = THREE.sRGBEncoding;
+  }
+  return cachedBaseTexture;
+}
+
+function configureTexture(baseTexture, { repeat, anisotropy }) {
+  const texture = baseTexture.clone();
+  texture.needsUpdate = true;
+  texture.wrapS = texture.wrapT = THREE.RepeatWrapping;
+
+  if (typeof repeat === 'number') {
+    texture.repeat.set(repeat, repeat);
+  }
+
+  if (typeof anisotropy === 'number') {
+    texture.anisotropy = Math.max(texture.anisotropy || 0, anisotropy);
+  }
+
+  if ('SRGBColorSpace' in THREE) texture.colorSpace = THREE.SRGBColorSpace;
+  else if ('sRGBEncoding' in THREE) texture.encoding = THREE.sRGBEncoding;
+
+  return texture;
+}
+
 export function createDirtGround({
   size = 200,
   repeat = 16,
@@ -15,18 +47,7 @@ export function createDirtGround({
   geo.rotateX(-Math.PI / 2);
   geo.translate(0, height, 0);
 
-  const texLoader = new THREE.TextureLoader();
-
-  const color = texLoader.load(resolveAssetUrl('assets/textures/athens_dust.jpg'));
-
-  [color].forEach(t => {
-    t.wrapS = t.wrapT = THREE.RepeatWrapping;
-    t.repeat.set(repeat, repeat);
-    t.anisotropy = Math.max(t.anisotropy || 0, anisotropy);
-  });
-
-  if ('SRGBColorSpace' in THREE) color.colorSpace = THREE.SRGBColorSpace;
-  else if ('sRGBEncoding' in THREE) color.encoding = THREE.sRGBEncoding;
+  const color = configureTexture(loadBaseTexture(), { repeat, anisotropy });
 
   const mat = new THREE.MeshStandardMaterial({
     map: color,

--- a/src/ground/index.js
+++ b/src/ground/index.js
@@ -11,6 +11,150 @@ export const GroundType = Object.freeze({
   GRASS: 'grass',
 });
 
+const DEFAULT_TILE_GRID = Object.freeze({ columns: 5, rows: 5 });
+
+function toVector3(position) {
+  if (position instanceof THREE.Vector3) {
+    return position.clone();
+  }
+
+  if (Array.isArray(position)) {
+    const [x = 0, y = 0, z = 0] = position;
+    return new THREE.Vector3(x, y, z);
+  }
+
+  const source = position && typeof position === 'object' ? position : {};
+  const { x = 0, y = 0, z = 0 } = source;
+  return new THREE.Vector3(x, y, z);
+}
+
+function parseSpacing(spacing) {
+  if (typeof spacing === 'number') {
+    return { x: spacing, z: spacing };
+  }
+
+  if (spacing && typeof spacing === 'object') {
+    const { x = 0, z = 0 } = spacing;
+    return {
+      x: typeof x === 'number' ? x : 0,
+      z: typeof z === 'number' ? z : 0,
+    };
+  }
+
+  return { x: 0, z: 0 };
+}
+
+function createGridTiles({
+  grid,
+  size,
+  repeat,
+  spacing,
+}) {
+  const columns = Math.max(1, Math.floor(grid?.columns ?? grid?.x ?? 1));
+  const rows = Math.max(1, Math.floor(grid?.rows ?? grid?.z ?? 1));
+  const { x: spacingX, z: spacingZ } = parseSpacing(spacing);
+
+  const tiles = [];
+  const stepX = size + spacingX;
+  const stepZ = size + spacingZ;
+  const offsetX = ((columns - 1) * stepX) / 2;
+  const offsetZ = ((rows - 1) * stepZ) / 2;
+
+  for (let row = 0; row < rows; row += 1) {
+    for (let col = 0; col < columns; col += 1) {
+      const x = col * stepX - offsetX;
+      const z = row * stepZ - offsetZ;
+
+      tiles.push({
+        size,
+        repeat,
+        position: new THREE.Vector3(x, 0, z),
+        enableDirt: true,
+        enableGrass: true,
+      });
+    }
+  }
+
+  return tiles;
+}
+
+function normalizeTile(tile, { defaultSize, defaultRepeat }) {
+  if (!tile || typeof tile !== 'object') {
+    return {
+      size: defaultSize,
+      repeat: defaultRepeat,
+      position: new THREE.Vector3(),
+      enableDirt: true,
+      enableGrass: true,
+    };
+  }
+
+  const {
+    size = defaultSize,
+    repeat = defaultRepeat,
+    position,
+    x,
+    y,
+    z,
+    enableDirt,
+    enableGrass,
+    dirt,
+    grass,
+    dirtOptions,
+    grassOptions,
+    dirtName,
+    grassName,
+    name,
+  } = tile;
+
+  const vectorPosition = position ? toVector3(position) : toVector3({ x, y, z });
+
+  return {
+    size,
+    repeat,
+    position: vectorPosition,
+    enableDirt: enableDirt ?? (dirt !== false),
+    enableGrass: enableGrass ?? (grass !== false),
+    dirtOptions: dirtOptions && typeof dirtOptions === 'object' ? { ...dirtOptions } : undefined,
+    grassOptions: grassOptions && typeof grassOptions === 'object' ? { ...grassOptions } : undefined,
+    dirtName: dirtName ?? (name ? `${name}:dirt` : undefined),
+    grassName: grassName ?? (name ? `${name}:grass` : undefined),
+  };
+}
+
+function buildTileDefinitions({
+  tiles,
+  tileGrid,
+  tileSize,
+  tileRepeat,
+  tileSpacing,
+  defaultSize,
+  defaultRepeat,
+}) {
+  const effectiveSize = typeof tileSize === 'number' ? tileSize : defaultSize;
+  const effectiveRepeat = typeof tileRepeat === 'number' ? tileRepeat : defaultRepeat;
+
+  let definitions = [];
+
+  if (Array.isArray(tiles) && tiles.length > 0) {
+    definitions = tiles.map(t => normalizeTile(t, { defaultSize: effectiveSize, defaultRepeat: effectiveRepeat }));
+  } else {
+    const gridTiles = createGridTiles({
+      grid: tileGrid ?? DEFAULT_TILE_GRID,
+      size: effectiveSize,
+      repeat: effectiveRepeat,
+      spacing: tileSpacing,
+    });
+    definitions = gridTiles.map(t => normalizeTile(t, { defaultSize: effectiveSize, defaultRepeat: effectiveRepeat }));
+  }
+
+  if (definitions.length === 0) {
+    definitions.push(normalizeTile({}, { defaultSize, defaultRepeat }));
+  }
+
+  return definitions;
+}
+
 /**
  * Builds a layered ground group containing separate dirt and grass groups.
  * You can toggle visibility on each layer independently.
@@ -20,6 +164,11 @@ export const GroundType = Object.freeze({
  * @param {Object} [options.grassOptions] - Options passed to createGrassGround
  * @param {boolean} [options.showDirt=true]
  * @param {boolean} [options.showGrass=true]
+ * @param {Object[]} [options.tiles]      - Explicit tile definitions. If omitted a grid will be generated.
+ * @param {{ columns?: number, rows?: number }} [options.tileGrid] - Grid size when generating tiles. Defaults to 5x5.
+ * @param {number} [options.tileSize]     - Base tile size (used for generated tiles and as fallback for explicit tiles).
+ * @param {number} [options.tileRepeat]   - Base texture repeat for generated tiles.
+ * @param {number|{x?:number,z?:number}} [options.tileSpacing=0] - Gap/overlap between generated tiles.
  * @returns {{ root: THREE.Group, dirt: THREE.Group, grass: THREE.Group }}
  */
 export function createGroundLayered({
@@ -27,18 +176,74 @@ export function createGroundLayered({
   grassOptions = {},
   showDirt = true,
   showGrass = true,
+  tiles,
+  tileGrid,
+  tileSize,
+  tileRepeat,
+  tileSpacing = 0,
 } = {}) {
   const root = new THREE.Group();
   root.name = 'ground:root';
 
-  const dirt = createDirtGround(dirtOptions);
-  const grass = createGrassGround(grassOptions);
+  const dirtLayer = new THREE.Group();
+  dirtLayer.name = 'ground:dirt';
 
-  dirt.visible = !!showDirt;
-  grass.visible = !!showGrass;
+  const grassLayer = new THREE.Group();
+  grassLayer.name = 'ground:grass';
 
-  root.add(dirt);
-  root.add(grass);
+  root.add(dirtLayer);
+  root.add(grassLayer);
 
-  return { root, dirt, grass };
+  const defaultSize =
+    (typeof tileSize === 'number' && tileSize > 0) ? tileSize :
+    (typeof grassOptions.size === 'number' ? grassOptions.size : dirtOptions.size);
+
+  const resolvedDefaultSize = typeof defaultSize === 'number' ? defaultSize : 200;
+
+  const defaultRepeat =
+    (typeof tileRepeat === 'number' && tileRepeat > 0) ? tileRepeat :
+    (typeof grassOptions.repeat === 'number' ? grassOptions.repeat : dirtOptions.repeat);
+
+  const resolvedDefaultRepeat = typeof defaultRepeat === 'number' ? defaultRepeat : 16;
+
+  const tileDefinitions = buildTileDefinitions({
+    tiles,
+    tileGrid,
+    tileSize: resolvedDefaultSize,
+    tileRepeat: resolvedDefaultRepeat,
+    tileSpacing,
+    defaultSize: resolvedDefaultSize,
+    defaultRepeat: resolvedDefaultRepeat,
+  });
+
+  tileDefinitions.forEach((tile, index) => {
+    if (tile.enableDirt) {
+      const dirt = createDirtGround({
+        ...dirtOptions,
+        ...(tile.dirtOptions ?? {}),
+        size: tile.dirtOptions?.size ?? tile.size ?? dirtOptions.size ?? resolvedDefaultSize,
+        repeat: tile.dirtOptions?.repeat ?? tile.repeat ?? dirtOptions.repeat ?? resolvedDefaultRepeat,
+      });
+      dirt.name = tile.dirtName ?? `ground:dirt:tile:${index}`;
+      dirt.position.copy(tile.position);
+      dirtLayer.add(dirt);
+    }
+
+    if (tile.enableGrass) {
+      const grass = createGrassGround({
+        ...grassOptions,
+        ...(tile.grassOptions ?? {}),
+        size: tile.grassOptions?.size ?? tile.size ?? grassOptions.size ?? resolvedDefaultSize,
+        repeat: tile.grassOptions?.repeat ?? tile.repeat ?? grassOptions.repeat ?? resolvedDefaultRepeat,
+      });
+      grass.name = tile.grassName ?? `ground:grass:tile:${index}`;
+      grass.position.copy(tile.position);
+      grassLayer.add(grass);
+    }
+  });
+
+  dirtLayer.visible = !!showDirt;
+  grassLayer.visible = !!showGrass;
+
+  return { root, dirt: dirtLayer, grass: grassLayer };
 }

--- a/src/scene/ground.js
+++ b/src/scene/ground.js
@@ -8,11 +8,16 @@ export async function loadGround(scene, renderer, options = {}) {
     size = 400,
     repeat = 32,
     showDirt = true,
-    showGrass = false,
+    showGrass = true,
 
     // allow detailed overrides
     dirtOptions = {},
     grassOptions = {},
+    tiles,
+    tileGrid,
+    tileSize = size,
+    tileRepeat = repeat,
+    tileSpacing = 0,
   } = options;
 
   const ground = createGroundLayered({
@@ -20,6 +25,11 @@ export async function loadGround(scene, renderer, options = {}) {
     grassOptions:{ size, repeat, height: 0.02, ...grassOptions },
     showDirt,
     showGrass,
+    tiles,
+    tileGrid,
+    tileSize,
+    tileRepeat,
+    tileSpacing,
   });
 
   if (scene) scene.add(ground.root);


### PR DESCRIPTION
## Summary
- generate layered dirt and grass ground as a configurable grid of tiles so the entire play space is covered
- reuse cached dust and grass textures for each tile to avoid redundant loads when tiling
- enable grass by default and plumb tile configuration options through the scene ground loader

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d3ef09a6848327bdd175123fa831ff