### PR TITLE
Ensure Athens initializer is exposed before boot

### DIFF
--- a/index.html
+++ b/index.html
@@ -1585,6 +1585,30 @@ const retargetBuildingMaterials =
             }
         }
 
+        if (typeof window !== 'undefined') {
+            console.info('[Athens][Inline] Preparing initializer exposure');
+            window.initializeAthens = initializeAthens;
+            window.runAthens = runAthens;
+            if (typeof window.dispatchEvent === 'function') {
+                queueMicrotask(() => {
+                    const detail = { initializer: initializeAthens };
+                    try {
+                        window.dispatchEvent(new CustomEvent('athens:initializer-ready', { detail }));
+                    } catch (error) {
+                        try {
+                            if (typeof document !== 'undefined' && typeof document.createEvent === 'function') {
+                                const event = document.createEvent('CustomEvent');
+                                event.initCustomEvent('athens:initializer-ready', false, false, detail);
+                                window.dispatchEvent(event);
+                            }
+                        } catch (innerError) {
+                            console.debug('[Athens] Unable to dispatch initializer-ready event immediately.', innerError);
+                        }
+                    }
+                });
+            }
+        }
+
         const CITY_SCALE = 2;
         const scaleValue = (value) => value * CITY_SCALE;
         const scaleLocation = ({ x, y = 0, z }) => new THREE.Vector3(scaleValue(x), y, scaleValue(z));
@@ -7934,12 +7958,6 @@ world.addBody(archBody);
                     console.debug('[Athens] Unable to dispatch initializer-ready event.', error);
                 }
             }
-        }
-
-        if (typeof window !== 'undefined') {
-            window.initializeAthens = initializeAthens;
-            window.runAthens = runAthens;
-            notifyInitializerReady(initializeAthens);
         }
 
         }

--- a/src/main.js
+++ b/src/main.js
@@ -356,9 +356,13 @@ main[ATHENS_MAIN_SENTINEL] = true;
 
 if (typeof window !== 'undefined') {
   try {
-    window.initializeAthens = main;
-    console.info('[Athens][Main] Exposed module main() as window.initializeAthens');
+    if (typeof window.initializeAthens !== 'function') {
+      window.initializeAthens = main;
+      console.info('[Athens][Main] Exposed module main() as window.initializeAthens');
+    } else {
+      console.info('[Athens][Main] Detected existing window.initializeAthens');
+    }
   } catch (error) {
-    console.warn('[Athens][Main] Unable to expose main() on window.initializeAthens', error);
+    console.warn('[Athens][Main] Unable to coordinate window.initializeAthens', error);
   }
 }


### PR DESCRIPTION
## Summary
- expose the inline initializeAthens function as soon as it is defined and notify listeners via CustomEvent
- avoid overwriting an existing window.initializeAthens when loading the module main entry point

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d6388bf58483278c0e84473a88cd45