### PR TITLE
Fix ground texture clones missing images

### DIFF
--- a/src/ground/dirt.js
+++ b/src/ground/dirt.js
@@ -11,9 +11,13 @@ function ensureColorSpace(texture) {
   else if ('sRGBEncoding' in THREE) texture.encoding = THREE.sRGBEncoding;
 }
 
-function flushPendingTextureUpdates() {
+function flushPendingTextureUpdates(baseTexture) {
   if (pendingTextureUpdates.size === 0) return;
+  const sourceImage = baseTexture?.image;
   pendingTextureUpdates.forEach((texture) => {
+    if (sourceImage && !texture.image) {
+      texture.image = sourceImage;
+    }
     texture.needsUpdate = true;
   });
   pendingTextureUpdates.clear();
@@ -25,19 +29,22 @@ function loadBaseTexture() {
       resolveAssetUrl('assets/textures/athens_dust.jpg'),
       (texture) => {
         ensureColorSpace(texture);
-        flushPendingTextureUpdates();
+        flushPendingTextureUpdates(texture);
       }
     );
 
     ensureColorSpace(cachedBaseTexture);
   } else if (cachedBaseTexture.image) {
-    flushPendingTextureUpdates();
+    flushPendingTextureUpdates(cachedBaseTexture);
   }
   return cachedBaseTexture;
 }
 
 function configureTexture(baseTexture, { repeat, anisotropy }) {
   const texture = baseTexture.clone();
+  if (baseTexture?.image) {
+    texture.image = baseTexture.image;
+  }
   texture.wrapS = texture.wrapT = THREE.RepeatWrapping;
 
   if (typeof repeat === 'number') {

--- a/src/ground/grass.js
+++ b/src/ground/grass.js
@@ -11,9 +11,13 @@ function ensureColorSpace(texture) {
   else if ('sRGBEncoding' in THREE) texture.encoding = THREE.sRGBEncoding;
 }
 
-function flushPendingTextureUpdates() {
+function flushPendingTextureUpdates(baseTexture) {
   if (pendingTextureUpdates.size === 0) return;
+  const sourceImage = baseTexture?.image;
   pendingTextureUpdates.forEach((texture) => {
+    if (sourceImage && !texture.image) {
+      texture.image = sourceImage;
+    }
     texture.needsUpdate = true;
   });
   pendingTextureUpdates.clear();
@@ -25,19 +29,22 @@ function loadBaseTexture() {
       resolveAssetUrl('assets/textures/grass.jpg'),
       (texture) => {
         ensureColorSpace(texture);
-        flushPendingTextureUpdates();
+        flushPendingTextureUpdates(texture);
       }
     );
 
     ensureColorSpace(cachedBaseTexture);
   } else if (cachedBaseTexture.image) {
-    flushPendingTextureUpdates();
+    flushPendingTextureUpdates(cachedBaseTexture);
   }
   return cachedBaseTexture;
 }
 
 function configureTexture(baseTexture, { repeat, anisotropy }) {
   const texture = baseTexture.clone();
+  if (baseTexture?.image) {
+    texture.image = baseTexture.image;
+  }
   texture.wrapS = texture.wrapT = THREE.RepeatWrapping;
 
   if (typeof repeat === 'number') {


### PR DESCRIPTION
## Summary
- ensure cloned ground textures copy the loaded base image before rendering
- update deferred texture flush to hydrate waiting clones when the base asset finishes loading
- keep grass and dirt materials responsive by marking textures dirty once images are available

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68d474614d5483279add821efe2a65bf