### PR TITLE
Ensure ground materials stay opaque

### DIFF
--- a/src/ground/dirt.js
+++ b/src/ground/dirt.js
@@ -87,7 +87,12 @@ export function createDirtGround({
     map: color,
     roughness: 1.0,
     side: THREE.DoubleSide,
+    transparent: false,
   });
+
+  mat.opacity = 1;
+  mat.depthWrite = true;
+  mat.colorWrite = true;
 
   if (!mat.map) {
     mat.color.set(0x6b5a45);

--- a/src/ground/grass.js
+++ b/src/ground/grass.js
@@ -88,7 +88,12 @@ export function createGrassGround({
     map: color,
     roughness: 0.9,
     side: THREE.DoubleSide,
+    transparent: false,
   });
+
+  mat.opacity = 1;
+  mat.depthWrite = true;
+  mat.colorWrite = true;
 
   if (!mat.map) {
     mat.color.set(0x4a7f39);


### PR DESCRIPTION
## Summary
- prevent the new dirt and grass materials from being treated as transparent by explicitly disabling transparency
- force the ground materials to continue writing depth and color buffers so the surface renders solidly

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d4dd363c548327840e475c734927f8