### PR TITLE
Use inline favicon data URI

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <title>Ancient Athens - Visual Masterpiece</title>
+<link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='6' ry='6' fill='%23333'/%3E%3Ctext x='16' y='22' font-size='18' text-anchor='middle' fill='%23fff' font-family='Cinzel, serif'%3EA%3C/text%3E%3C/svg%3E">
 <!-- Physics library -->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/cannon.js/0.6.2/cannon.min.js"></script>
 <script type="importmap">


### PR DESCRIPTION
## Summary
- remove the standalone favicon asset that introduced a binary file
- inline a simple SVG favicon via a data URI in index.html to avoid 404s without bundling binaries

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d4b353b1548327ba9aa920a3eec718