### PR TITLE
Fix ground fallbacks and expose debug helper

### DIFF
--- a/src/ground/dirt.js
+++ b/src/ground/dirt.js
@@ -87,6 +87,11 @@ export function createDirtGround({
     roughness: 1.0,
   });
 
+  if (!mat.map) {
+    mat.color.set(0x6b5a45);
+    mat.needsUpdate = true;
+  }
+
   mat.polygonOffset = true;
   mat.polygonOffsetFactor = 1;
   mat.polygonOffsetUnits = 1;

--- a/src/ground/grass.js
+++ b/src/ground/grass.js
@@ -88,6 +88,11 @@ export function createGrassGround({
     roughness: 0.9,
   });
 
+  if (!mat.map) {
+    mat.color.set(0x4a7f39);
+    mat.needsUpdate = true;
+  }
+
   const mesh = new THREE.Mesh(geo, mat);
   mesh.receiveShadow = receiveShadow;
   mesh.renderOrder = 1;

--- a/src/scene/ground.js
+++ b/src/scene/ground.js
@@ -25,9 +25,13 @@ function hideLegacyGroundPlanes(scene, layeredGroundRoot) {
   });
 }
 
-function ensureWindowGroundAccessor() {
+function ensureWindowGroundAccessor(groundLayers) {
   if (typeof window === 'undefined') return;
-  window.getGround = () => __groundSingleton;
+  window.getGround = () => groundLayers;
+  window.showGround = () => {
+    if (groundLayers?.dirt) groundLayers.dirt.visible = true;
+    if (groundLayers?.grass) groundLayers.grass.visible = true;
+  };
 }
 
 // Signature stays the same as your current code expects.
@@ -86,7 +90,7 @@ export async function loadGround(scene, renderer, options = {}) {
   }
 
   hideLegacyGroundPlanes(scene, __groundSingleton?.root);
-  ensureWindowGroundAccessor();
+  ensureWindowGroundAccessor(__groundSingleton);
 
   return __groundSingleton;
 }

--- a/src/utils/asset-paths.js
+++ b/src/utils/asset-paths.js
@@ -71,7 +71,7 @@ const envBase =
 const moduleBase = computeModuleBase();
 const locationBase = computeLocationBase();
 
-const inferredBase = envBase ?? moduleBase ?? locationBase ?? '/';
+const inferredBase = envBase ?? locationBase ?? moduleBase ?? '/';
 
 const ASSET_BASE = ensureTrailingSlash(inferredBase);
 


### PR DESCRIPTION
## Summary
- add fallback colors to dirt and grass materials when textures are unavailable
- prefer inferred asset base from location before module base
- expose a window.showGround helper alongside existing debug accessor

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d4a19113d48327989937b49e160aa6