### PR TITLE
Fix Tone.js loader to use working CDN

### DIFF
--- a/index.html
+++ b/index.html
@@ -513,8 +513,7 @@ import {
 import { initDistrictHUD, watchPlayerPosition } from './src/scene/districts-hud.js';
 
         const TONE_JS_SOURCES = [
-            resolveAssetUrl('assets/vendor/Tone.js'),
-            'https://cdnjs.cloudflare.com/ajax/libs/tone/14.7.77/Tone.min.js'
+            'https://cdnjs.cloudflare.com/ajax/libs/tone/14.8.49/Tone.min.js'
         ];
         let toneLoadingPromise = null;
 


### PR DESCRIPTION
## Summary
- update the Tone.js loader source list to use a single, valid CDN URL

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d4a549542483278623a1db044f902d