### PR TITLE
Ensure dirt ground layer visible by default

### DIFF
--- a/src/ground/index.js
+++ b/src/ground/index.js
@@ -69,7 +69,7 @@ function createGridTiles({
         size,
         repeat,
         position: new THREE.Vector3(x, 0, z),
-        enableDirt: false,
+        enableDirt: true,
         enableGrass: true,
       });
     }
@@ -84,7 +84,7 @@ function normalizeTile(tile, { defaultSize, defaultRepeat }) {
       size: defaultSize,
       repeat: defaultRepeat,
       position: new THREE.Vector3(),
-      enableDirt: false,
+      enableDirt: true,
       enableGrass: true,
     };
   }
@@ -113,7 +113,7 @@ function normalizeTile(tile, { defaultSize, defaultRepeat }) {
     size,
     repeat,
     position: vectorPosition,
-    enableDirt: enableDirt ?? (dirt === true),
+    enableDirt: enableDirt ?? (dirt !== false),
     enableGrass: enableGrass ?? (grass !== false),
     dirtOptions: dirtOptions && typeof dirtOptions === 'object' ? { ...dirtOptions } : undefined,
     grassOptions: grassOptions && typeof grassOptions === 'object' ? { ...grassOptions } : undefined,

--- a/src/scene/ground.js
+++ b/src/scene/ground.js
@@ -56,7 +56,7 @@ export async function loadGround(scene, renderer, options = {}) {
   const hasShowDirtOverride = Object.prototype.hasOwnProperty.call(options, 'showDirt');
   const hasShowGrassOverride = Object.prototype.hasOwnProperty.call(options, 'showGrass');
 
-  const initialShowDirt = hasShowDirtOverride ? !!showDirt : false;
+  const initialShowDirt = hasShowDirtOverride ? !!showDirt : true;
   const initialShowGrass = hasShowGrassOverride ? !!showGrass : true;
 
   if (!__groundSingleton) {


### PR DESCRIPTION
## Summary
- include dirt meshes when generating default ground tiles so the base layer is always present
- default the ground loader to show the dirt layer when no override is provided

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d4dcdfaa0c8327ab9a46b690b1236a