### PR TITLE
Fix Tone.js source configuration

### DIFF
--- a/index.html
+++ b/index.html
@@ -513,7 +513,6 @@ import {
 import { initDistrictHUD, watchPlayerPosition } from './src/scene/districts-hud.js';
 
         const TONE_JS_SOURCES = [
-            resolveAssetUrl('assets/vendor/Tone.js'),
             'https://cdnjs.cloudflare.com/ajax/libs/tone/14.8.49/Tone.min.js'
         ];
         let toneLoadingPromise = null;


### PR DESCRIPTION
## Summary
- remove reference to a missing local Tone.js vendor file
- load Tone.js exclusively from the working 14.8.49 CDN release

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d4a63f16088327a8b8e4d268631ca8