### PR TITLE
fix: update Tone.js CDN URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -514,7 +514,7 @@ import { initDistrictHUD, watchPlayerPosition } from './src/scene/districts-hud.
 
         const TONE_JS_SOURCES = [
             resolveAssetUrl('assets/vendor/Tone.js'),
-            'https://cdnjs.cloudflare.com/ajax/libs/tone/14.7.77/Tone.min.js'
+            'https://cdnjs.cloudflare.com/ajax/libs/tone/14.8.49/Tone.min.js'
         ];
         let toneLoadingPromise = null;
 


### PR DESCRIPTION
## Summary
- update the fallback Tone.js CDN URL in `index.html` to the latest working release

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d4a4c656fc83278c6979ace73ab7e7