### PR TITLE
Apply configurable world compression to placements

### DIFF
--- a/src/buildings-from-geojson.js
+++ b/src/buildings-from-geojson.js
@@ -7,21 +7,7 @@ import { applyFeatureOffset } from './geo/featureOffsets.js';
 import { getDistrictAt, getDistricts } from './scene/districts.js';
 import { defaultPlacementOptions } from './scene/placement-options.js';
 import { estimateAABB, GridIndex } from './scene/placement-grid.js';
-
-const WORLD_COMPRESSION = 0.5; // 50% closer
-
-function applyWorldCompression(vector) {
-  if (!vector) {
-    return vector;
-  }
-  if (typeof vector.x === 'number') {
-    vector.x *= WORLD_COMPRESSION;
-  }
-  if (typeof vector.z === 'number') {
-    vector.z *= WORLD_COMPRESSION;
-  }
-  return vector;
-}
+import { applyCompressionToVector3 } from './world/scale.js';
 
 const deg = (d)=> THREE.MathUtils.degToRad(d);
 
@@ -531,7 +517,7 @@ function prioritizeCandidates(candidates) {
 
 function buildPlacement(candidate, position, rotationDeg) {
   const compressedPosition = position.clone();
-  applyWorldCompression(compressedPosition);
+  applyCompressionToVector3(compressedPosition);
   return {
     name: candidate.rawName || candidate.name,
     meshKind: candidate.kind,
@@ -831,7 +817,7 @@ export function instantiateMeshes(placements, scene) {
     }
     const compressedPoints = points.map((point) => {
       const vector = point.clone ? point.clone() : new THREE.Vector3(point.x, point.y ?? 0, point.z);
-      return applyWorldCompression(vector);
+      return applyCompressionToVector3(vector);
     });
     const wall = makeWallPath(compressedPoints, { segment: 10, height: 4, width: 2.5 });
     root.add(wall);

--- a/src/landmarks-loader.js
+++ b/src/landmarks-loader.js
@@ -1,21 +1,7 @@
 import THREE from './three.js';
 import { applyFeatureOffset } from './geo/featureOffsets.js';
 import { createFeatureLines } from './scene/feature-lines.js';
-
-const WORLD_COMPRESSION = 0.5; // 50% closer
-
-function applyWorldCompression(vector) {
-  if (!vector) {
-    return vector;
-  }
-  if (typeof vector.x === 'number') {
-    vector.x *= WORLD_COMPRESSION;
-  }
-  if (typeof vector.z === 'number') {
-    vector.z *= WORLD_COMPRESSION;
-  }
-  return vector;
-}
+import { applyCompressionToVector3 } from './world/scale.js';
 
 /**
  * Load every feature from a GeoJSON file and add to the scene.
@@ -63,7 +49,7 @@ export async function loadLandmarks({
         fallbackName: name
       });
       const pos = projectLonLat(lon, lat);
-      applyWorldCompression(pos);
+      applyCompressionToVector3(pos);
 
       const pin = makePinMesh(cat);
       pin.position.copy(pos);
@@ -93,7 +79,7 @@ export async function loadLandmarks({
     featureLines = createFeatureLines({
       features: lineFeatures,
       projector: projectLonLat,
-      worldCompressionFn: applyWorldCompression
+      worldCompressionFn: applyCompressionToVector3
     });
 
     if (featureLines?.root) {

--- a/src/vegetation/trees.js
+++ b/src/vegetation/trees.js
@@ -2,8 +2,7 @@ import * as THREE from 'three';
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 import { createProceduralTree } from './procTree.js';
 import { resolveAssetUrl } from '../utils/asset-paths.js';
-
-const WORLD_COMPRESSION = 0.5; // 50% closer
+import { applyCompressionToVector3 } from '../world/scale.js';
 
 const TREE_MODEL_FILES = {
   olive: 'olive.glb',
@@ -362,18 +361,17 @@ function cloneTemplate(template) {
 function applyTransform(object, options = {}) {
   const { position, rotation, scale } = options;
 
-  if (position) {
-    object.position.set(
-      (position.x ?? 0) * WORLD_COMPRESSION,
-      position.y ?? 0,
-      (position.z ?? 0) * WORLD_COMPRESSION
+  const basePosition = position ?? options;
+  if (basePosition) {
+    const pos = new THREE.Vector3(
+      basePosition.x ?? 0,
+      basePosition.y ?? 0,
+      basePosition.z ?? 0
     );
+    applyCompressionToVector3(pos);
+    object.position.copy(pos);
   } else {
-    object.position.set(
-      (options.x ?? 0) * WORLD_COMPRESSION,
-      options.y ?? 0,
-      (options.z ?? 0) * WORLD_COMPRESSION
-    );
+    object.position.set(0, 0, 0);
   }
 
   if (rotation) {
@@ -523,11 +521,8 @@ function createInstancedGrove(definition, placements) {
 
   const dummy = new THREE.Object3D();
   placements.forEach((placement, index) => {
-    dummy.position.set(
-      placement.x * WORLD_COMPRESSION,
-      placement.y,
-      placement.z * WORLD_COMPRESSION
-    );
+    dummy.position.set(placement.x, placement.y, placement.z);
+    applyCompressionToVector3(dummy.position);
     dummy.rotation.set(0, placement.rotation, 0);
     dummy.scale.setScalar(placement.scale);
     dummy.updateMatrix();

--- a/src/world/scale.js
+++ b/src/world/scale.js
@@ -1,0 +1,32 @@
+const MIN_COMPRESSION = 0.25;
+const MAX_COMPRESSION = 1.0;
+const DEFAULT_COMPRESSION = 0.6;
+
+export let WORLD_COMPRESSION = DEFAULT_COMPRESSION;
+
+export function setWorldCompression(value) {
+  const numeric = Number(value);
+  if (Number.isFinite(numeric)) {
+    WORLD_COMPRESSION = Math.min(MAX_COMPRESSION, Math.max(MIN_COMPRESSION, numeric));
+  }
+  return WORLD_COMPRESSION;
+}
+
+export function getWorldCompression() {
+  return WORLD_COMPRESSION;
+}
+
+export function applyCompressionToVector3(vector) {
+  if (!vector || typeof vector.x !== 'number' || typeof vector.z !== 'number') {
+    return vector;
+  }
+
+  const factor = getWorldCompression();
+  vector.x *= factor;
+  vector.z *= factor;
+  return vector;
+}
+
+if (typeof window !== 'undefined') {
+  window.setWorldCompression = setWorldCompression;
+}


### PR DESCRIPTION
## Summary
- add a world compression helper module with runtime controls for x/z distances
- apply the compression helper to landmark, building, and vegetation placement positions
- ensure generated wall paths reuse the compressed coordinates for consistency

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d534cd32bc832791a1b2da282648b0