### PR TITLE
Fix star field controller scope

### DIFF
--- a/index.html
+++ b/index.html
@@ -980,6 +980,10 @@ const retargetBuildingMaterials =
         let spaceGroup = null;
         let savedDayBackground = null;
         let savedDayEnvironment = null;
+        let starFieldController = null;
+        let moonController = null;
+        let starsEnabled = true;
+        let moonEnabled = true;
 
         function loadNightSkyEquirectangular(scene, renderer) {
             const loader = new THREE.TextureLoader();
@@ -1903,10 +1907,10 @@ const retargetBuildingMaterials =
         let bloomPass;
         let fogEnabled = true;
         let spaceNight = null;
-        let starFieldController = null;
-        let moonController = null;
-        let starsEnabled = true;
-        let moonEnabled = true;
+        starFieldController = null;
+        moonController = null;
+        starsEnabled = true;
+        moonEnabled = true;
         let mountainRimMesh = null;
         let rimEnabled = HORIZON_ENABLE;
         let photoSkydome = null;


### PR DESCRIPTION
## Summary
- declare the star and moon controllers in the shared scope used by the space night initializer
- reset the controller state when Athens boots to keep toggle logic working

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d53fb3dc2c83278d2ab4c48f2da835