### PR TITLE
Add positional ambient zone audio

### DIFF
--- a/index.html
+++ b/index.html
@@ -549,6 +549,7 @@ const findFirstMaterial = (candidate, visited = new Set()) => {
         import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
         import { SkeletonUtils } from 'three/examples/jsm/utils/SkeletonUtils.js';
         import { EffectComposer } from 'three/examples/jsm/postprocessing/EffectComposer.js';
+        import { AmbientZoneManager } from './src/audio/ambient-zones.js';
         import { RenderPass } from 'three/examples/jsm/postprocessing/RenderPass.js';
         import { UnrealBloomPass } from 'three/examples/jsm/postprocessing/UnrealBloomPass.js';
         import { createPhotoSkydome } from './src/sky/photoSkydome.js';
@@ -1433,7 +1434,7 @@ const retargetBuildingMaterials =
         async function main() {
 
         // --- GLOBAL VARIABLES ---
-        let scene, camera, renderer, composer, ambientLight, directionalLight, hemisphereLight, player;
+        let scene, camera, renderer, composer, ambientLight, directionalLight, hemisphereLight, player, ambientZoneManager;
         let world;
         let controls = { W: false, A: false, S: false, D: false, E: false, ShiftLeft: false, ShiftRight: false, Space: false, ArrowUp: false, ArrowLeft: false, ArrowDown: false, ArrowRight: false };
         const toggleKeyTimestamps = {};
@@ -1450,6 +1451,30 @@ const retargetBuildingMaterials =
         const setScaledPosition = (object, x, y, z) => {
             object.position.set(scaleValue(x), y, scaleValue(z));
         };
+        const pendingAmbientZones = [];
+        function registerAmbientZone(node, options = {}) {
+            if (!node) {
+                return;
+            }
+
+            if (ambientZoneManager) {
+                ambientZoneManager.registerZone({ node, ...options });
+                return;
+            }
+
+            pendingAmbientZones.push({ node, options });
+        }
+
+        function flushPendingAmbientZones() {
+            if (!ambientZoneManager || pendingAmbientZones.length === 0) {
+                return;
+            }
+
+            const queued = pendingAmbientZones.splice(0, pendingAmbientZones.length);
+            queued.forEach(({ node, options }) => {
+                ambientZoneManager.registerZone({ node, ...options });
+            });
+        }
         // Controls how quickly the photographic sky panorama pans across the horizon.
         const PHOTO_SKYDOME_SCROLL_SPEED_DEG_PER_SECOND = 1.0;
         const GEO_TO_SCENE_MATRIX = Object.freeze({
@@ -2015,6 +2040,10 @@ const retargetBuildingMaterials =
             camera.far = Math.max(camera.far, 60000);
             camera.updateProjectionMatrix();
             window.camera = camera;
+
+            ambientZoneManager = new AmbientZoneManager({ maxActive: 3, fadeTime: 0.75 });
+            ambientZoneManager.setCamera(camera);
+            flushPendingAmbientZones();
             
             // Renderer
             renderer = new THREE.WebGLRenderer({
@@ -2469,6 +2498,7 @@ const retargetBuildingMaterials =
             createPhaleronHarbor();
             createHouses();
             createTrees();
+            createCountrysideAmbienceAnchor();
             createFountain();
             createCityFortifications();
             createMarketStalls();
@@ -3678,6 +3708,14 @@ function createAgoraComplex() {
     const agoraGroup = new THREE.Group();
     agoraGroup.name = 'Agora Precinct';
     scene.add(agoraGroup);
+    registerAmbientZone(agoraGroup, {
+        id: 'agora-market',
+        type: 'market',
+        radius: scaleValue(45),
+        maxDistance: scaleValue(240),
+        volume: 0.58,
+        rolloff: 2.4
+    });
 
     const plazaMaterial = new THREE.MeshStandardMaterial({
         color: 0xb9a880,
@@ -5239,6 +5277,14 @@ world.addBody(archBody);
              setScaledPosition(pnyx, PNYX_POSITION.x, 0, PNYX_POSITION.z);
              pnyx.rotation.y = -Math.PI / 2;
              scene.add(pnyx);
+             registerAmbientZone(pnyx, {
+                id: 'assembly-pnyx',
+                type: 'assembly',
+                radius: scaleValue(35),
+                maxDistance: scaleValue(220),
+                volume: 0.6,
+                rolloff: 2.0
+             });
 
              const dikasteria = createEnhancedBuilding(0, -15, 8, 12, 6, marbleMaterial);
              const colonnade = new THREE.Group();
@@ -5286,6 +5332,22 @@ world.addBody(archBody);
             }
             stoaWay.receiveShadow = true;
             scene.add(stoaWay);
+        }
+
+        function createCountrysideAmbienceAnchor() {
+            const countrysideAnchor = new THREE.Object3D();
+            countrysideAnchor.name = 'Countryside Ambience Anchor';
+            setScaledPosition(countrysideAnchor, -140, 6, 130);
+            scene.add(countrysideAnchor);
+            registerAmbientZone(countrysideAnchor, {
+                id: 'countryside-hills',
+                type: 'countryside',
+                radius: scaleValue(60),
+                maxDistance: scaleValue(280),
+                volume: 0.65,
+                rolloff: 1.6
+            });
+            return countrysideAnchor;
         }
 
         // --- NPC AND INTERACTIVE OBJECTS ---
@@ -6275,6 +6337,10 @@ world.addBody(archBody);
                 updateSoundPositions(delta);
             }
 
+            if (ambientZoneManager) {
+                ambientZoneManager.update(delta, camera.position);
+            }
+
             updatePhotoSkydomeScroll(delta);
             updateNightCycle(delta);
 
@@ -6866,12 +6932,31 @@ world.addBody(archBody);
 
                 audioStartInProgress = true;
                 try {
-                    await createAmbientSounds();
-                    initializeChickenAudio();
-                    audioStarted = true;
-                    console.log("Audio context started.");
+                    const tonePromise = (async () => {
+                        await createAmbientSounds();
+                        initializeChickenAudio();
+                    })();
+                    const zonePromise = ambientZoneManager?.resume?.() ?? Promise.resolve();
+
+                    const [toneResult, zoneResult] = await Promise.allSettled([tonePromise, zonePromise]);
+
+                    if (zoneResult?.status === 'rejected') {
+                        console.warn('Unable to resume ambient zone audio context:', zoneResult.reason);
+                    }
+
+                    if (ambientZoneManager) {
+                        ambientZoneManager.setEnabled(true);
+                        ambientZoneManager.update(0, camera.position);
+                    }
+
+                    if (toneResult.status === 'fulfilled') {
+                        audioStarted = true;
+                        console.log("Audio context started.");
+                    } else if (toneResult.status === 'rejected') {
+                        console.warn('Unable to start audio context:', toneResult.reason);
+                    }
                 } catch (error) {
-                    console.warn('Unable to start audio context:', error);
+                    console.warn('Unable to start audio systems:', error);
                 } finally {
                     audioStartInProgress = false;
                 }

--- a/src/audio/ambient-zones.js
+++ b/src/audio/ambient-zones.js
@@ -1,0 +1,396 @@
+import * as THREE from 'three';
+
+function clamp(value, min, max) {
+  return Math.min(max, Math.max(min, value));
+}
+
+function applyLoopFades(data, sampleRate, fadeSeconds = 0.2) {
+  const fadeSamples = Math.min(Math.floor(sampleRate * fadeSeconds), Math.floor(data.length / 2));
+  if (fadeSamples <= 0) {
+    return;
+  }
+
+  for (let i = 0; i < fadeSamples; i += 1) {
+    const fadeIn = i / fadeSamples;
+    const fadeOut = 1 - fadeIn;
+    data[i] *= fadeIn;
+    data[data.length - 1 - i] *= fadeOut;
+  }
+}
+
+function createCrowdBuffer(context) {
+  const duration = 12;
+  const sampleRate = context.sampleRate;
+  const frameCount = Math.floor(sampleRate * duration);
+  const buffer = context.createBuffer(1, frameCount, sampleRate);
+  const channel = buffer.getChannelData(0);
+
+  let murmur = 0;
+  const voices = new Array(5).fill(null).map(() => ({
+    nextEvent: Math.random() * 1.5,
+    phase: 0,
+    freq: 0,
+    remaining: 0,
+    duration: 0,
+    amplitude: 0,
+  }));
+
+  for (let i = 0; i < frameCount; i += 1) {
+    const time = i / sampleRate;
+    murmur = murmur * 0.995 + (Math.random() * 2 - 1) * 0.005;
+    let value = murmur * 0.45;
+    value += Math.sin(time * 2 * Math.PI * 0.27) * 0.05;
+
+    voices.forEach((voice) => {
+      if (time >= voice.nextEvent) {
+        voice.freq = 140 + Math.random() * 160;
+        voice.duration = 0.22 + Math.random() * 0.35;
+        voice.remaining = voice.duration;
+        voice.phase = 0;
+        voice.amplitude = 0.12 + Math.random() * 0.08;
+        voice.nextEvent = time + 0.8 + Math.random() * 1.6;
+      }
+
+      if (voice.remaining > 0) {
+        const progress = 1 - (voice.remaining / voice.duration);
+        const envelope = Math.sin(Math.PI * clamp(progress, 0, 1));
+        value += Math.sin(voice.phase) * voice.amplitude * envelope;
+        voice.phase += (2 * Math.PI * voice.freq) / sampleRate;
+        voice.remaining -= 1 / sampleRate;
+      }
+    });
+
+    channel[i] = clamp(value * 0.7, -1, 1);
+  }
+
+  applyLoopFades(channel, sampleRate, 0.35);
+  return buffer;
+}
+
+function createAssemblyBuffer(context) {
+  const duration = 14;
+  const sampleRate = context.sampleRate;
+  const frameCount = Math.floor(sampleRate * duration);
+  const buffer = context.createBuffer(1, frameCount, sampleRate);
+  const channel = buffer.getChannelData(0);
+
+  const drones = [98, 131, 164].map((freq) => ({ freq, phase: 0 }));
+  let rustle = 0;
+  const call = {
+    nextEvent: 0.4,
+    freq: 0,
+    remaining: 0,
+    duration: 0,
+    phase: 0,
+    amplitude: 0,
+  };
+
+  for (let i = 0; i < frameCount; i += 1) {
+    const time = i / sampleRate;
+    let value = 0;
+
+    drones.forEach((tone, index) => {
+      const modulation = 0.07 + index * 0.02;
+      const amp = 0.07 + index * 0.03;
+      value += Math.sin(tone.phase) * amp * (0.8 + 0.2 * Math.sin(time * 2 * Math.PI * 0.1));
+      tone.phase += (2 * Math.PI * tone.freq) / sampleRate;
+    });
+
+    rustle = rustle * 0.997 + (Math.random() * 2 - 1) * 0.003;
+    value += rustle * 0.2;
+
+    if (time >= call.nextEvent) {
+      call.freq = 170 + Math.random() * 90;
+      call.duration = 0.9 + Math.random() * 0.9;
+      call.remaining = call.duration;
+      call.phase = 0;
+      call.amplitude = 0.24 + Math.random() * 0.08;
+      call.nextEvent = time + 1.5 + Math.random() * 2.7;
+    }
+
+    if (call.remaining > 0) {
+      const progress = 1 - (call.remaining / call.duration);
+      const envelope = Math.sin(Math.PI * clamp(progress, 0, 1));
+      value += Math.sin(call.phase) * call.amplitude * envelope;
+      call.phase += (2 * Math.PI * call.freq) / sampleRate;
+      call.remaining -= 1 / sampleRate;
+    }
+
+    channel[i] = clamp(value * 0.75, -1, 1);
+  }
+
+  applyLoopFades(channel, sampleRate, 0.4);
+  return buffer;
+}
+
+function createCountrysideBuffer(context) {
+  const duration = 16;
+  const sampleRate = context.sampleRate;
+  const frameCount = Math.floor(sampleRate * duration);
+  const buffer = context.createBuffer(1, frameCount, sampleRate);
+  const channel = buffer.getChannelData(0);
+
+  let breeze = 0;
+  const chirps = new Array(3).fill(null).map(() => ({
+    nextEvent: Math.random() * 3,
+    freq: 0,
+    remaining: 0,
+    duration: 0,
+    phase: 0,
+    amplitude: 0,
+  }));
+
+  for (let i = 0; i < frameCount; i += 1) {
+    const time = i / sampleRate;
+    breeze = breeze * 0.996 + (Math.random() * 2 - 1) * 0.004;
+    let value = breeze * 0.55;
+    value += Math.sin(time * 2 * Math.PI * 0.08) * 0.03;
+
+    chirps.forEach((chirp) => {
+      if (time >= chirp.nextEvent) {
+        chirp.freq = 2000 + Math.random() * 1400;
+        chirp.duration = 0.18 + Math.random() * 0.22;
+        chirp.remaining = chirp.duration;
+        chirp.phase = 0;
+        chirp.amplitude = 0.22 + Math.random() * 0.1;
+        chirp.nextEvent = time + 1.2 + Math.random() * 2.4;
+      }
+
+      if (chirp.remaining > 0) {
+        const progress = 1 - (chirp.remaining / chirp.duration);
+        const envelope = Math.sin(Math.PI * clamp(progress, 0, 1));
+        const trill = Math.sin(chirp.phase) * chirp.amplitude * envelope;
+        value += trill;
+        chirp.phase += (2 * Math.PI * chirp.freq) / sampleRate;
+        chirp.remaining -= 1 / sampleRate;
+      }
+    });
+
+    channel[i] = clamp(value * 0.6, -1, 1);
+  }
+
+  applyLoopFades(channel, sampleRate, 0.45);
+  return buffer;
+}
+
+function generateBuffer(type, context) {
+  switch (type) {
+    case 'market':
+    case 'plaza':
+      return createCrowdBuffer(context);
+    case 'assembly':
+      return createAssemblyBuffer(context);
+    case 'countryside':
+      return createCountrysideBuffer(context);
+    default:
+      return createCrowdBuffer(context);
+  }
+}
+
+export class AmbientZoneManager {
+  constructor({ maxActive = 3, fadeTime = 0.65 } = {}) {
+    this.maxActive = Math.max(1, maxActive);
+    this.fadeTime = fadeTime;
+    this.listener = null;
+    this.enabled = false;
+    this.zones = [];
+    this.zoneIndex = new Map();
+    this.bufferCache = new Map();
+  }
+
+  setCamera(camera) {
+    if (!camera) {
+      return;
+    }
+
+    if (!this.listener) {
+      this.listener = new THREE.AudioListener();
+    }
+
+    if (this.listener.parent !== camera) {
+      camera.add(this.listener);
+    }
+  }
+
+  registerZone({ id, node, type = 'market', radius = 30, maxDistance, volume = 0.5, rolloff = 1.5 } = {}) {
+    if (!node) {
+      return null;
+    }
+
+    const zoneId = id ?? `zone-${this.zones.length}`;
+    let zone = this.zoneIndex.get(zoneId);
+    const resolvedMaxDistance = maxDistance ?? radius * 3;
+
+    if (!zone) {
+      zone = {
+        id: zoneId,
+        node,
+        type,
+        radius,
+        maxDistance: resolvedMaxDistance,
+        volume: clamp(volume, 0, 1),
+        rolloff,
+        worldPosition: new THREE.Vector3(),
+        currentGain: 0,
+        targetGain: 0,
+        audio: null,
+        loading: null,
+        distance: Infinity,
+      };
+      this.zones.push(zone);
+      this.zoneIndex.set(zoneId, zone);
+    } else {
+      zone.node = node;
+      zone.type = type;
+      zone.radius = radius;
+      zone.maxDistance = resolvedMaxDistance;
+      zone.volume = clamp(volume, 0, 1);
+      zone.rolloff = rolloff;
+      if (zone.audio && zone.audio.parent !== node) {
+        zone.audio.removeFromParent();
+        node.add(zone.audio);
+      }
+    }
+
+    return zone;
+  }
+
+  setEnabled(value) {
+    const enabled = Boolean(value);
+    if (this.enabled === enabled) {
+      return;
+    }
+
+    this.enabled = enabled;
+    if (!enabled) {
+      this.zones.forEach((zone) => {
+        if (zone.audio && zone.audio.isPlaying) {
+          zone.audio.stop();
+        }
+        if (zone.audio) {
+          zone.audio.setVolume(0);
+        }
+        zone.currentGain = 0;
+        zone.targetGain = 0;
+      });
+    }
+  }
+
+  async resume() {
+    if (!this.listener) {
+      return;
+    }
+
+    const context = this.listener.context;
+    if (context && typeof context.resume === 'function' && context.state === 'suspended') {
+      await context.resume();
+    }
+  }
+
+  ensureZoneAudio(zone) {
+    if (!this.listener || !zone || zone.audio || zone.loading) {
+      return;
+    }
+
+    const audio = new THREE.PositionalAudio(this.listener);
+    audio.name = `ambient-zone:${zone.id}`;
+    audio.setDistanceModel('linear');
+    audio.setRefDistance(zone.radius);
+    audio.setMaxDistance(zone.maxDistance);
+    audio.setRolloffFactor(zone.rolloff);
+    audio.setLoop(true);
+    audio.setVolume(0);
+
+    zone.node.add(audio);
+    zone.audio = audio;
+
+    const loadBuffer = async () => {
+      if (!this.listener) {
+        return;
+      }
+      const context = this.listener.context;
+      if (!context) {
+        return;
+      }
+
+      let buffer = this.bufferCache.get(zone.type);
+      if (!buffer) {
+        buffer = generateBuffer(zone.type, context);
+        this.bufferCache.set(zone.type, buffer);
+      }
+
+      if (buffer) {
+        audio.setBuffer(buffer);
+      }
+    };
+
+    zone.loading = loadBuffer()
+      .catch((error) => {
+        console.warn(`[ambient-zones] Unable to create buffer for ${zone.id}`, error);
+        if (zone.audio) {
+          zone.audio.removeFromParent();
+        }
+        zone.audio = null;
+      })
+      .finally(() => {
+        zone.loading = null;
+      });
+  }
+
+  update(delta, listenerPosition) {
+    if (!this.enabled || !this.listener || !listenerPosition) {
+      return;
+    }
+
+    const availableZones = [];
+    this.zones.forEach((zone) => {
+      if (!zone.node) {
+        zone.targetGain = 0;
+        return;
+      }
+      zone.node.getWorldPosition(zone.worldPosition);
+      zone.distance = zone.worldPosition.distanceTo(listenerPosition);
+      zone.targetGain = 0;
+      availableZones.push(zone);
+    });
+
+    availableZones.sort((a, b) => a.distance - b.distance);
+
+    let activated = 0;
+    for (const zone of availableZones) {
+      if (zone.distance <= zone.maxDistance && activated < this.maxActive) {
+        zone.targetGain = zone.volume;
+        activated += 1;
+      }
+    }
+
+    const smoothing = this.fadeTime > 0 ? 1 - Math.exp(-Math.max(delta, 0) / this.fadeTime) : 1;
+
+    this.zones.forEach((zone) => {
+      if (zone.targetGain > 0 && !zone.audio && !zone.loading) {
+        this.ensureZoneAudio(zone);
+      }
+
+      if (!zone.audio || !zone.audio.buffer) {
+        return;
+      }
+
+      zone.currentGain += (zone.targetGain - zone.currentGain) * smoothing;
+      if (Math.abs(zone.currentGain) < 0.0001) {
+        zone.currentGain = 0;
+      }
+
+      zone.audio.setVolume(clamp(zone.currentGain, 0, 1));
+
+      if (zone.currentGain > 0.002) {
+        if (!zone.audio.isPlaying) {
+          zone.audio.play();
+        }
+      } else if (zone.audio.isPlaying && zone.targetGain <= 0) {
+        zone.audio.stop();
+      }
+    });
+  }
+}
+
+export default AmbientZoneManager;


### PR DESCRIPTION
## Summary
- add an AmbientZoneManager that generates lightweight looping buffers and attaches positional audio to scene nodes
- register agora, pnyx, and countryside anchors with distance-aware ambient sound and limit active zones to three
- integrate the manager with scene initialization and audio start flow so ambience resumes after the user click

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68d5105c91488327862105371ca67a6d