### PR TITLE
Harden render surface layout sizing

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,12 +56,22 @@
             padding: 0;
             box-sizing: border-box;
         }
-        
+
+        html,
+        body {
+            width: 100%;
+            height: 100%;
+            min-height: 100vh;
+        }
+
         body {
             background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
             font-family: 'Cormorant Garamond', serif;
             overflow: hidden;
             position: relative;
+            display: flex;
+            flex-direction: column;
+            min-height: 100vh;
         }
         
         body::before {
@@ -135,9 +145,35 @@
             display: block;
         }
         
+        body > canvas {
+            flex: 1 1 auto;
+            display: block;
+            width: 100%;
+            height: 100%;
+            min-width: 1px;
+            min-height: 1px;
+        }
+
         canvas {
             display: block;
             border-radius: 0;
+        }
+
+        canvas[data-overlay],
+        canvas[data-role='overlay'],
+        canvas.overlay-layer {
+            position: absolute;
+            inset: 0;
+            width: 100%;
+            height: 100%;
+            pointer-events: none;
+            z-index: 150;
+        }
+
+        canvas[data-overlay][data-interactive='true'],
+        canvas[data-role='overlay'][data-interactive='true'],
+        canvas.overlay-layer[data-interactive='true'] {
+            pointer-events: auto;
         }
         
         .golden-text {
@@ -507,9 +543,7 @@
 <p id="info-text"></p>
 </div>
 </div>
-<canvas id="landmarks-canvas" style="position:fixed; right:16px; top:16px; width:420px; height:420px; z-index:150;
-               border:1px solid #FFD700; border-radius:10px; background:rgba(0,0,0,.18);">
-</canvas>
+<canvas id="landmarks-canvas" data-overlay="labels" aria-hidden="true"></canvas>
 <script type="module">
 // SAFETY helper: treat non-arrays as [] so `.map()` never crashes
 const asArray = (v) => (Array.isArray(v) ? v : (v == null ? [] : [v]));

--- a/public/index.html
+++ b/public/index.html
@@ -15,7 +15,9 @@
 
       html,
       body {
+        width: 100%;
         height: 100%;
+        min-height: 100vh;
         margin: 0;
         font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
         background: #0f172a;
@@ -25,13 +27,15 @@
       body {
         display: flex;
         flex-direction: column;
+        min-height: 100vh;
       }
 
       #app {
         position: relative;
-        flex: 1;
-        min-height: 100vh;
+        flex: 1 1 auto;
         width: 100%;
+        min-width: 0;
+        min-height: 100vh;
         overflow: hidden;
         display: flex;
         align-items: stretch;
@@ -41,12 +45,31 @@
           linear-gradient(180deg, rgba(15, 23, 42, 0.9), rgba(15, 23, 42, 1));
       }
 
-      canvas {
+      #app > canvas,
+      #app > .athens-display {
+        flex: 1 1 auto;
         display: block;
         width: 100%;
         height: 100%;
         min-width: 1px;
         min-height: 1px;
+      }
+
+      canvas[data-overlay],
+      canvas[data-role='overlay'],
+      canvas.overlay-layer {
+        position: absolute;
+        inset: 0;
+        width: 100%;
+        height: 100%;
+        pointer-events: none;
+        z-index: 2;
+      }
+
+      canvas[data-overlay][data-interactive='true'],
+      canvas[data-role='overlay'][data-interactive='true'],
+      canvas.overlay-layer[data-interactive='true'] {
+        pointer-events: auto;
       }
 
       #dev-log {


### PR DESCRIPTION
## Summary
- ensure html, body, and render root stretch to the viewport to keep the canvas visible
- size render and overlay canvases to fill their containers while allowing overlays to opt into pointer events
- normalize the landmarks overlay canvas markup for absolute positioning over the renderer

## Testing
- Not run (CSS/HTML only)


------
https://chatgpt.com/codex/tasks/task_b_68d721ad1bec8327ae840eb434a1f9f0