### PR TITLE
Fix service worker registration for GitHub Pages deployments

### DIFF
--- a/index.html
+++ b/index.html
@@ -8533,8 +8533,13 @@ const asArray = (v) => (Array.isArray(v) ? v : (v == null ? [] : [v]));
     <script>
         if ('serviceWorker' in navigator) {
             window.addEventListener('load', () => {
+                const serviceWorkerUrl = new URL('service-worker.js', window.location.href);
+                const scopeUrl = new URL('./', window.location.href);
+
                 navigator.serviceWorker
-                    .register('/service-worker.js')
+                    .register(serviceWorkerUrl.pathname.startsWith('/') ? serviceWorkerUrl.pathname : serviceWorkerUrl.toString(), {
+                        scope: scopeUrl.pathname.startsWith('/') ? scopeUrl.pathname : scopeUrl.toString()
+                    })
                     .catch((error) => {
                         console.warn('Service worker registration failed:', error);
                     });


### PR DESCRIPTION
## Summary
- ensure the service worker registration resolves to the correct path and scope based on the current location
- prevent 404 errors on GitHub Pages by using URLs relative to the deployed site

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d63fe4f5048327bc108e9f140c12b6