### PR TITLE
Ensure all ground layers render from both sides

### DIFF
--- a/src/ground/dirt.js
+++ b/src/ground/dirt.js
@@ -85,6 +85,7 @@ export function createDirtGround({
   const mat = new THREE.MeshStandardMaterial({
     map: color,
     roughness: 1.0,
+    side: THREE.DoubleSide,
   });
 
   if (!mat.map) {
@@ -92,6 +93,7 @@ export function createDirtGround({
     mat.needsUpdate = true;
   }
 
+  mat.shadowSide = THREE.DoubleSide;
   mat.polygonOffset = true;
   mat.polygonOffsetFactor = 1;
   mat.polygonOffsetUnits = 1;

--- a/src/ground/grass.js
+++ b/src/ground/grass.js
@@ -86,6 +86,7 @@ export function createGrassGround({
   const mat = new THREE.MeshStandardMaterial({
     map: color,
     roughness: 0.9,
+    side: THREE.DoubleSide,
   });
 
   if (!mat.map) {
@@ -93,6 +94,7 @@ export function createGrassGround({
     mat.needsUpdate = true;
   }
 
+  mat.shadowSide = THREE.DoubleSide;
   const mesh = new THREE.Mesh(geo, mat);
   mesh.receiveShadow = receiveShadow;
   mesh.renderOrder = 1;


### PR DESCRIPTION
## Summary
- update the dirt ground material to render on both sides and accept shadows from either direction
- extend the grass material configuration so shadow maps honor both faces as well

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d4bd69f84083278057d870631262ce