### PR TITLE
Fix Athens initialization preset reference error

### DIFF
--- a/index.html
+++ b/index.html
@@ -5174,9 +5174,6 @@ function createBasicAgoraFallback() {
                 : fallbackEnvIntensity;
             desiredEnvironmentIntensity = targetEnvIntensity;
             updateSceneEnvironmentIntensity();
-
- 
-            }
             const featureLinesGetter = typeof window !== 'undefined' ? window.getFeatureLines : null;
             if (typeof featureLinesGetter === 'function') {
                 const featureLines = featureLinesGetter();


### PR DESCRIPTION
## Summary
- remove an extraneous closing brace in the time-of-day handler
- ensure preset-dependent lighting logic stays within the function scope to prevent ReferenceError

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d5f7b9b8948327b6737553dd133bf4