### PR TITLE
Prevent overwriting existing Athens initializer

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -327,5 +327,9 @@ export async function main(opts = {}) {
 main[ATHENS_MAIN_SENTINEL] = true;
 
 if (typeof window !== 'undefined') {
-  window.initializeAthens = main;
+  const existingInitializer = window.initializeAthens;
+
+  if (typeof existingInitializer !== 'function' || isAthensMainEntrypoint(existingInitializer)) {
+    window.initializeAthens = main;
+  }
 }


### PR DESCRIPTION
## Summary
- avoid replacing an already-registered `initializeAthens` function when loading the main module so the external initializer remains available

## Testing
- npm run build *(fails: Missing script "build")*

------
https://chatgpt.com/codex/tasks/task_b_68d61da3fdac8327b3264e64c135162c