### PR TITLE
Fix syntax error in Athens initialization handler

### DIFF
--- a/index.html
+++ b/index.html
@@ -7769,7 +7769,7 @@ world.addBody(archBody);
         
         // --- START  
         window.onload = function() {
-            initializeAthens(); {
+            initializeAthens();
         };
 </script>
 <script type="module">


### PR DESCRIPTION
## Summary
- remove the stray brace in the window onload handler so the bundle parses without a syntax error

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d5aaa785cc8327ab84d76343f207e0