### PR TITLE
Add Daily List UI and logic for Memory Cue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/memory-cue/app.js
+++ b/memory-cue/app.js
@@ -1,0 +1,213 @@
+import { initializeApp, getApp, getApps } from 'https://www.gstatic.com/firebasejs/10.12.0/firebase-app.js';
+import { getFirestore, doc, getDoc, setDoc, arrayUnion } from 'https://www.gstatic.com/firebasejs/10.12.0/firebase-firestore.js';
+
+if (!getApps().length) {
+  if (!window.firebaseConfig) {
+    throw new Error('Missing Firebase configuration. Define window.firebaseConfig before loading app.js.');
+  }
+  initializeApp(window.firebaseConfig);
+}
+
+const db = getFirestore(getApp());
+
+const cuesView = document.getElementById('cues-view');
+const dailyListView = document.getElementById('daily-list-view');
+const tabButtons = document.querySelectorAll('[data-tab-target]');
+const dailyListHeader = document.getElementById('daily-list-header');
+const dailyTasksContainer = document.getElementById('daily-tasks-container');
+const quickAddForm = document.getElementById('quick-add-form');
+const quickAddInput = document.getElementById('quick-add-input');
+const clearCompletedBtn = document.getElementById('clear-completed-btn');
+
+let currentDailyListId = null;
+let currentDailyTasks = [];
+
+const getTodayDateId = () => {
+  const today = new Date();
+  const year = today.getFullYear();
+  const month = `${today.getMonth() + 1}`.padStart(2, '0');
+  const day = `${today.getDate()}`.padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};
+
+const formatHumanReadableDate = (dateId) => {
+  const [year, month, day] = dateId.split('-').map((value) => parseInt(value, 10));
+  const parsed = new Date(year, month - 1, day);
+  return parsed.toLocaleDateString(undefined, {
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  });
+};
+
+const dailyListDoc = (dateId) => doc(db, 'dailyLists', dateId);
+
+const normalizeTasks = (tasks) => {
+  if (!Array.isArray(tasks)) {
+    return [];
+  }
+
+  return tasks
+    .map((task) => ({
+      text: typeof task?.text === 'string' ? task.text : '',
+      completed: Boolean(task?.completed),
+    }))
+    .filter((task) => task.text.trim().length > 0);
+};
+
+const renderDailyTasks = (tasks) => {
+  dailyTasksContainer.innerHTML = '';
+
+  if (!tasks.length) {
+    const emptyState = document.createElement('p');
+    emptyState.className = 'text-sm text-base-content/70';
+    emptyState.textContent = 'No tasks yet. Add one using the quick add form.';
+    dailyTasksContainer.appendChild(emptyState);
+    return;
+  }
+
+  tasks.forEach((task, index) => {
+    const label = document.createElement('label');
+    label.className = 'flex items-center gap-3 rounded-lg border border-base-300 bg-base-100 p-3 shadow-sm';
+
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.className = 'checkbox checkbox-primary daily-task-checkbox';
+    checkbox.dataset.index = String(index);
+    checkbox.checked = Boolean(task.completed);
+
+    const span = document.createElement('span');
+    span.className = 'text-base';
+    span.textContent = task.text;
+    if (task.completed) {
+      span.classList.add('line-through', 'opacity-60');
+    }
+
+    label.appendChild(checkbox);
+    label.appendChild(span);
+    dailyTasksContainer.appendChild(label);
+  });
+};
+
+const loadDailyList = async () => {
+  const todayId = getTodayDateId();
+  currentDailyListId = todayId;
+  dailyListHeader.textContent = `Today's List - ${formatHumanReadableDate(todayId)}`;
+
+  try {
+    const snapshot = await getDoc(dailyListDoc(todayId));
+    currentDailyTasks = snapshot.exists() ? normalizeTasks(snapshot.data().tasks) : [];
+  } catch (error) {
+    console.error('Failed to load daily list tasks:', error);
+    currentDailyTasks = [];
+  }
+
+  renderDailyTasks(currentDailyTasks);
+};
+
+const setActiveTab = (activeTab) => {
+  tabButtons.forEach((tab) => {
+    const isActive = tab === activeTab;
+    tab.classList.toggle('tab-active', isActive);
+    tab.setAttribute('aria-selected', String(isActive));
+  });
+};
+
+const showView = (targetId) => {
+  if (!cuesView || !dailyListView) {
+    return;
+  }
+
+  if (targetId === 'daily-list-view') {
+    cuesView.classList.add('hidden');
+    dailyListView.classList.remove('hidden');
+  } else {
+    cuesView.classList.remove('hidden');
+    dailyListView.classList.add('hidden');
+  }
+};
+
+tabButtons.forEach((tab) => {
+  tab.addEventListener('click', async (event) => {
+    event.preventDefault();
+    const { tabTarget } = tab.dataset;
+    if (!tabTarget) {
+      return;
+    }
+
+    setActiveTab(tab);
+    showView(tabTarget);
+
+    if (tabTarget === 'daily-list-view') {
+      await loadDailyList();
+    }
+  });
+});
+
+setActiveTab(document.getElementById('tab-cues'));
+showView('cues-view');
+
+quickAddForm?.addEventListener('submit', async (event) => {
+  event.preventDefault();
+  const text = quickAddInput.value.trim();
+  if (!text) {
+    return;
+  }
+
+  const todayId = currentDailyListId ?? getTodayDateId();
+  const newTask = { text, completed: false };
+
+  try {
+    await setDoc(dailyListDoc(todayId), { tasks: arrayUnion(newTask) }, { merge: true });
+    quickAddInput.value = '';
+    await loadDailyList();
+  } catch (error) {
+    console.error('Failed to add quick task:', error);
+  }
+});
+
+dailyTasksContainer?.addEventListener('change', async (event) => {
+  const target = event.target;
+  if (!(target instanceof HTMLInputElement) || !target.classList.contains('daily-task-checkbox')) {
+    return;
+  }
+
+  const index = Number.parseInt(target.dataset.index ?? '', 10);
+  if (!Number.isInteger(index) || !currentDailyTasks[index]) {
+    return;
+  }
+
+  currentDailyTasks = currentDailyTasks.map((task, taskIndex) => (
+    taskIndex === index ? { ...task, completed: target.checked } : task
+  ));
+  renderDailyTasks(currentDailyTasks);
+
+  const todayId = currentDailyListId ?? getTodayDateId();
+  try {
+    await setDoc(dailyListDoc(todayId), { tasks: currentDailyTasks }, { merge: true });
+  } catch (error) {
+    console.error('Failed to update task completion:', error);
+  }
+});
+
+clearCompletedBtn?.addEventListener('click', async () => {
+  if (!currentDailyTasks.length) {
+    return;
+  }
+
+  const todayId = currentDailyListId ?? getTodayDateId();
+  const remainingTasks = currentDailyTasks.filter((task) => !task.completed);
+
+  if (remainingTasks.length === currentDailyTasks.length) {
+    return;
+  }
+
+  currentDailyTasks = remainingTasks;
+  renderDailyTasks(currentDailyTasks);
+
+  try {
+    await setDoc(dailyListDoc(todayId), { tasks: remainingTasks }, { merge: true });
+  } catch (error) {
+    console.error('Failed to clear completed tasks:', error);
+  }
+});

