### PR TITLE
Fix fail-soft loader export and add landing CTA

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Ancient Athens</title>
+    <style>
+      :root {
+        color-scheme: dark light;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      html,
+      body {
+        margin: 0;
+        min-height: 100vh;
+        font-family: 'Cinzel', 'Times New Roman', serif;
+        background: radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.1), transparent 55%),
+          linear-gradient(135deg, #0f172a, #1e293b);
+        color: #f8fafc;
+      }
+
+      body {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 2rem;
+        text-align: center;
+      }
+
+      main {
+        display: flex;
+        flex-direction: column;
+        gap: 1.5rem;
+        align-items: center;
+        padding: 2.5rem 3rem;
+        border-radius: 1.25rem;
+        background: rgba(15, 23, 42, 0.75);
+        box-shadow: 0 25px 50px -12px rgba(15, 23, 42, 0.8);
+        backdrop-filter: blur(12px);
+        max-width: 32rem;
+      }
+
+      h1 {
+        margin: 0;
+        font-size: clamp(2rem, 5vw, 2.75rem);
+        letter-spacing: 0.04em;
+      }
+
+      a.cta {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        padding: 0.85rem 2.75rem;
+        border-radius: 999px;
+        font-size: 1.125rem;
+        font-weight: 600;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        text-decoration: none;
+        color: #0f172a;
+        background: linear-gradient(135deg, #fbbf24, #f97316);
+        box-shadow: 0 18px 40px -16px rgba(251, 191, 36, 0.75);
+        transition: transform 0.2s ease, box-shadow 0.2s ease;
+      }
+
+      a.cta:hover,
+      a.cta:focus-visible {
+        transform: translateY(-2px);
+        box-shadow: 0 22px 48px -16px rgba(249, 115, 22, 0.8);
+        outline: none;
+      }
+
+      p {
+        margin: 0;
+        font-size: 1.05rem;
+        line-height: 1.6;
+        color: rgba(226, 232, 240, 0.86);
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Ancient Athens Awaits</h1>
+      <p>Step through time and experience the city in its classical glory.</p>
+      <a class="cta" href="dev-boot.html">Enter Ancient Athens</a>
+    </main>
+  </body>
+</html>

--- a/src/utils/fail-soft-loaders.js
+++ b/src/utils/fail-soft-loaders.js
@@ -48,7 +48,7 @@ function createSolidColorTexture({ color = DEFAULT_TEXTURE_FALLBACK_COLOR, name 
  * fallback map with the real texture instead of mutating the DataTexture.
  * This avoids writing to read-only fields when the loader resolves.
  */
-export function applyLoadedTexture(
+function applyLoadedTexture(
   material,
   mapKey,
   loadedTex,


### PR DESCRIPTION
## Summary
- fix the duplicate export of applyLoadedTexture in the fail-soft loader helpers
- add a minimal public landing page with an "Enter Ancient Athens" call-to-action linking to the dev boot experience

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d7d21cf568832796acf3293188d404