### PR TITLE
Ensure Athens resolves presets before initialization

### DIFF
--- a/index.html
+++ b/index.html
@@ -570,8 +570,8 @@ const findFirstMaterial = (candidate, visited = new Set()) => {
         import { RenderPass } from 'three/examples/jsm/postprocessing/RenderPass.js';
         import { UnrealBloomPass } from 'three/examples/jsm/postprocessing/UnrealBloomPass.js';
         import { createPhotoSkydome } from './src/sky/photoSkydome.js';
-        import { KNOWN_PRESETS, resolvePreset } from './src/sky/presets.js';
-        import { resolveName } from './src/core/nameResolver.js';
+        import { KNOWN_PRESETS } from './src/sky/presets.js';
+        import { resolvePreset } from './src/core/presetResolver.js';
         import { nightSkyDataUrl } from './src/sky/nightSkyTextureData.js';
         import { createStarField } from './src/sky/starField.js';
         import { createMoon } from './src/sky/moon.js';
@@ -1516,10 +1516,10 @@ const retargetBuildingMaterials =
                 ? window.__AthensEnv?.preset ?? window.__AthensEnv?.skydomePreset ?? null
                 : null;
             const rawName = fromOptions ?? fromURL ?? fromEnv ?? null;
-            const safeName = resolveName(rawName);
+            const safeName = resolvePreset(rawName);
 
             if (!rawName) {
-                console.error('[Athens] initializeAthens(): No preset provided. Falling back to default:', safeName);
+                console.warn('[Athens] initializeAthens(): No preset provided. Falling back to default:', safeName);
             }
 
             return safeName;
@@ -1562,9 +1562,15 @@ const retargetBuildingMaterials =
                     window.__AthensOptions = mainOptions;
                     window.__AthensSkyPreset = presetName;
                     window.__AthensResolvedName = presetName;
+                    window.__AthensPreset = presetName;
                 }
 