--- a/memory-cue/index.html
+++ b/memory-cue/index.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Memory Cue</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/daisyui@4.7.3/dist/full.min.css" />
+</head>
+<body class="bg-base-200 min-h-screen">
+  <div class="container mx-auto max-w-3xl p-4">
+    <div role="tablist" class="tabs tabs-boxed w-full">
+      <button type="button" role="tab" class="tab tab-active" id="tab-cues" data-tab-target="cues-view">Cues</button>
+      <button type="button" role="tab" class="tab" id="tab-daily" data-tab-target="daily-list-view">Today's List</button>
+    </div>
+
+    <div id="cues-view" class="mt-6 space-y-4">
+      <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <h1 class="text-3xl font-semibold">Memory Cue</h1>
+        <button id="show-add-cue-modal" class="btn btn-primary w-full sm:w-auto">Add New Cue</button>
+      </div>
+      <div id="cues-list" class="mt-2"></div>
+    </div>
+
+    <div id="daily-list-view" class="hidden mt-6 space-y-4">
+      <h2 id="daily-list-header" class="text-2xl font-semibold"></h2>
+      <form id="quick-add-form" class="form-control">
+        <div class="join">
+          <input
+            id="quick-add-input"
+            type="text"
+            placeholder="Add a quick task..."
+            class="input input-bordered join-item w-full"
+            autocomplete="off"
+            required
+          />
+          <button type="submit" class="btn btn-primary join-item">Add</button>
+        </div>
+      </form>
+      <div id="daily-tasks-container" class="space-y-2"></div>
+      <button id="clear-completed-btn" class="btn btn-sm btn-outline mt-4 w-full sm:w-auto">Clear Completed Tasks</button>
+    </div>
+  </div>
+
+  <script type="module" src="./app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a tabbed Memory Cue interface with DaisyUI tabs and dedicated containers for cues and the new daily list
- implement Firestore-backed daily list loading, quick-add, completion toggling, and clearing completed tasks
- add a .gitignore entry to keep node_modules out of version control

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d5f9880dac8327b6af9858dd46f53e