### PR TITLE
Refactor texture fallback handling to avoid read-only mutations

### DIFF
--- a/src/ground/dirt.js
+++ b/src/ground/dirt.js
@@ -35,10 +35,27 @@ function loadBaseTexture() {
       loader: textureLoader,
       label: 'ground dirt texture',
       fallbackColor: 0x6b5a45,
-      onLoad: (texture, { fallback }) => {
+      onLoad: (texture, { fallback, fallbackTexture }) => {
         applySharedSettings(texture);
-        if (!fallback) {
+        if (fallback) {
           flushPendingTextureUpdates(texture);
+          return;
+        }
+        const previous = cachedBaseTexture;
+        cachedBaseTexture = texture;
+        flushPendingTextureUpdates(texture);
+        if (fallbackTexture && fallbackTexture !== texture) {
+          try {
+            fallbackTexture.dispose?.();
+          } catch {
+            /* ignore */
+          }
+        } else if (previous && previous !== texture) {
+          try {
+            previous.dispose?.();
+          } catch {
+            /* ignore */
+          }
         }
       },
       onFallback: (texture) => {
@@ -56,6 +73,7 @@ function loadBaseTexture() {
 
 function configureTexture(baseTexture, { repeat, anisotropy }) {
   const texture = baseTexture.clone();
+  const isFallback = Boolean(baseTexture?.userData?.isFallbackTexture);
   if (baseTexture?.image) {
     texture.image = baseTexture.image;
   }
@@ -73,7 +91,8 @@ function configureTexture(baseTexture, { repeat, anisotropy }) {
 
   if (baseTexture.image) {
     texture.needsUpdate = true;
-  } else {
+  }
+  if (!baseTexture.image || isFallback) {
     pendingTextureUpdates.add(texture);
   }
 


### PR DESCRIPTION
## Summary
- add `applyLoadedTexture` helper to swap in loaded textures without mutating DataTextures
- update fail-soft texture loader to use the helper metadata and streamline logging
- refresh ground and road loaders to swap textures and dispose fallbacks once the real image arrives

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d7c2b8ed848327a67f1237baa368df