### PR TITLE
Fix sky dome material ordering

### DIFF
--- a/index.html
+++ b/index.html
@@ -4394,6 +4394,13 @@ function createBasicAgoraFallback() {
             }
 
             sky = new SkyClass();
+
+            if (sky?.material) {
+                sky.material.depthWrite = false;
+                sky.material.side = THREE.BackSide;
+            }
+
+            sky.renderOrder = -1;
             sky.scale.setScalar(450000);
             scene.add(sky);
 


### PR DESCRIPTION
## Summary
- update the Sky mesh in `index.html` to render with back faces, skip depth writes, and draw first so it no longer occludes the scene

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d4f245d2588327b19c60ba89bc19f9