### PR TITLE
Ensure Athens main entry point exports correctly

### DIFF
--- a/src/core/bootstrap.js
+++ b/src/core/bootstrap.js
@@ -51,6 +51,10 @@ export default async function boot(opts = {}) {
 
     const entryPoint = typeof overrideMain === 'function' ? overrideMain : main;
 
+    if (typeof entryPoint !== 'function') {
+      throw new Error('Athens main entry point is not available.');
+    }
+
     if (!candidateOptions?.preset && !candidateOptions?.skydomePreset) {
       candidateOptions.preset = 'High Noon';
     }

--- a/src/main.js
+++ b/src/main.js
@@ -326,6 +326,6 @@ export async function main(opts = {}) {
 
 main[ATHENS_MAIN_SENTINEL] = true;
 
-if (typeof window !== 'undefined') {
+if (typeof window !== 'undefined' && typeof window.initializeAthens !== 'function') {
   window.initializeAthens = main;
 }


### PR DESCRIPTION
## Summary
- guard the legacy window.initializeAthens assignment so the real initializer is preserved
- validate the resolved entry point inside the boot wrapper before calling it and surface a clear error

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d60c4d78ac8327bcb9bd78336bbc82