### PR TITLE
Normalize Vite base path handling

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -3,10 +3,15 @@ import { fileURLToPath, URL } from 'node:url';
 
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '');
-  const base = env.VITE_BASE ?? env.BASE ?? '/';
+  const rawBase = env.VITE_BASE ?? env.BASE ?? '/';
+  const normalizedBase = (() => {
+    if (!rawBase) return '/';
+    const withLeading = rawBase.startsWith('/') ? rawBase : `/${rawBase}`;
+    return withLeading.endsWith('/') ? withLeading : `${withLeading}/`;
+  })();
 
   return {
-    base,
+    base: normalizedBase,
     resolve: {
       alias: {
         '@': fileURLToPath(new URL('./src', import.meta.url)),


### PR DESCRIPTION
## Summary
- normalize the computed Vite base path so GitHub Pages-style subpaths always include leading and trailing slashes

## Testing
- npm run build *(fails: Maximum call stack size exceeded in rollup)*

------
https://chatgpt.com/codex/tasks/task_b_68d77a71c9d88327a8a1c4e3edffae9d