-                await runAthens(mainOptions);
+                try {
+                    await runAthens(mainOptions);
+                } catch (error) {
+                    console.error('🏛️ Athens Initialization Error - initializeAthens()', error);
+                    throw error;
+                }
             } catch (error) {
                 if (!error?.__athensLogged) {
                     console.error('Athens experience failed to initialize:', error);
@@ -1590,17 +1596,22 @@ const retargetBuildingMaterials =
 
         async function runAthens(options = {}) {
 
-            const providedPreset = options?.preset ?? options?.skydomePreset ?? (typeof window !== 'undefined'
-                ? window.__AthensResolvedName ?? window.__AthensSkyPreset ?? null
-                : null);
-            const initialResolvedPreset = resolveName(providedPreset);
+            const fallbackPreset = typeof window !== 'undefined'
+                ? window.__AthensPreset ?? window.__AthensResolvedName ?? window.__AthensSkyPreset ?? null
+                : null;
+            const providedPreset = options?.preset ?? options?.skydomePreset ?? fallbackPreset;
+            const safePreset = resolvePreset(providedPreset);
 
             if (!providedPreset) {
-                console.error('[Athens] runAthens(): No preset provided. Falling back to default:', initialResolvedPreset);
+                console.warn('[Athens] runAthens(): No preset passed, using default:', safePreset);
             }
 
+            options = { ...options, preset: safePreset, skydomePreset: safePreset };
+
             if (typeof window !== 'undefined') {
-                window.__AthensResolvedName = initialResolvedPreset;
+                window.__AthensPreset = safePreset;
+                window.__AthensResolvedName = safePreset;
+                window.__AthensSkyPreset = safePreset;
             }
 
         // --- GLOBAL VARIABLES ---
@@ -2056,7 +2067,7 @@ const retargetBuildingMaterials =
         let lastTime = performance.now();
         
         let soundEnabled = true;
-        const initialSkyPreset = initialResolvedPreset;
+        const initialSkyPreset = safePreset;
         const initialSkyConfig = photoSkyTimeConfig?.[initialSkyPreset] || null;
         if (typeof window !== 'undefined') {
             window.__AthensSkyPreset = initialSkyPreset;

--- a/src/core/bootstrap.js
+++ b/src/core/bootstrap.js
@@ -77,7 +77,12 @@ export default async function boot(opts = {}) {
       return;
     }
 
-    await candidate(opts);
+    const candidateOptions = (opts && typeof opts === 'object') ? { ...opts } : {};
+    if (!candidateOptions?.preset && !candidateOptions?.skydomePreset) {
+      candidateOptions.preset = 'High Noon';
+    }
+
+    await candidate(candidateOptions);
     logPhase('Boot complete', { elapsedMs: Date.now() - startedAt });
   } catch (err) {
     lastError = err;

--- a/src/core/presetResolver.js
+++ b/src/core/presetResolver.js
@@ -1,0 +1,46 @@
+const KNOWN_PRESETS = ['High Noon', 'Golden Dawn', 'Golden Dusk', 'Blue Hour', 'Night Sky'];
+
+const CANONICAL_PRESETS = new Map([
+  ['high noon', 'High Noon'],
+  ['golden dawn', 'Golden Dawn'],
+  ['golden dusk', 'Golden Dusk'],
+  ['blue hour', 'Blue Hour'],
+  ['night sky', 'Starlit Night'],
+  ['starlit night', 'Starlit Night']
+]);
+
+let warnedUnknownPreset = false;
+
+export function resolvePreset(name) {
+  if (!name || typeof name !== 'string') {
+    return getDefaultPreset();
+  }
+
+  const normalized = name.trim().toLowerCase();
+  if (!normalized) {
+    return getDefaultPreset();
+  }
+
+  const canonical = CANONICAL_PRESETS.get(normalized);
+  if (canonical) {
+    return canonical;
+  }
+
+  const found = KNOWN_PRESETS.find((preset) => preset.toLowerCase() === normalized);
+  if (found) {
+    return CANONICAL_PRESETS.get(found.toLowerCase()) || found;
+  }
+
+  if (!warnedUnknownPreset) {
+    console.warn('[Athens] Unknown preset name:', name, '→ defaulting');
+    warnedUnknownPreset = true;
+  }
+
+  return getDefaultPreset();
+}
+
+export function getDefaultPreset() {
+  return 'High Noon';
+}
+
+export { KNOWN_PRESETS };

--- a/src/sky/presets.js
+++ b/src/sky/presets.js
@@ -1,3 +1,5 @@
+import { resolvePreset as resolvePresetSafe, getDefaultPreset as getDefaultPresetSafe } from '../core/presetResolver.js';
+
 export const KNOWN_PRESETS = [
   'Golden Dawn',
   'Blue Hour',
@@ -17,6 +19,9 @@ export function normalizePresetName(name) {
     return null;
   }
   const normalized = name.trim().toLowerCase();
+  if (!normalized) {
+    return null;
+  }
   const alias = PRESET_ALIASES.get(normalized);
   if (alias) {
     return alias;
@@ -25,25 +30,16 @@ export function normalizePresetName(name) {
 }
 
 export function getDefaultPreset() {
-  if (KNOWN_PRESETS.includes('Starlit Night')) {
-    return 'Starlit Night';
-  }
-  if (KNOWN_PRESETS.includes('Night Sky')) {
-    return 'Night Sky';
-  }
-  if (KNOWN_PRESETS.includes('High Noon')) {
-    return 'High Noon';
-  }
-  return KNOWN_PRESETS[0] || 'High Noon';
+  return getDefaultPresetSafe();
 }
 
 let warnedUnknownPreset = false;
 export function resolvePreset(inputName) {
   const normalized = normalizePresetName(inputName);
   if (normalized) {
-    return normalized;
+    return resolvePresetSafe(normalized);
   }
-  const fallback = getDefaultPreset();
+  const fallback = getDefaultPresetSafe();
   if (inputName && !warnedUnknownPreset) {
     console.warn('[Athens] Unknown sky preset:', inputName, '→ using', fallback);
     warnedUnknownPreset = true;


### PR DESCRIPTION
## Summary
- add a shared preset resolver to normalize names, aliases, and fallbacks for Athens
- resolve presets during initializeAthens/runAthens, persist them on window, and log explicit errors
- ensure bootstrap provides a default preset and reuse the resolver inside sky preset helpers

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d5ef1066108327b4f1cb1d73a78aa1