### PR TITLE
Fix import map to load three.js examples from CDN

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,17 +11,17 @@
 <script type="importmap">
     {
         "imports": {
-            "three": "./node_modules/three/build/three.module.js",
-            "three/examples/jsm/loaders/GLTFLoader.js": "./node_modules/three/examples/jsm/loaders/GLTFLoader.js",
-            "three/examples/jsm/objects/Sky.js": "./node_modules/three/examples/jsm/objects/Sky.js",
-            "three/examples/jsm/postprocessing/EffectComposer.js": "./node_modules/three/examples/jsm/postprocessing/EffectComposer.js",
-            "three/examples/jsm/postprocessing/RenderPass.js": "./node_modules/three/examples/jsm/postprocessing/RenderPass.js",
-            "three/examples/jsm/postprocessing/UnrealBloomPass.js": "./node_modules/three/examples/jsm/postprocessing/UnrealBloomPass.js",
-            "three/examples/jsm/utils/SkeletonUtils.js": "./node_modules/three/examples/jsm/utils/SkeletonUtils.js",
-            "three/examples/jsm/lines/Line2.js": "./node_modules/three/examples/jsm/lines/Line2.js",
-            "three/examples/jsm/lines/LineGeometry.js": "./node_modules/three/examples/jsm/lines/LineGeometry.js",
-            "three/examples/jsm/lines/LineMaterial.js": "./node_modules/three/examples/jsm/lines/LineMaterial.js",
-            "three/examples/jsm/libs/stats.module.js": "./node_modules/three/examples/jsm/libs/stats.module.js"
+            "three": "https://cdn.jsdelivr.net/npm/three@0.180.0/build/three.module.js",
+            "three/examples/jsm/loaders/GLTFLoader.js": "https://cdn.jsdelivr.net/npm/three@0.180.0/examples/jsm/loaders/GLTFLoader.js",
+            "three/examples/jsm/objects/Sky.js": "https://cdn.jsdelivr.net/npm/three@0.180.0/examples/jsm/objects/Sky.js",
+            "three/examples/jsm/postprocessing/EffectComposer.js": "https://cdn.jsdelivr.net/npm/three@0.180.0/examples/jsm/postprocessing/EffectComposer.js",
+            "three/examples/jsm/postprocessing/RenderPass.js": "https://cdn.jsdelivr.net/npm/three@0.180.0/examples/jsm/postprocessing/RenderPass.js",
+            "three/examples/jsm/postprocessing/UnrealBloomPass.js": "https://cdn.jsdelivr.net/npm/three@0.180.0/examples/jsm/postprocessing/UnrealBloomPass.js",
+            "three/examples/jsm/utils/SkeletonUtils.js": "https://cdn.jsdelivr.net/npm/three@0.180.0/examples/jsm/utils/SkeletonUtils.js",
+            "three/examples/jsm/lines/Line2.js": "https://cdn.jsdelivr.net/npm/three@0.180.0/examples/jsm/lines/Line2.js",
+            "three/examples/jsm/lines/LineGeometry.js": "https://cdn.jsdelivr.net/npm/three@0.180.0/examples/jsm/lines/LineGeometry.js",
+            "three/examples/jsm/lines/LineMaterial.js": "https://cdn.jsdelivr.net/npm/three@0.180.0/examples/jsm/lines/LineMaterial.js",
+            "three/examples/jsm/libs/stats.module.js": "https://cdn.jsdelivr.net/npm/three@0.180.0/examples/jsm/libs/stats.module.js"
         }
     }
     </script>


### PR DESCRIPTION
## Summary
- update the import map to fetch the three.js core and example modules from jsDelivr so they are available when the app is served without node_modules

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d5c41580f88327bf90f7f144a95d57