### PR TITLE
Fix missing closure in initializeAthens script

### DIFF
--- a/index.html
+++ b/index.html
@@ -7914,6 +7914,8 @@ world.addBody(archBody);
             window.initializeAthens = initializeAthens;
             window.runAthens = runAthens;
         }
+
+        }
 </script>
 <script type="module">
     import boot from './src/core/bootstrap.js';


### PR DESCRIPTION
## Summary
- close the initializeAthens function in index.html to prevent runtime syntax errors

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d5f91acf2883278435b95f7531f58a