### PR TITLE
Auto-start Athens initialization

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,6 +93,10 @@
             transition: opacity 1s ease;
         }
 
+        #start-overlay.initialized {
+            background: rgba(0, 0, 0, 0.35);
+        }
+
         .overlay-button {
             background: linear-gradient(135deg, rgba(255, 215, 0, 0.8), rgba(255, 165, 0, 0.8));
             border: 2px solid rgba(255, 215, 0, 1);
@@ -1522,6 +1526,7 @@ const retargetBuildingMaterials =
         }
 
         let initialSetupPromise = null;
+        let athensStartPromise = null;
 
         async function initializeAthens(options = {}) {
             try {
@@ -1581,10 +1586,44 @@ const retargetBuildingMaterials =
             }
         }
 
+        function ensureAthensInitialized(options = {}) {
+            if (!athensStartPromise) {
+                athensStartPromise = initializeAthens(options).catch((error) => {
+                    athensStartPromise = null;
+                    throw error;
+                });
+            }
+
+            return athensStartPromise;
+        }
+
+        const scheduleAthensAutostart = () => {
+            const triggerInitialization = () => {
+                ensureAthensInitialized({ autoStarted: true })
+                    .then(() => {
+                        const overlay = document.getElementById('start-overlay');
+                        if (overlay && !overlay.classList.contains('initialized')) {
+                            overlay.classList.add('initialized');
+                        }
+                    })
+                    .catch((error) => {
+                        console.error('Automatic Athens initialization failed:', error);
+                    });
+            };
+
+            if (document.readyState === 'complete' || document.readyState === 'interactive') {
+                queueMicrotask(triggerInitialization);
+            } else {
+                document.addEventListener('DOMContentLoaded', triggerInitialization, { once: true });
+            }
+        };
+
         if (typeof window !== 'undefined') {
             console.info('[Athens][Inline] Preparing initializer exposure');
             window.initializeAthens = initializeAthens;
+            window.ensureAthensInitialized = ensureAthensInitialized;
             window.runAthens = runAthens;
+            scheduleAthensAutostart();
             if (typeof window.dispatchEvent === 'function') {
                 queueMicrotask(() => {
                     const detail = { initializer: initializeAthens };
@@ -7395,7 +7434,7 @@ world.addBody(archBody);
                 // Start the main Athens experience
                 try {
                     console.log('Starting Athens experience...');
-                    await initializeAthens();
+                    await ensureAthensInitialized();
                 } catch (error) {
                     console.error('Failed to start Athens experience:', error);
                     // Don't return here - still try to initialize audio


### PR DESCRIPTION
## Summary
- add an auto-start helper so `initializeAthens` runs as soon as the document is ready and reuse that promise for manual starts
- soften the start overlay once initialization finishes to reveal the scene while keeping the audio opt-in UX intact

## Testing
- none

------
https://chatgpt.com/codex/tasks/task_b_68d71c00c7a8832794b4a357ab32cf5a