### PR TITLE
Handle non-positive initializer timeouts

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -207,6 +207,13 @@ async function waitForAthensInitializer({ timeoutMs = 5000, pollIntervalMs = 50 
     return null;
   }
 
+  const normalizedTimeout =
+    typeof timeoutMs === 'number' && Number.isFinite(timeoutMs) && timeoutMs > 0 ? timeoutMs : null;
+  const normalizedPollInterval =
+    typeof pollIntervalMs === 'number' && Number.isFinite(pollIntervalMs) && pollIntervalMs > 0
+      ? pollIntervalMs
+      : 50;
+
   const resolveInitializer = () => {
     if (typeof window.initializeAthens === 'function') {
       return window.initializeAthens;
@@ -224,7 +231,7 @@ async function waitForAthensInitializer({ timeoutMs = 5000, pollIntervalMs = 50 
 
   return new Promise((resolve) => {
     const start = Date.now();
-    const hasTimeout = typeof timeoutMs === 'number' && timeoutMs >= 0 && Number.isFinite(timeoutMs);
+    const hasTimeout = normalizedTimeout !== null;
 
     let timeoutId = null;
     let listener = null;
@@ -248,16 +255,16 @@ async function waitForAthensInitializer({ timeoutMs = 5000, pollIntervalMs = 50 
         return;
       }
 
-      if (hasTimeout && Date.now() - start >= timeoutMs) {
+      if (hasTimeout && Date.now() - start >= normalizedTimeout) {
         cleanup();
         resolve(null);
         return;
       }
 
-      timeoutId = setTimeout(tick, pollIntervalMs);
+      timeoutId = setTimeout(tick, normalizedPollInterval);
     };
 
-    timeoutId = setTimeout(tick, pollIntervalMs);
+    timeoutId = setTimeout(tick, normalizedPollInterval);
 
     if (typeof window.addEventListener === 'function') {
       listener = (event) => {


### PR DESCRIPTION
## Summary
- normalize timeout and poll interval handling in waitForAthensInitializer so non-positive values no longer trigger immediate failure

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d606c01e7883279396fca8102a2e13