### PR TITLE
chore: harden vite dev config

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -11,7 +11,11 @@ export default defineConfig(({ mode }) => {
   })();
 
   return {
+    cacheDir: 'node_modules/.vite-athens',
     base: normalizedBase,
+    optimizeDeps: {
+      force: true,
+    },
     resolve: {
       alias: {
         '@': fileURLToPath(new URL('./src', import.meta.url)),
@@ -19,6 +23,10 @@ export default defineConfig(({ mode }) => {
     },
     server: {
       open: true,
+      strictPort: true,
+      headers: {
+        'Cache-Control': 'no-store',
+      },
     },
   };
 });


### PR DESCRIPTION
## Summary
- set a dedicated Vite cache directory and force dependency optimization during dev
- tighten dev server caching headers and port handling to avoid reuse of stale state

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d7cae388f8832794f036c9eb5ec205