### PR TITLE
Fix grass ground visibility

### DIFF
--- a/src/ground/grass.js
+++ b/src/ground/grass.js
@@ -86,6 +86,7 @@ export function createGrassGround({
   const mat = new THREE.MeshStandardMaterial({
     map: color,
     roughness: 0.9,
+    side: THREE.DoubleSide,
   });
 
   if (!mat.map) {


### PR DESCRIPTION
## Summary
- ensure the grass ground mesh renders from both sides to prevent transparency issues

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d4bd69f84083278057d870631262ce