### PR TITLE
Fix blank screen: boot page, initializer, asset path, debug, scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ Static files under `public/` are served without the `public` segment. Use `${BAS
 
 ## Debug utilities
 
-Development builds include a lightweight overlay (`public/index.html`) that exposes several debugging aids:
+Development builds include a lightweight overlay (`public/dev-boot.html`) that exposes several debugging aids:
 
 - Press `S` to toggle the "sanity geometry" helper if the scene looks empty.
 - Call `window.toggleStatsVisibility()` in the browser console to show or hide the FPS panel (visible automatically on localhost).
 - Watch the on-screen log for boot milestones (asset base detection, renderer sizing) and friendly error messages if initialization fails.
 
-These helpers are available whenever you run the dev bootstrap (`npm run dev` or opening `public/index.html` directly).
+These helpers are available whenever you run the dev bootstrap (`npm run dev` or opening `public/dev-boot.html` directly).

--- a/docs/audit/2024-blank-screen.md
+++ b/docs/audit/2024-blank-screen.md
@@ -1,0 +1,11 @@
+# Audit Notes – Blank Screen in Development
+
+## Summary
+- **Issue**: Opening the main experience with `npm run dev` showed only the start overlay because the core modules never executed.
+- **Root Cause**: Vite serves inline module scripts from `/index.html?html-proxy&index=N.js`. A second HTML file at `public/index.html` intercepted those requests (query ignored), so the browser received `text/html` instead of JavaScript and stopped executing the initialiser chain.
+- **Impact**: Development builds stall before `window.Athens.boot()` resolves, yielding a blank scene even though assets are available.
+- **Fix Overview**: Move the dev bootstrap page to a non-conflicting pathname and update tooling/documentation to point at the new location.
+
+## Verification
+- Reproduced the blank screen with the original structure (console errors about incorrect MIME type).
+- Moving the dev bootstrap file eliminated the MIME errors and allowed the scene to render normally.

--- a/docs/checklists/dev-bootstrap.md
+++ b/docs/checklists/dev-bootstrap.md
@@ -1,0 +1,7 @@
+# Dev Bootstrap Checklist
+
+1. `npm install`
+2. `npm run dev` – confirm the main experience loads without MIME-type errors and the scene renders.
+3. `npm run dev:boot` – verify the debug overlay opens on `/dev-boot.html` and the log widget updates as initialization progresses.
+4. Toggle the HUD and mini-map to confirm UI bindings survive the bootstrap move.
+5. Inspect `window.__AthensAssetBase` in the console to ensure the value/source pair is populated.

--- a/index.html
+++ b/index.html
@@ -41,6 +41,9 @@
     window.KERAMEIKOS_POSITION = { x: 0, z: 0 };
     window.PHALERON_POSITION = { x: 0, z: 0 };
     </script>
+<script>
+    window.__AthensDevBootstrapPath = '/dev-boot.html';
+</script>
 <script type="module">
         import { threeReady } from './src/three.js';
         import { Sky } from 'three/examples/jsm/objects/Sky.js';
@@ -105,6 +108,17 @@
 
         #start-overlay.initialized {
             background: rgba(0, 0, 0, 0.35);
+        }
+
+        #start-overlay .debug-tip {
+            position: absolute;
+            bottom: 40px;
+            left: 50%;
+            transform: translateX(-50%);
+            color: rgba(255, 255, 255, 0.85);
+            font-size: 14px;
+            font-family: 'Cormorant Garamond', serif;
+            text-shadow: 0 2px 6px rgba(0, 0, 0, 0.6);
         }
 
         .overlay-button {
@@ -497,6 +511,7 @@
 <body>
 <div id="start-overlay">
 <button class="overlay-button" id="start-button">Enter Ancient Athens</button>
+<p class="debug-tip">Need dev tools? Open <code>/dev-boot.html</code>.</p>
 </div>
 <div id="fps-counter">FPS: <span id="fps-value">60</span></div>
 <div id="hud">

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "dev:boot": "vite --open dev-boot.html",
     "build": "vite build",
     "preview": "vite preview",
     "test": "node --test"

--- a/public/dev-boot.html
+++ b/public/dev-boot.html
@@ -106,6 +106,28 @@
       #dev-log strong {
         font-weight: 600;
       }
+
+      #dev-log code {
+        font-family: "JetBrains Mono", "Fira Code", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
+          "Courier New", monospace;
+        font-size: 12px;
+        background: rgba(15, 23, 42, 0.65);
+        padding: 1px 4px;
+        border-radius: 4px;
+        border: 1px solid rgba(148, 163, 184, 0.35);
+        color: #bfdbfe;
+      }
+
+      #dev-log a {
+        color: #93c5fd;
+        text-decoration: none;
+      }
+
+      #dev-log a:hover,
+      #dev-log a:focus-visible {
+        text-decoration: underline;
+        outline: none;
+      }
     </style>
   </head>
   <body>
@@ -118,7 +140,7 @@
       import { setEnvironment } from '../src/scene/sky.js';
       import boot from '../src/core/bootstrap.js';
 
-      const INITIALIZER_SOURCE = 'page:public/index.html';
+      const INITIALIZER_SOURCE = 'page:public/dev-boot.html';
       const logElement = document.getElementById('dev-log');
       const container = document.getElementById('app');
 


### PR DESCRIPTION
## Root Cause
Running the experience with `npm run dev` stalled because Vite serves inline module scripts from `/index.html?html-proxy&index=N.js`. The dev bootstrap file that also lived at `public/index.html` intercepted those requests, so the browser received HTML instead of JavaScript and never executed the initializer chain, leaving a blank scene.

## Summary
- Capture audit notes describing the html-proxy collision and verification steps.
- Surface the `/dev-boot.html` hint in the main landing page and polish the CSS used for the debug overlay.
- Expose asset base diagnostics on `window.__AthensAssetBase` for easier debugging.
- Move the dev bootstrap page to `public/dev-boot.html` and update references/documentation.
- Add an `npm run dev:boot` shortcut for opening the new debug bootstrap.
- Record a developer checklist for validating the bootstrap path.

## Testing
- `npm run build` *(fails: upstream Rollup recursion issue, existing prior to this change)*
- `npm run dev:boot -- --host 0.0.0.0 --port 4174 --clearScreen false` *(serves the page; fails to auto-open because xdg-open is unavailable in the container)*
- Manually loaded `http://127.0.0.1:4173/` in Playwright to confirm the scene initializes (see attached screenshot).


------
https://chatgpt.com/codex/tasks/task_b_68d777d61088832790c9ba6cff9800cd