### PR TITLE
Fix fail-soft loader exports and landing link

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -86,7 +86,7 @@
     <main>
       <h1>Ancient Athens Awaits</h1>
       <p>Step through time and experience the city in its classical glory.</p>
-      <a class="cta" href="dev-boot.html">Enter Ancient Athens</a>
+      <a class="cta" href="./dev-boot.html">Enter Ancient Athens</a>
     </main>
   </body>
 </html>

--- a/src/utils/fail-soft-loaders.js
+++ b/src/utils/fail-soft-loaders.js
@@ -86,7 +86,7 @@ function formatHex(color) {
   return toColorInstance(color).getHexString();
 }
 
-export function loadTextureWithFallback(url, options = {}) {
+function loadTextureWithFallback(url, options = {}) {
   const {
     loader = new THREE.TextureLoader(),
     fallbackColor = DEFAULT_TEXTURE_FALLBACK_COLOR,
@@ -191,7 +191,7 @@ export function loadTextureWithFallback(url, options = {}) {
   return texture;
 }
 
-export async function loadTextureAsyncWithFallback(url, options = {}) {
+async function loadTextureAsyncWithFallback(url, options = {}) {
   const {
     loader = new THREE.TextureLoader(),
     fallbackColor = DEFAULT_TEXTURE_FALLBACK_COLOR,
@@ -264,7 +264,7 @@ function createFallbackGltf({ color, label } = {}) {
   };
 }
 
-export async function loadGltfWithFallback(loader, url, options = {}) {
+async function loadGltfWithFallback(loader, url, options = {}) {
   const { label = 'model', fallbackColor = DEFAULT_MODEL_FALLBACK_COLOR } = options;
   if (!loader || typeof loader.loadAsync !== 'function') {
     throw new Error('loadGltfWithFallback requires a loader that supports loadAsync.');
@@ -312,5 +312,8 @@ export {
   DEFAULT_MODEL_FALLBACK_COLOR,
   createSolidColorTexture,
   ensureColorSpace,
-  applyLoadedTexture
+  applyLoadedTexture,
+  loadTextureWithFallback,
+  loadTextureAsyncWithFallback,
+  loadGltfWithFallback
 };


### PR DESCRIPTION
## Summary
- ensure the fail-soft loader helpers are exported once through the module export list to avoid duplicate export parse errors
- point the landing page CTA at the dev boot entry so the experience starts when clicking “Enter Ancient Athens”

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d7d57e48648327b8dd5243e227458d