### PR TITLE
Adjust district overlay tinting

### DIFF
--- a/src/scene/districts.js
+++ b/src/scene/districts.js
@@ -218,13 +218,21 @@ export function setDistricts(districtDefs = []) {
 
     const shape = new THREE.Shape(polygon.map(([vx, vz]) => new THREE.Vector2(vx, vz)));
     const shapeGeometry = new THREE.ShapeGeometry(shape);
-    const fillColor = baseColor.clone().lerp(new THREE.Color(0xffffff), 0.7);
+    const baseHsl = { h: 0, s: 0, l: 0 };
+    baseColor.getHSL(baseHsl);
+    const fillColor = baseColor.clone();
+    fillColor.setHSL(
+      baseHsl.h,
+      THREE.MathUtils.clamp(baseHsl.s + 0.15, 0, 1),
+      THREE.MathUtils.clamp(baseHsl.l + 0.08, 0, 1)
+    );
+
     const fillMaterial = new THREE.MeshBasicMaterial({
       color: fillColor,
       transparent: true,
-      opacity: 0.08,
+      opacity: 0.06,
       side: THREE.DoubleSide,
-      depthWrite: true
+      depthWrite: false,
     });
 
     const fillMesh = new THREE.Mesh(shapeGeometry, fillMaterial);


### PR DESCRIPTION
## Summary
- derive district fill colors from the base hue with additional saturation/lightness instead of lerping to white, preventing the washed-out look near the Acropolis
- disable depth writing on district fill materials so the transparent overlay no longer mutes the grass texture underneath

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d4fb6c36048327ac131c7613b74f3f