### PR TITLE
Fix Athens bootstrap to use exported main entry point

### DIFF
--- a/src/core/bootstrap.js
+++ b/src/core/bootstrap.js
@@ -31,40 +31,29 @@ function showErrorOverlay(msg, err) {
   }
 }
 
-function logPhase(label, data) {
-  const t = new Date().toISOString();
-  if (data !== undefined) {
-    console.info(`[Athens][${t}] ${label}`, data);
-  } else {
-    console.info(`[Athens][${t}] ${label}`);
-  }
-}
-
 export default async function boot(opts = {}) {
   startedAt = Date.now();
   lastError = null;
-  logPhase('Boot start');
+
+  const options = opts && typeof opts === 'object' ? { ...opts } : {};
+
+  if (!options?.preset && !options?.skydomePreset) {
+    options.preset = 'High Noon';
+  }
+
+  const entryPointLabel = '[Athens][Bootstrap] Booting with main()';
+  console.info(entryPointLabel, { options });
 
   try {
-    const rawOptions = opts && typeof opts === 'object' ? { ...opts } : {};
-    const { main: overrideMain, ...candidateOptions } = rawOptions;
-
-    const entryPoint = typeof overrideMain === 'function' ? overrideMain : main;
-
-    if (typeof entryPoint !== 'function') {
-      throw new Error('Athens main entry point is not available.');
-    }
-
-    if (!candidateOptions?.preset && !candidateOptions?.skydomePreset) {
-      candidateOptions.preset = 'High Noon';
-    }
-
-    await entryPoint(candidateOptions);
-    logPhase('Boot complete', { elapsedMs: Date.now() - startedAt });
+    await main(options);
+    console.info('[Athens][Bootstrap] Boot complete', {
+      elapsedMs: Date.now() - startedAt
+    });
   } catch (err) {
     lastError = err;
     console.error('🏛️ Athens Initialization Error - Boot Wrapper', err);
     showErrorOverlay('Error during initialization', err);
+    throw err;
   }
 }
 

--- a/src/main.js
+++ b/src/main.js
@@ -326,6 +326,6 @@ export async function main(opts = {}) {
 
 main[ATHENS_MAIN_SENTINEL] = true;
 
-if (typeof window !== 'undefined' && typeof window.initializeAthens !== 'function') {
+if (typeof window !== 'undefined') {
   window.initializeAthens = main;
 }


### PR DESCRIPTION
## Summary
- ensure the global initializeAthens fallback always references the exported main entry point
- call main directly from the bootstrap wrapper and add logging for the selected entry point

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d60fb6176083279ef426d424ac5d92