### PR TITLE
Brighten High Noon sky tones

### DIFF
--- a/index.html
+++ b/index.html
@@ -4279,18 +4279,18 @@ function createBasicAgoraFallback() {
                     settings.elevation = 72;
                     settings.azimuth = 180;
                     settings.ambientIntensity = 0.36;
-                    settings.ambientColor = 0xfef7eb;
+                    settings.ambientColor = 0xe4f2ff;
                     settings.directionalIntensity = 1.05;
                     settings.directionalColor = 0xffffff;
-                    settings.hemisphereIntensity = 0.55;
-                    settings.hemiSkyColor = 0x8fc7ff;
+                    settings.hemisphereIntensity = 0.6;
+                    settings.hemiSkyColor = 0x4fb5ff;
                     settings.hemiGroundColor = 0xc5a572;
                     settings.exposure = 1.0;
                     settings.bloomStrength = 0.18;
-                    settings.fogColor = 0xcfe8ff;
-                    settings.skyTurbidity = 3.5;
-                    settings.skyRayleigh = 1.3;
-                    settings.skyMie = 0.002;
+                    settings.fogColor = 0xaad8ff;
+                    settings.skyTurbidity = 2.6;
+                    settings.skyRayleigh = 1.9;
+                    settings.skyMie = 0.0015;
                     break;
                 case 'Golden Dusk':
                     settings.elevation = 4;


### PR DESCRIPTION
## Summary
- retune the High Noon sky lighting to use a cooler ambient tint and brighter azure hemisphere color
- reduce haze parameters so the midday sky renders with a more saturated blue tone

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d3f3e5d7888327b6e98f5b0c274c99