### PR TITLE
Ensure ground meshes stay visible from every angle

### DIFF
--- a/src/ground/dirt.js
+++ b/src/ground/dirt.js
@@ -1,5 +1,6 @@
 import * as THREE from 'three';
 import { resolveAssetUrl } from '../utils/asset-paths.js';
+import { applyDoubleSidedGroundSupport } from './double-sided.js';
 
 const textureLoader = new THREE.TextureLoader();
 let cachedBaseTexture = null;
@@ -97,6 +98,7 @@ export function createDirtGround({
   mat.polygonOffsetUnits = 1;
 
   const mesh = new THREE.Mesh(geo, mat);
+  applyDoubleSidedGroundSupport(mesh);
   mesh.receiveShadow = receiveShadow;
 
   group.add(mesh);

--- a/src/ground/double-sided.js
+++ b/src/ground/double-sided.js
@@ -1,0 +1,57 @@
+import * as THREE from 'three';
+
+function applyDoubleSideToMaterial(material) {
+  if (!material || typeof material !== 'object') return;
+
+  material.side = THREE.DoubleSide;
+  if ('shadowSide' in material) {
+    material.shadowSide = THREE.DoubleSide;
+  }
+  material.needsUpdate = true;
+}
+
+function ensureCustomDepthMaterial(mesh) {
+  if (!mesh) return;
+
+  if (mesh.customDepthMaterial && mesh.customDepthMaterial.isMaterial) {
+    mesh.customDepthMaterial.side = THREE.DoubleSide;
+    mesh.customDepthMaterial.needsUpdate = true;
+    return;
+  }
+
+  mesh.customDepthMaterial = new THREE.MeshDepthMaterial({
+    depthPacking: THREE.RGBADepthPacking,
+    side: THREE.DoubleSide,
+  });
+}
+
+function ensureCustomDistanceMaterial(mesh) {
+  if (!mesh) return;
+
+  const DistanceMaterial = THREE.MeshDistanceMaterial;
+  if (typeof DistanceMaterial !== 'function') {
+    return;
+  }
+
+  if (mesh.customDistanceMaterial && mesh.customDistanceMaterial.isMaterial) {
+    mesh.customDistanceMaterial.side = THREE.DoubleSide;
+    mesh.customDistanceMaterial.needsUpdate = true;
+    return;
+  }
+
+  mesh.customDistanceMaterial = new DistanceMaterial({
+    side: THREE.DoubleSide,
+  });
+}
+
+export function applyDoubleSidedGroundSupport(mesh) {
+  if (!mesh || !mesh.isMesh) return;
+
+  const materials = Array.isArray(mesh.material) ? mesh.material : [mesh.material];
+  materials.forEach(applyDoubleSideToMaterial);
+
+  ensureCustomDepthMaterial(mesh);
+  ensureCustomDistanceMaterial(mesh);
+
+  mesh.frustumCulled = false;
+}

--- a/src/ground/grass.js
+++ b/src/ground/grass.js
@@ -1,5 +1,6 @@
 import * as THREE from 'three';
 import { resolveAssetUrl } from '../utils/asset-paths.js';
+import { applyDoubleSidedGroundSupport } from './double-sided.js';
 
 const textureLoader = new THREE.TextureLoader();
 let cachedBaseTexture = null;
@@ -94,6 +95,7 @@ export function createGrassGround({
   }
 
   const mesh = new THREE.Mesh(geo, mat);
+  applyDoubleSidedGroundSupport(mesh);
   mesh.receiveShadow = receiveShadow;
   mesh.renderOrder = 1;
 


### PR DESCRIPTION
## Summary
- add a helper that forces ground meshes to render and cast shadows from both sides while disabling frustum culling
- apply the helper to the dirt and grass layers so they remain visible even when viewed from below or through shadow passes

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d4bd69f84083278057d870631262ce