### PR TITLE
Use CDN-hosted cannon.js for GitHub Pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
 <title>Ancient Athens - Visual Masterpiece</title>
 <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='6' ry='6' fill='%23333'/%3E%3Ctext x='16' y='22' font-size='18' text-anchor='middle' fill='%23fff' font-family='Cinzel, serif'%3EA%3C/text%3E%3C/svg%3E">
 <!-- Physics library -->
-<script src="./node_modules/cannon/build/cannon.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/cannon@0.6.2/build/cannon.min.js" integrity="sha384-OLBgp1GsljhM2TJ+sbHjaiH9txEUvgdDTAzHv2P24donTt6/529l+9Ua0vFImLlb" crossorigin="anonymous"></script>
 <script type="importmap">
     {
         "imports": {


### PR DESCRIPTION
## Summary
- load cannon.js from jsDelivr instead of the unavailable node_modules path
- add SRI metadata so the CDN asset can be safely consumed from GitHub Pages

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d5ba86cad88327862753aed174aa25