### PR TITLE
Add centralized bootstrap flow for Athens app

### DIFF
--- a/index.html
+++ b/index.html
@@ -1517,11 +1517,26 @@ const retargetBuildingMaterials =
             return resolvePreset(fromOptions ?? fromURL ?? fromEnv ?? null);
         }
 
-        async function initializeAthens() {
+        let initialSetupPromise = null;
+
+        async function initializeAthens(options = {}) {
             try {
                 if (window.threeJSReady) {
                     await window.threeJSReady;
                 }
+
+                if (!initialSetupPromise) {
+                    initialSetupPromise = (async () => {
+                        if (typeof init === 'function') {
+                            await init();
+                        }
+                    })().catch((error) => {
+                        initialSetupPromise = null;
+                        throw error;
+                    });
+                }
+
+                await initialSetupPromise;
 
                 if (typeof THREE === 'undefined') {
                     console.error('THREE.js is not available. Please ensure external resources can be loaded.');
@@ -1531,15 +1546,16 @@ const retargetBuildingMaterials =
 
                 console.log('THREE.js is ready, initializing Athens...');
 
-                const baseOptions = typeof window !== 'undefined' ? window.__AthensOptions : null;
-                const presetName = determineSkydomePreset(baseOptions || undefined);
-                const mainOptions = { ...(baseOptions || {}), skydomePreset: presetName };
+                const envOptions = typeof window !== 'undefined' ? window.__AthensOptions : null;
+                const mergedOptions = { ...(envOptions || {}), ...(options || {}) };
+                const presetName = determineSkydomePreset(mergedOptions || undefined);
+                const mainOptions = { ...mergedOptions, skydomePreset: presetName };
                 if (typeof window !== 'undefined') {
                     window.__AthensOptions = mainOptions;
                     window.__AthensSkyPreset = presetName;
                 }
 
-                await main(mainOptions);
+                await runAthens(mainOptions);
             } catch (error) {
                 if (!error?.__athensLogged) {
                     console.error('Athens experience failed to initialize:', error);
@@ -1563,7 +1579,7 @@ const retargetBuildingMaterials =
             object.position.set(scaleValue(x), y, scaleValue(z));
         };
 
-        async function main(options = {}) {
+        async function runAthens(options = {}) {
 
         // --- GLOBAL VARIABLES ---
         let scene, camera, renderer, composer, ambientLight, directionalLight, hemisphereLight, player, ambientZoneManager;
@@ -7866,28 +7882,35 @@ world.addBody(archBody);
             }
         }
         
-        // Initialize the application
-        try {
-            if (typeof init === 'function') {
-                await init();
-            } else {
-                console.warn('Main init function not available, continuing with fallback initialization...');
-            }
-        } catch (error) {
-            console.error('Failed to initialize Athens experience:', error);
-            if (error?.stack) {
-                console.error(error.stack);
-            }
-            logDetailedError('Async Initialization', error);
-            showErrorOverlay('Async Initialization', error, false);
-            error.__athensLogged = true;
-            throw error;
+        if (typeof window !== 'undefined') {
+            window.initializeAthens = initializeAthens;
+            window.runAthens = runAthens;
+        }
+</script>
+<script type="module">
+    import boot from './src/core/bootstrap.js';
+
+    const triggerBoot = () => {
+        boot(window.__AthensOptions || {});
+    };
+
+    if (typeof document !== 'undefined') {
+        if (document.readyState === 'loading') {
+            window.addEventListener('DOMContentLoaded', triggerBoot, { once: true });
+        } else {
+            triggerBoot();
         }
 
-        // --- START
-        window.onload = function() {
-            initializeAthens();
-        };
+        document.addEventListener('keydown', (event) => {
+            if (event.shiftKey && (event.key === 'B' || event.key === 'b')) {
+                console.clear();
+                console.log('Rebooting Athens…');
+                window.Athens?.boot?.(window.__AthensOptions || {});
+            }
+        });
+    } else {
+        triggerBoot();
+    }
 </script>
 <script type="module">
     // SAFETY: turn undefined / single value into an array so .map() never crashes

--- a/src/core/bootstrap.js
+++ b/src/core/bootstrap.js
@@ -1,0 +1,93 @@
+let startedAt = null;
+let lastError = null;
+
+function showErrorOverlay(msg, err) {
+  try {
+    const id = 'athens-init-error';
+    if (typeof document === 'undefined') {
+      return;
+    }
+    if (document.getElementById(id)) return;
+    const d = document.createElement('div');
+    d.id = id;
+    d.style.cssText = 'position:fixed;inset:0;background:rgba(0,0,0,.7);color:#fff;padding:24px;z-index:99999;font:14px/1.4 system-ui;overflow:auto;';
+    d.innerHTML = '<h2 style="margin-top:0">🏛️ Athens Initialization Error</h2><p>' +
+      (msg || 'Unknown error') +
+      '</p><pre style="white-space:pre-wrap">' +
+      (err?.stack || '') +
+      '</pre><p>Press ESC to dismiss</p>';
+    document.body.appendChild(d);
+    window.addEventListener(
+      'keydown',
+      (e) => {
+        if (e.key === 'Escape') d.remove();
+      },
+      { once: true }
+    );
+  } catch (_) {
+    // noop
+  }
+}
+
+function logPhase(label, data) {
+  const t = new Date().toISOString();
+  if (data !== undefined) {
+    console.info(`[Athens][${t}] ${label}`, data);
+  } else {
+    console.info(`[Athens][${t}] ${label}`);
+  }
+}
+
+async function fallbackInit() {
+  logPhase('Fallback init engaged (no main/init available)');
+  showErrorOverlay(
+    'Main init function not available. Check that your build exports a `main()` or defines `window.initializeAthens`.'
+  );
+}
+
+export default async function boot(opts = {}) {
+  startedAt = Date.now();
+  lastError = null;
+  logPhase('Boot start');
+
+  try {
+    let candidate = null;
+    if (typeof opts.main === 'function') {
+      candidate = opts.main;
+      logPhase('Using opts.main()');
+    } else {
+      try {
+        const mod = await import('../main.js');
+        if (typeof mod.main === 'function') {
+          candidate = mod.main;
+          logPhase('Using module main() from src/main.js');
+        }
+      } catch (e) {
+        logPhase('Module main() not found (import failed). Will try globals next.');
+      }
+    }
+
+    if (!candidate && typeof window !== 'undefined' && typeof window.initializeAthens === 'function') {
+      candidate = window.initializeAthens;
+      logPhase('Using global initializeAthens()');
+    }
+
+    if (!candidate) {
+      await fallbackInit();
+      return;
+    }
+
+    await candidate(opts);
+    logPhase('Boot complete', { elapsedMs: Date.now() - startedAt });
+  } catch (err) {
+    lastError = err;
+    console.error('🏛️ Athens Initialization Error - Boot Wrapper', err);
+    showErrorOverlay('Error during initialization', err);
+  }
+}
+
+if (typeof window !== 'undefined') {
+  window.Athens = window.Athens || {};
+  window.Athens.boot = (o) => boot(o);
+  window.Athens.getBootInfo = () => ({ startedAt, lastError });
+}

--- a/src/main.js
+++ b/src/main.js
@@ -201,3 +201,16 @@ export function updateTrees(delta) {
 export function getTreeLibrary() {
   return treeLibraryState;
 }
+
+export async function main(options = {}) {
+  if (typeof window !== 'undefined') {
+    if (typeof window.initializeAthens === 'function') {
+      return window.initializeAthens(options);
+    }
+    if (typeof window.runAthens === 'function') {
+      return window.runAthens(options);
+    }
+  }
+
+  throw new Error('Athens main entry point is not available.');
+}


### PR DESCRIPTION
## Summary
- add a reusable `boot` helper that prefers the module `main()` export, falls back to globals, and surfaces initialization errors with an overlay
- update the HTML bootstrap to expose `initializeAthens`, reuse the helper on load, and wire a Shift+B reboot hotkey for QA
- export `main()` from `src/main.js` to forward to the window bootstrap functions during the transition

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d5cd2b276883278a46c793776d28e5