### PR TITLE
Set default ground coverage to grass

### DIFF
--- a/src/ground/index.js
+++ b/src/ground/index.js
@@ -69,7 +69,7 @@ function createGridTiles({
         size,
         repeat,
         position: new THREE.Vector3(x, 0, z),
-        enableDirt: true,
+        enableDirt: false,
         enableGrass: true,
       });
     }
@@ -84,7 +84,7 @@ function normalizeTile(tile, { defaultSize, defaultRepeat }) {
       size: defaultSize,
       repeat: defaultRepeat,
       position: new THREE.Vector3(),
-      enableDirt: true,
+      enableDirt: false,
       enableGrass: true,
     };
   }
@@ -113,7 +113,7 @@ function normalizeTile(tile, { defaultSize, defaultRepeat }) {
     size,
     repeat,
     position: vectorPosition,
-    enableDirt: enableDirt ?? (dirt !== false),
+    enableDirt: enableDirt ?? (dirt === true),
     enableGrass: enableGrass ?? (grass !== false),
     dirtOptions: dirtOptions && typeof dirtOptions === 'object' ? { ...dirtOptions } : undefined,
     grassOptions: grassOptions && typeof grassOptions === 'object' ? { ...grassOptions } : undefined,

--- a/src/scene/ground.js
+++ b/src/scene/ground.js
@@ -56,7 +56,7 @@ export async function loadGround(scene, renderer, options = {}) {
   const hasShowDirtOverride = Object.prototype.hasOwnProperty.call(options, 'showDirt');
   const hasShowGrassOverride = Object.prototype.hasOwnProperty.call(options, 'showGrass');
 
-  const initialShowDirt = hasShowDirtOverride ? !!showDirt : true;
+  const initialShowDirt = hasShowDirtOverride ? !!showDirt : false;
   const initialShowGrass = hasShowGrassOverride ? !!showGrass : true;
 
   if (!__groundSingleton) {


### PR DESCRIPTION
## Summary
- disable dirt generation for auto-created ground tiles so only the grass texture renders
- default the ground loader to hide the dirt layer unless explicitly requested

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d4bbb7cdbc832785044b42414bacdd