### PR TITLE
Improve asset base resolution and resilient loaders

### DIFF
--- a/src/ground/grass.js
+++ b/src/ground/grass.js
@@ -1,16 +1,14 @@
 import * as THREE from 'three';
 import { resolveAssetUrl } from '../utils/asset-paths.js';
+import {
+  loadTextureWithFallback,
+  ensureColorSpace as ensureTextureColorSpace
+} from '../utils/fail-soft-loaders.js';
 import { applyDoubleSidedGroundSupport } from './double-sided.js';
 
 const textureLoader = new THREE.TextureLoader();
 let cachedBaseTexture = null;
 const pendingTextureUpdates = new Set();
-
-function ensureColorSpace(texture) {
-  if (!texture) return;
-  if ('SRGBColorSpace' in THREE) texture.colorSpace = THREE.SRGBColorSpace;
-  else if ('sRGBEncoding' in THREE) texture.encoding = THREE.sRGBEncoding;
-}
 
 function flushPendingTextureUpdates(baseTexture) {
   if (pendingTextureUpdates.size === 0) return;
@@ -24,17 +22,32 @@ function flushPendingTextureUpdates(baseTexture) {
   pendingTextureUpdates.clear();
 }
 
+function applySharedSettings(texture) {
+  if (!texture) return;
+  texture.wrapS = texture.wrapT = THREE.RepeatWrapping;
+  ensureTextureColorSpace(texture);
+}
+
 function loadBaseTexture() {
   if (!cachedBaseTexture) {
-    cachedBaseTexture = textureLoader.load(
-      resolveAssetUrl('assets/textures/grass.jpg'),
-      (texture) => {
-        ensureColorSpace(texture);
+    const url = resolveAssetUrl('assets/textures/grass.jpg');
+    cachedBaseTexture = loadTextureWithFallback(url, {
+      loader: textureLoader,
+      label: 'ground grass texture',
+      fallbackColor: 0x4a7f39,
+      onLoad: (texture, { fallback }) => {
+        applySharedSettings(texture);
+        if (!fallback) {
+          flushPendingTextureUpdates(texture);
+        }
+      },
+      onFallback: (texture) => {
+        applySharedSettings(texture);
         flushPendingTextureUpdates(texture);
       }
-    );
+    });
 
-    ensureColorSpace(cachedBaseTexture);
+    applySharedSettings(cachedBaseTexture);
   } else if (cachedBaseTexture.image) {
     flushPendingTextureUpdates(cachedBaseTexture);
   }
@@ -56,7 +69,7 @@ function configureTexture(baseTexture, { repeat, anisotropy }) {
     texture.anisotropy = Math.max(texture.anisotropy || 0, anisotropy);
   }
 
-  ensureColorSpace(texture);
+  ensureTextureColorSpace(texture);
 
   if (baseTexture.image) {
     texture.needsUpdate = true;

--- a/src/roads/hybridRoads.js
+++ b/src/roads/hybridRoads.js
@@ -1,5 +1,6 @@
 import THREE from '../three.js';
 import { resolveAssetUrl } from '../utils/asset-paths.js';
+import { loadTextureAsyncWithFallback } from '../utils/fail-soft-loaders.js';
 
 const textureLoader = new THREE.TextureLoader();
 const textureCache = new Map();
@@ -369,7 +370,10 @@ async function loadRoadTexture(texturePath) {
     return textureCache.get(resolvedTexturePath);
   }
 
-  const texture = await textureLoader.loadAsync(resolvedTexturePath);
+  const texture = await loadTextureAsyncWithFallback(resolvedTexturePath, {
+    loader: textureLoader,
+    label: 'road texture'
+  });
   texture.wrapS = THREE.RepeatWrapping;
   texture.wrapT = THREE.RepeatWrapping;
   texture.anisotropy = Math.max(texture.anisotropy || 1, 8);

--- a/src/scene/materials.js
+++ b/src/scene/materials.js
@@ -1,5 +1,6 @@
 import * as THREE from 'three';
 import { resolveAssetUrl } from '../utils/asset-paths.js';
+import { loadTextureWithFallback } from '../utils/fail-soft-loaders.js';
 
 const fallbackMaterial = new THREE.MeshStandardMaterial({
   color: 0xbfbfbf,
@@ -15,74 +16,89 @@ export function loadBuildingTextures() {
     roughness: 0.75,
     metalness: 0.0
   });
-
-  loader.load(
-    resolveAssetUrl('assets/textures/marble.jpg'),
-    (texture) => {
+  const applyMarbleFallback = () => {
+    marbleMat.map = null;
+    marbleMat.color.set(0xdedede);
+    marbleMat.needsUpdate = true;
+  };
+  loadTextureWithFallback(resolveAssetUrl('assets/textures/marble.jpg'), {
+    loader,
+    label: 'marble texture',
+    fallbackColor: 0xdedede,
+    onLoad: (texture, { fallback }) => {
+      if (fallback) {
+        applyMarbleFallback();
+        return;
+      }
       texture.wrapS = THREE.RepeatWrapping;
       texture.wrapT = THREE.RepeatWrapping;
       texture.repeat.set(2, 2);
       texture.anisotropy = Math.max(texture.anisotropy || 0, 8);
-      texture.colorSpace = THREE.SRGBColorSpace;
-      texture.needsUpdate = true;
       marbleMat.map = texture;
       marbleMat.color.set(0xffffff);
       marbleMat.needsUpdate = true;
     },
-    undefined,
-    (error) => {
-      console.warn('[materials] marble.jpg missing; will use color.', error);
-    }
-  );
+    onFallback: applyMarbleFallback
+  });
 
   const roofMat = new THREE.MeshStandardMaterial({
     color: 0x8b3a2f,
     roughness: 0.9,
     metalness: 0.0
   });
-
-  loader.load(
-    resolveAssetUrl('assets/textures/roof_tiles.jpg'),
-    (texture) => {
+  const applyRoofFallback = () => {
+    roofMat.map = null;
+    roofMat.color.set(0x8b3a2f);
+    roofMat.needsUpdate = true;
+  };
+  loadTextureWithFallback(resolveAssetUrl('assets/textures/roof_tiles.jpg'), {
+    loader,
+    label: 'roof texture',
+    fallbackColor: 0x8b3a2f,
+    onLoad: (texture, { fallback }) => {
+      if (fallback) {
+        applyRoofFallback();
+        return;
+      }
       texture.wrapS = THREE.RepeatWrapping;
       texture.wrapT = THREE.RepeatWrapping;
       texture.repeat.set(2, 2);
       texture.anisotropy = Math.max(texture.anisotropy || 0, 8);
-      texture.colorSpace = THREE.SRGBColorSpace;
-      texture.needsUpdate = true;
       roofMat.map = texture;
       roofMat.color.set(0xffffff);
       roofMat.needsUpdate = true;
     },
-    undefined,
-    (error) => {
-      console.warn('[materials] roof_tiles.jpg missing; will use color.', error);
-    }
-  );
+    onFallback: applyRoofFallback
+  });
 
   const cityWallMat = new THREE.MeshStandardMaterial({
     color: 0xb8a27c,
     roughness: 0.82,
     metalness: 0.04
   });
-
-  loader.load(
-    new URL('../../public/assets/textures/city_wall.jpg', import.meta.url).href,
-    (texture) => {
+  const applyCityWallFallback = () => {
+    cityWallMat.map = null;
+    cityWallMat.color.set(0xb8a27c);
+    cityWallMat.needsUpdate = true;
+  };
+  loadTextureWithFallback(resolveAssetUrl('assets/textures/city_wall.jpg'), {
+    loader,
+    label: 'city wall texture',
+    fallbackColor: 0xb8a27c,
+    onLoad: (texture, { fallback }) => {
+      if (fallback) {
+        applyCityWallFallback();
+        return;
+      }
       texture.wrapS = THREE.RepeatWrapping;
       texture.wrapT = THREE.RepeatWrapping;
       texture.anisotropy = Math.max(texture.anisotropy || 0, 8);
-      texture.colorSpace = THREE.SRGBColorSpace;
-      texture.needsUpdate = true;
       cityWallMat.map = texture;
       cityWallMat.color.set(0xffffff);
       cityWallMat.needsUpdate = true;
     },
-    undefined,
-    (error) => {
-      console.warn('[materials] city_wall.jpg missing; will use color.', error);
-    }
-  );
+    onFallback: applyCityWallFallback
+  });
 
   return { marbleMat, roofMat, cityWallMat };
 }

--- a/src/utils/fail-soft-loaders.js
+++ b/src/utils/fail-soft-loaders.js
@@ -1,0 +1,267 @@
+import * as THREE from 'three';
+
+const DEFAULT_TEXTURE_FALLBACK_COLOR = 0x999999;
+const DEFAULT_MODEL_FALLBACK_COLOR = 0xff4477;
+
+function toColorInstance(color) {
+  if (color instanceof THREE.Color) {
+    return color;
+  }
+  return new THREE.Color(color ?? DEFAULT_TEXTURE_FALLBACK_COLOR);
+}
+
+function ensureColorSpace(texture) {
+  if (!texture) return;
+  if ('colorSpace' in texture && THREE.SRGBColorSpace) {
+    texture.colorSpace = THREE.SRGBColorSpace;
+  } else if ('encoding' in texture && THREE.sRGBEncoding) {
+    texture.encoding = THREE.sRGBEncoding;
+  }
+}
+
+function createFallbackImageData(color) {
+  const c = toColorInstance(color);
+  const data = new Uint8Array([
+    Math.round(THREE.MathUtils.clamp(c.r, 0, 1) * 255),
+    Math.round(THREE.MathUtils.clamp(c.g, 0, 1) * 255),
+    Math.round(THREE.MathUtils.clamp(c.b, 0, 1) * 255),
+    255
+  ]);
+  return { data, width: 1, height: 1 };
+}
+
+function createSolidColorTexture({ color = DEFAULT_TEXTURE_FALLBACK_COLOR, name } = {}) {
+  const image = createFallbackImageData(color);
+  const texture = new THREE.DataTexture(image.data, image.width, image.height, THREE.RGBAFormat);
+  texture.name = name ?? 'FallbackTexture';
+  ensureColorSpace(texture);
+  texture.needsUpdate = true;
+  texture.userData = {
+    ...(texture.userData || {}),
+    isFallbackTexture: true
+  };
+  return texture;
+}
+
+function adoptTexture(target, source) {
+  if (!target || !source) return target;
+  const originalUuid = target.uuid;
+  const originalId = target.id;
+  target.copy(source);
+  target.uuid = originalUuid;
+  target.id = originalId;
+  target.needsUpdate = true;
+  return target;
+}
+
+function formatHex(color) {
+  return toColorInstance(color).getHexString();
+}
+
+export function loadTextureWithFallback(url, options = {}) {
+  const {
+    loader = new THREE.TextureLoader(),
+    fallbackColor = DEFAULT_TEXTURE_FALLBACK_COLOR,
+    label = 'texture',
+    name = undefined,
+    onLoad = undefined,
+    onFallback = undefined
+  } = options;
+
+  const texture = createSolidColorTexture({
+    color: fallbackColor,
+    name: name ?? `${label}::fallback`
+  });
+
+  texture.userData = {
+    ...(texture.userData || {}),
+    sourceUrl: url ?? null,
+    isFallbackTexture: true
+  };
+
+  const notifyFallback = (error) => {
+    if (typeof onFallback === 'function') {
+      try {
+        onFallback(texture, error ?? null);
+      } catch (callbackError) {
+        console.warn('[asset-loader] onFallback callback threw an error.', callbackError);
+      }
+    }
+    if (typeof onLoad === 'function') {
+      try {
+        onLoad(texture, { fallback: true, url, error: error ?? null });
+      } catch (callbackError) {
+        console.warn('[asset-loader] onLoad callback threw an error.', callbackError);
+      }
+    }
+  };
+
+  if (!url) {
+    console.warn(
+      `[asset-loader] Missing URL for ${label}; using fallback #${formatHex(fallbackColor)}.`
+    );
+    notifyFallback(new Error('Missing texture URL.'));
+    return texture;
+  }
+
+  loader.load(
+    url,
+    (loaded) => {
+      try {
+        adoptTexture(texture, loaded);
+        texture.userData = {
+          ...(texture.userData || {}),
+          sourceUrl: url,
+          isFallbackTexture: false
+        };
+        if (typeof onLoad === 'function') {
+          onLoad(texture, { fallback: false, url, source: loaded });
+        }
+      } catch (error) {
+        console.warn(
+          `[asset-loader] Texture post-processing failed for ${label} at ${url}; retaining fallback.`,
+          error
+        );
+        texture.userData.isFallbackTexture = true;
+        notifyFallback(error);
+      }
+    },
+    undefined,
+    (error) => {
+      texture.userData = {
+        ...(texture.userData || {}),
+        sourceUrl: url,
+        isFallbackTexture: true
+      };
+      console.warn(
+        `[asset-loader] Failed to load ${label} at ${url}; using fallback #${formatHex(fallbackColor)}.`,
+        error
+      );
+      notifyFallback(error);
+    }
+  );
+
+  return texture;
+}
+
+export async function loadTextureAsyncWithFallback(url, options = {}) {
+  const {
+    loader = new THREE.TextureLoader(),
+    fallbackColor = DEFAULT_TEXTURE_FALLBACK_COLOR,
+    label = 'texture'
+  } = options;
+
+  if (!url) {
+    console.warn(
+      `[asset-loader] Missing URL for ${label}; using fallback #${formatHex(fallbackColor)}.`
+    );
+    return createSolidColorTexture({ color: fallbackColor, name: `${label}::fallback` });
+  }
+
+  try {
+    const texture = await loader.loadAsync(url);
+    texture.userData = {
+      ...(texture.userData || {}),
+      sourceUrl: url,
+      isFallbackTexture: false
+    };
+    ensureColorSpace(texture);
+    texture.needsUpdate = true;
+    return texture;
+  } catch (error) {
+    console.warn(
+      `[asset-loader] Failed to load ${label} at ${url}; using fallback #${formatHex(fallbackColor)}.`,
+      error
+    );
+    const fallback = createSolidColorTexture({ color: fallbackColor, name: `${label}::fallback` });
+    fallback.userData.sourceUrl = url;
+    return fallback;
+  }
+}
+
+function createFallbackMesh({ color = DEFAULT_MODEL_FALLBACK_COLOR, size = 1, label = 'asset' } = {}) {
+  const geometry = new THREE.BoxGeometry(size, size, size);
+  const material = new THREE.MeshStandardMaterial({
+    color,
+    roughness: 0.8,
+    metalness: 0.1,
+    emissiveIntensity: 0
+  });
+  const mesh = new THREE.Mesh(geometry, material);
+  mesh.name = `${label}::fallback-mesh`;
+  mesh.userData = {
+    ...(mesh.userData || {}),
+    isFallbackAsset: true
+  };
+  return mesh;
+}
+
+function createFallbackGltf({ color, label } = {}) {
+  const mesh = createFallbackMesh({ color, label });
+  const group = new THREE.Group();
+  group.name = label ? `${label} (missing asset)` : 'MissingAsset';
+  group.add(mesh);
+  group.userData = {
+    ...(group.userData || {}),
+    isFallbackAsset: true
+  };
+  return {
+    scene: group,
+    scenes: [group],
+    animations: [],
+    parser: null,
+    userData: {
+      isFallbackAsset: true
+    }
+  };
+}
+
+export async function loadGltfWithFallback(loader, url, options = {}) {
+  const { label = 'model', fallbackColor = DEFAULT_MODEL_FALLBACK_COLOR } = options;
+  if (!loader || typeof loader.loadAsync !== 'function') {
+    throw new Error('loadGltfWithFallback requires a loader that supports loadAsync.');
+  }
+
+  if (!url) {
+    console.warn(
+      `[asset-loader] Missing URL for ${label}; substituting fallback primitive #${formatHex(
+        fallbackColor
+      )}.`
+    );
+    return createFallbackGltf({ color: fallbackColor, label });
+  }
+
+  try {
+    const gltf = await loader.loadAsync(url);
+    gltf.userData = {
+      ...(gltf.userData || {}),
+      sourceUrl: url,
+      isFallbackAsset: false
+    };
+    if (gltf.scene) {
+      gltf.scene.userData = {
+        ...(gltf.scene.userData || {}),
+        sourceUrl: url,
+        isFallbackAsset: false
+      };
+    }
+    return gltf;
+  } catch (error) {
+    console.warn(
+      `[asset-loader] Failed to load ${label} at ${url}; substituting fallback primitive #${formatHex(
+        fallbackColor
+      )}.`,
+      error
+    );
+    const fallback = createFallbackGltf({ color: fallbackColor, label });
+    fallback.userData.sourceUrl = url;
+    return fallback;
+  }
+}
+
+export {
+  DEFAULT_TEXTURE_FALLBACK_COLOR,
+  DEFAULT_MODEL_FALLBACK_COLOR,
+  createSolidColorTexture,
+  ensureColorSpace
+};


### PR DESCRIPTION
## Summary
- Hardened asset base URL detection to support relative, env-provided, and subpath deployments while normalizing public/ prefixes at call sites.
- Added reusable fail-soft texture/model loader utilities and applied them across ground, road, building, and sky systems to provide visible fallbacks when assets miss.
- Updated photo skydome and material loading flows to reuse the new helpers, cache fallbacks safely, and keep scenes interactive when assets fail to fetch.

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d7232cc9fc8327b262f7be8058e648