### PR TITLE
Fix horizon flag initialization error

### DIFF
--- a/index.html
+++ b/index.html
@@ -2471,7 +2471,6 @@ const retargetBuildingMaterials =
                 horizonSegments = Math.min(horizonSegments, 64);
             }
 
-            const HORIZON_ENABLE = true;
             const HORIZON_RADIUS = 900;
             const HORIZON_HEIGHT = 70;
             window.getMountainRim = () => null;


### PR DESCRIPTION
## Summary
- remove the redundant horizon flag declaration within the init routine to avoid temporal dead zone access errors

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68d53c83073c832787eb36ba1dae5f05