### PR TITLE
Fix CDN imports for GitHub Pages deployment

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,21 +7,21 @@
 <title>Ancient Athens - Visual Masterpiece</title>
 <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='6' ry='6' fill='%23333'/%3E%3Ctext x='16' y='22' font-size='18' text-anchor='middle' fill='%23fff' font-family='Cinzel, serif'%3EA%3C/text%3E%3C/svg%3E">
 <!-- Physics library -->
-<script src="./node_modules/cannon/build/cannon.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/cannon@0.6.2/build/cannon.min.js"></script>
 <script type="importmap">
     {
         "imports": {
-            "three": "./node_modules/three/build/three.module.js",
-            "three/examples/jsm/loaders/GLTFLoader.js": "./node_modules/three/examples/jsm/loaders/GLTFLoader.js",
-            "three/examples/jsm/objects/Sky.js": "./node_modules/three/examples/jsm/objects/Sky.js",
-            "three/examples/jsm/postprocessing/EffectComposer.js": "./node_modules/three/examples/jsm/postprocessing/EffectComposer.js",
-            "three/examples/jsm/postprocessing/RenderPass.js": "./node_modules/three/examples/jsm/postprocessing/RenderPass.js",
-            "three/examples/jsm/postprocessing/UnrealBloomPass.js": "./node_modules/three/examples/jsm/postprocessing/UnrealBloomPass.js",
-            "three/examples/jsm/utils/SkeletonUtils.js": "./node_modules/three/examples/jsm/utils/SkeletonUtils.js",
-            "three/examples/jsm/lines/Line2.js": "./node_modules/three/examples/jsm/lines/Line2.js",
-            "three/examples/jsm/lines/LineGeometry.js": "./node_modules/three/examples/jsm/lines/LineGeometry.js",
-            "three/examples/jsm/lines/LineMaterial.js": "./node_modules/three/examples/jsm/lines/LineMaterial.js",
-            "three/examples/jsm/libs/stats.module.js": "./node_modules/three/examples/jsm/libs/stats.module.js"
+            "three": "https://cdn.jsdelivr.net/npm/three@0.180.0/build/three.module.js",
+            "three/examples/jsm/loaders/GLTFLoader.js": "https://cdn.jsdelivr.net/npm/three@0.180.0/examples/jsm/loaders/GLTFLoader.js",
+            "three/examples/jsm/objects/Sky.js": "https://cdn.jsdelivr.net/npm/three@0.180.0/examples/jsm/objects/Sky.js",
+            "three/examples/jsm/postprocessing/EffectComposer.js": "https://cdn.jsdelivr.net/npm/three@0.180.0/examples/jsm/postprocessing/EffectComposer.js",
+            "three/examples/jsm/postprocessing/RenderPass.js": "https://cdn.jsdelivr.net/npm/three@0.180.0/examples/jsm/postprocessing/RenderPass.js",
+            "three/examples/jsm/postprocessing/UnrealBloomPass.js": "https://cdn.jsdelivr.net/npm/three@0.180.0/examples/jsm/postprocessing/UnrealBloomPass.js",
+            "three/examples/jsm/utils/SkeletonUtils.js": "https://cdn.jsdelivr.net/npm/three@0.180.0/examples/jsm/utils/SkeletonUtils.js",
+            "three/examples/jsm/lines/Line2.js": "https://cdn.jsdelivr.net/npm/three@0.180.0/examples/jsm/lines/Line2.js",
+            "three/examples/jsm/lines/LineGeometry.js": "https://cdn.jsdelivr.net/npm/three@0.180.0/examples/jsm/lines/LineGeometry.js",
+            "three/examples/jsm/lines/LineMaterial.js": "https://cdn.jsdelivr.net/npm/three@0.180.0/examples/jsm/lines/LineMaterial.js",
+            "three/examples/jsm/libs/stats.module.js": "https://cdn.jsdelivr.net/npm/three@0.180.0/examples/jsm/libs/stats.module.js"
         }
     }
     </script>


### PR DESCRIPTION
## Summary
- load cannon and three.js modules from jsDelivr instead of local node_modules paths so the site works on GitHub Pages

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d67b038f6083279f1e18784215ae11