### PR TITLE
Delay Athens boot until DOM is ready

### DIFF
--- a/src/core/bootstrap.js
+++ b/src/core/bootstrap.js
@@ -59,6 +59,14 @@ export default async function boot(opts = {}) {
 
 if (typeof window !== 'undefined') {
   window.Athens = window.Athens || {};
-  window.Athens.boot = (o) => boot(o);
+  window.Athens.boot = (o) => {
+    const startBoot = () => boot(o);
+
+    if (typeof document !== 'undefined' && document.readyState === 'loading') {
+      window.addEventListener('DOMContentLoaded', startBoot, { once: true });
+    } else {
+      startBoot();
+    }
+  };
   window.Athens.getBootInfo = () => ({ startedAt, lastError });
 }


### PR DESCRIPTION
## Summary
- ensure the Athens boot routine waits for the DOM to be ready before running
- prevent early boot calls from touching the DOM before `DOMContentLoaded`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d61f922a6883279ab8252065853c94