### PR TITLE
Brighten and scale citizen NPCs

### DIFF
--- a/index.html
+++ b/index.html
@@ -1601,7 +1601,7 @@ import { initDistrictHUD, watchPlayerPosition } from './src/scene/districts-hud.
                         baseModel.updateMatrixWorld(true);
                         const bounds = new THREE.Box3().setFromObject(baseModel);
                         const height = Math.max(0.001, bounds.max.y - bounds.min.y);
-                        const targetHeight = 2.0;
+                        const targetHeight = 2.4;
                         const scaleFactor = targetHeight / height;
                         const pivotOffset = -bounds.min.y * scaleFactor;
 
@@ -5019,19 +5019,61 @@ world.addBody(archBody);
         }
 
         // --- NPC AND INTERACTIVE OBJECTS ---
-        
+
+        function brightenNPCMaterial(material, lightenAmount = 0.25, emissiveBoost = 0.25) {
+            const targetColor = new THREE.Color(0xffffff);
+            const applyEnhancements = (mat) => {
+                if (!mat) return;
+
+                if (mat.color && mat.color.isColor) {
+                    mat.color = mat.color.clone();
+                    mat.color.lerp(targetColor, lightenAmount);
+                }
+
+                if (Array.isArray(mat)) {
+                    mat.forEach(applyEnhancements);
+                    return;
+                }
+
+                if (mat.isMeshStandardMaterial) {
+                    if (!mat.emissive || !mat.emissive.isColor) {
+                        mat.emissive = new THREE.Color(0x000000);
+                    } else {
+                        mat.emissive = mat.emissive.clone();
+                    }
+                    mat.emissive.lerp(targetColor, emissiveBoost * 0.5);
+                    mat.emissiveIntensity = Math.max(mat.emissiveIntensity || 0, emissiveBoost);
+                    mat.envMapIntensity = Math.max(mat.envMapIntensity || 0, 1.0);
+                    if (typeof mat.roughness === 'number') {
+                        mat.roughness = Math.max(0, mat.roughness - 0.2);
+                    }
+                }
+
+                mat.needsUpdate = true;
+            };
+
+            if (Array.isArray(material)) {
+                material.forEach(applyEnhancements);
+            } else {
+                applyEnhancements(material);
+            }
+        }
+
         function createCitizenModel(tunicColor, type = 'citizen') {
-            const citizenGroup = new THREE.Group();
-            const skinMaterial = createEnhancedMaterial(0xad6452, 0.8, 0.1);
-            const tunicMaterial = createEnhancedMaterial(tunicColor, 0.9, 0.1);
-            const hairMaterial = createEnhancedMaterial(0x333333, 0.9, 0.1);
+            const citizenBody = new THREE.Group();
+            const skinMaterial = createEnhancedMaterial(0xad6452, 0.7, 0.1);
+            brightenNPCMaterial(skinMaterial, 0.28, 0.3);
+            const tunicMaterial = createEnhancedMaterial(tunicColor, 0.8, 0.1);
+            brightenNPCMaterial(tunicMaterial, 0.3, 0.32);
+            const hairMaterial = createEnhancedMaterial(0x333333, 0.8, 0.1);
+            brightenNPCMaterial(hairMaterial, 0.2, 0.25);
 
             // Head
             const head = new THREE.Mesh(new THREE.SphereGeometry(0.25, 16, 12), skinMaterial);
-            head.position.y = 1.6;
+            head.position.y = 1.7;
             head.name = "head";
-            citizenGroup.add(head);
-            
+            citizenBody.add(head);
+
             // Nose
             const noseGeo = new THREE.CylinderGeometry(0.02, 0.05, 0.1, 8);
             const nose = new THREE.Mesh(noseGeo, skinMaterial);
@@ -5039,84 +5081,103 @@ world.addBody(archBody);
             nose.position.y = -0.05;
             head.add(nose);
 
-
             // Simple Hair
             const hair = new THREE.Mesh(new THREE.SphereGeometry(0.26, 16, 12, 0, Math.PI * 2, 0, Math.PI / 1.8), hairMaterial);
             hair.position.y = 0.05;
             head.add(hair);
 
             // Eyes
-            const eyeMaterial = new THREE.MeshBasicMaterial({color: 0x111111});
+            const eyeMaterial = new THREE.MeshBasicMaterial({ color: 0x222222 });
             const eyeL = new THREE.Mesh(new THREE.SphereGeometry(0.04, 8, 8), eyeMaterial);
-            eyeL.position.set(-0.1, 0.05, 0.23);
+            eyeL.position.set(-0.1, 0.06, 0.23);
             head.add(eyeL);
             const eyeR = eyeL.clone();
             eyeR.position.x = 0.1;
             head.add(eyeR);
 
             // Torso
-            const torsoGeo = new THREE.CylinderGeometry(0.3, 0.35, 1.0, 12);
+            const torsoGeo = new THREE.CylinderGeometry(0.32, 0.37, 1.1, 12);
             const torso = new THREE.Mesh(torsoGeo, tunicMaterial);
-            torso.position.y = 1.0;
-            citizenGroup.add(torso);
-            
+            torso.position.y = 1.05;
+            citizenBody.add(torso);
+
             // Limbs
-            const limbGeo = new THREE.CylinderGeometry(0.08, 0.06, 0.55, 8);
-            limbGeo.translate(0, -0.275, 0); // Pivot at top
+            const limbGeo = new THREE.CylinderGeometry(0.08, 0.06, 0.6, 8);
+            limbGeo.translate(0, -0.3, 0); // Pivot at top
 
             // Left Arm
             const armL = new THREE.Mesh(limbGeo, skinMaterial);
-            armL.position.set(-0.35, 1.45, 0);
+            armL.position.set(-0.38, 1.48, 0);
             armL.name = "armL";
-            citizenGroup.add(armL);
+            citizenBody.add(armL);
 
             // Right Arm
             const armR = armL.clone();
-            armR.position.x = 0.35;
+            armR.position.x = 0.38;
             armR.name = "armR";
-            citizenGroup.add(armR);
+            citizenBody.add(armR);
 
             // Legs
-            const legGeo = new THREE.CylinderGeometry(0.1, 0.08, 0.5, 8);
-            legGeo.translate(0, -0.25, 0);
+            const legGeo = new THREE.CylinderGeometry(0.1, 0.08, 0.55, 8);
+            legGeo.translate(0, -0.275, 0);
 
             const legL = new THREE.Mesh(legGeo, skinMaterial);
-            legL.position.set(-0.15, 0.5, 0);
+            legL.position.set(-0.16, 0.55, 0);
             legL.name = "legL";
-            citizenGroup.add(legL);
+            citizenBody.add(legL);
 
             const legR = legL.clone();
-            legR.position.x = 0.15;
+            legR.position.x = 0.16;
             legR.name = "legR";
-            citizenGroup.add(legR);
-            
+            citizenBody.add(legR);
+
             // Feet
-            const footGeo = new THREE.BoxGeometry(0.15, 0.1, 0.25);
-            const footL = new THREE.Mesh(footGeo, createEnhancedMaterial(0x5C4033, 0.9, 0.1));
-            footL.position.y = -0.25;
-            footL.position.z = 0.05;
+            const footGeo = new THREE.BoxGeometry(0.17, 0.1, 0.27);
+            const sandalMaterial = createEnhancedMaterial(0x5C4033, 0.8, 0.1);
+            brightenNPCMaterial(sandalMaterial, 0.25, 0.28);
+            const footL = new THREE.Mesh(footGeo, sandalMaterial);
+            footL.position.y = -0.27;
+            footL.position.z = 0.06;
             legL.add(footL);
 
             const footR = footL.clone();
             legR.add(footR);
 
-            if(type === 'scribe'){
+            if (type === 'scribe') {
                 const scrollMat = createEnhancedMaterial(0xF5DEB3, 0.7, 0.1);
+                brightenNPCMaterial(scrollMat, 0.25, 0.25);
                 const scrollGeo = new THREE.CylinderGeometry(0.05, 0.05, 0.4, 8);
                 const scroll = new THREE.Mesh(scrollGeo, scrollMat);
                 scroll.rotation.z = Math.PI / 2;
                 scroll.position.y = -0.2;
                 armR.add(scroll);
             }
-            
-            citizenGroup.traverse(child => {
-                if(child.isMesh) {
+
+            citizenBody.traverse((child) => {
+                if (child.isMesh) {
                     child.castShadow = true;
                     child.receiveShadow = true;
                 }
             });
 
-            return citizenGroup;
+            const citizenScale = 1.2;
+            citizenBody.scale.setScalar(citizenScale);
+            citizenBody.updateMatrixWorld(true);
+
+            const citizenBounds = new THREE.Box3().setFromObject(citizenBody);
+            const baseYOffset = -citizenBounds.min.y;
+
+            const citizenRoot = new THREE.Group();
+            citizenRoot.name = type === 'scribe' ? 'Citizen NPC (Scribe)' : 'Citizen NPC (Procedural)';
+            citizenRoot.userData = {
+                ...(citizenRoot.userData || {}),
+                source: 'procedural_citizen',
+                baseYOffset
+            };
+
+            citizenRoot.add(citizenBody);
+
+            return citizenRoot;
         }
 
         function getRandomPointInZone(zone) {
@@ -5151,7 +5212,9 @@ world.addBody(archBody);
             ];
 
             const registerCitizen = (model, zone, spawnPosition) => {
+                const baseYOffset = model.userData?.baseYOffset ?? 0;
                 model.position.copy(spawnPosition);
+                model.position.y += baseYOffset;
                 model.rotation.y = Math.random() * Math.PI * 2;
 
                 const limbs = {
@@ -5164,7 +5227,7 @@ world.addBody(archBody);
                 const npc = {
                     model,
                     zone,
-                    baseY: spawnPosition.y,
+                    baseY: spawnPosition.y + baseYOffset,
                     speed: Math.random() * 0.6 + 0.8,
                     state: Math.random() < 0.6 ? 'walking' : 'idle',
                     walkTimer: 0,
@@ -5212,7 +5275,8 @@ world.addBody(archBody);
                             citizenRoot.userData = {
                                 ...(citizenRoot.userData || {}),
                                 tunicColor: color,
-                                source: 'npc_athenian.glb'
+                                source: 'npc_athenian.glb',
+                                baseYOffset: 0
                             };
 
                             const clone = SkeletonUtils?.clone
@@ -5224,8 +5288,18 @@ world.addBody(archBody);
                                 child.castShadow = true;
                                 child.receiveShadow = true;
                                 if (child.material) {
-                                    child.material = child.material.clone();
-                                    child.material.needsUpdate = true;
+                                    if (Array.isArray(child.material)) {
+                                        child.material = child.material.map((mat) => {
+                                            const clonedMaterial = mat?.clone ? mat.clone() : mat;
+                                            brightenNPCMaterial(clonedMaterial, 0.3, 0.35);
+                                            return clonedMaterial;
+                                        });
+                                    } else if (child.material.clone) {
+                                        child.material = child.material.clone();
+                                        brightenNPCMaterial(child.material, 0.3, 0.35);
+                                    } else {
+                                        brightenNPCMaterial(child.material, 0.3, 0.35);
+                                    }
                                 }
                             });
 


### PR DESCRIPTION
## Summary
- add a shared helper to boost citizen NPC material brightness and emissive response
- brighten both procedural and GLB-loaded citizen models while enlarging their proportions and updating placement offsets
- raise the default GLB target height to keep imported citizens roughly 20% taller than before

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d469689bcc83279cf9d3f80e400d29