### PR TITLE
Add stats.js performance monitor with toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,8 @@
             "three/examples/jsm/utils/SkeletonUtils.js": "https://cdn.jsdelivr.net/npm/three@0.128.0/examples/jsm/utils/SkeletonUtils.js",
             "three/examples/jsm/lines/Line2.js": "https://cdn.jsdelivr.net/npm/three@0.128.0/examples/jsm/lines/Line2.js",
             "three/examples/jsm/lines/LineGeometry.js": "https://cdn.jsdelivr.net/npm/three@0.128.0/examples/jsm/lines/LineGeometry.js",
-            "three/examples/jsm/lines/LineMaterial.js": "https://cdn.jsdelivr.net/npm/three@0.128.0/examples/jsm/lines/LineMaterial.js"
+            "three/examples/jsm/lines/LineMaterial.js": "https://cdn.jsdelivr.net/npm/three@0.128.0/examples/jsm/lines/LineMaterial.js",
+            "three/examples/jsm/libs/stats.module.js": "https://cdn.jsdelivr.net/npm/three@0.128.0/examples/jsm/libs/stats.module.js"
         }
     }
     </script>
@@ -558,7 +559,14 @@ const findFirstMaterial = (candidate, visited = new Set()) => {
         import { createMoon } from './src/sky/moon.js';
         import { createMountainRim } from './src/sky/mountainRim.js';
         import { resolveAssetUrl } from './src/utils/asset-paths.js';
-import { setupGround, configureGround, updateTrees } from './src/main.js';
+import {
+    setupGround,
+    configureGround,
+    updateTrees,
+    initPerformanceStats,
+    updatePerformanceStats,
+    toggleStatsVisibility
+} from './src/main.js';
 import { setEnvironment } from './src/scene/sky.js';
 import * as buildingMaterials from './src/scene/materials.js';
 import { createCityWallPerimeter, createCityGatehouse } from './src/scene/city-wall.js';
@@ -2244,6 +2252,7 @@ const retargetBuildingMaterials =
             renderer.shadowMap.enabled = true;
             renderer.shadowMap.type = THREE.PCFSoftShadowMap;
             document.body.appendChild(renderer.domElement);
+            initPerformanceStats();
             window.renderer = renderer;
 
             districtsLayer = createDistrictsLayer({ scene });
@@ -6565,6 +6574,7 @@ world.addBody(archBody);
 
             const dt = clock.getDelta();
             const delta = dt;
+            updatePerformanceStats();
             if (spaceNight) {
                 spaceNight.update(dt, camera);
             }
@@ -7225,6 +7235,14 @@ world.addBody(archBody);
             document.addEventListener('keydown', (e) => {
                 if (['Space', 'ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(e.code)) {
                     e.preventDefault();
+                }
+                if (e.shiftKey && e.code === 'KeyP') {
+                    if (e.repeat) {
+                        return;
+                    }
+                    e.preventDefault();
+                    toggleStatsVisibility();
+                    return;
                 }
                 controls[e.code] = true;
                 if (e.code === 'KeyD' || e.code === 'KeyN') {

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,140 @@
 import { loadGround } from './scene/ground.js';
 import { loadTreeLibrary, scatterTrees, updateTrees as updateTreeAnimations } from './vegetation/trees.js';
+
+const STATS_MODULE_ID = 'three/examples/jsm/libs/stats.module.js';
+const DEV_HOSTS = new Set(['localhost', '127.0.0.1', '0.0.0.0', '']);
+
+let StatsConstructor = null;
+let statsModuleError = null;
+
+if (typeof document !== 'undefined') {
+  try {
+    const module = await import(STATS_MODULE_ID);
+    StatsConstructor = module?.default ?? module;
+  } catch (error) {
+    statsModuleError = error;
+  }
+}
+
+let statsInstance = null;
+let statsVisible = false;
+let statsWarned = false;
+
+const isDomAvailable = () => typeof document !== 'undefined' && !!document.body;
+
+const isDevEnvironment = () => {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+
+  const { hostname = '', protocol = '', port = '' } = window.location || {};
+
+  if (protocol === 'file:') {
+    return true;
+  }
+
+  const normalizedHost = hostname.toLowerCase();
+
+  if (DEV_HOSTS.has(normalizedHost)) {
+    return true;
+  }
+
+  if (normalizedHost.endsWith('.local')) {
+    return true;
+  }
+
+  return port !== '' && port !== '80' && port !== '443';
+};
+
+const warnStatsUnavailable = (error) => {
+  if (statsWarned) {
+    return;
+  }
+  statsWarned = true;
+  if (error) {
+    console.warn('Stats.js unavailable', error);
+  } else {
+    console.warn('Stats.js unavailable');
+  }
+};
+
+const attachStatsDom = () => {
+  if (!statsInstance || !statsInstance.dom || !isDomAvailable()) {
+    return;
+  }
+
+  if (!statsInstance.dom.parentNode) {
+    document.body.appendChild(statsInstance.dom);
+  }
+};
+
+export function initPerformanceStats() {
+  if (statsInstance) {
+    attachStatsDom();
+    return statsInstance;
+  }
+
+  if (typeof StatsConstructor !== 'function') {
+    warnStatsUnavailable(statsModuleError);
+    return null;
+  }
+
+  try {
+    statsInstance = new StatsConstructor();
+  } catch (error) {
+    warnStatsUnavailable(error);
+    statsInstance = null;
+    return null;
+  }
+
+  statsInstance.dom.style.left = '0px';
+  statsInstance.dom.style.top = '0px';
+
+  statsVisible = isDevEnvironment();
+  statsInstance.dom.style.display = statsVisible ? '' : 'none';
+
+  attachStatsDom();
+
+  if (typeof window !== 'undefined') {
+    window.getStats = () => statsInstance;
+  }
+
+  return statsInstance;
+}
+
+export function updatePerformanceStats() {
+  if (!statsInstance) {
+    return;
+  }
+
+  statsInstance.update();
+}
+
+export function toggleStatsVisibility(forceVisible) {
+  const stats = statsInstance || initPerformanceStats();
+
+  if (!stats) {
+    return false;
+  }
+
+  if (typeof forceVisible === 'boolean') {
+    statsVisible = forceVisible;
+  } else {
+    statsVisible = !statsVisible;
+  }
+
+  stats.dom.style.display = statsVisible ? '' : 'none';
+
+  return statsVisible;
+}
+
+export function getStats() {
+  return statsInstance;
+}
+
+if (typeof window !== 'undefined' && typeof window.getStats !== 'function') {
+  window.getStats = () => statsInstance;
+}
 // --- Ground options (from codex/add-blended-ground-textures-and-districts-system)
 let groundOptions = {};
 


### PR DESCRIPTION
## Summary
- load stats.js lazily and expose helpers to initialize, update, toggle visibility, and access the stats panel
- default the performance overlay to visible in development, hidden otherwise, and register a Shift+P shortcut to toggle it
- integrate the performance monitor into the main animation loop and expose it globally via `window.getStats`

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d53e851e908327a6af4289ab929dab