### PR TITLE
Fix landing button and deduplicate texture loader export

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6,87 +6,82 @@
     <title>Ancient Athens</title>
     <style>
       :root {
-        color-scheme: dark light;
+        color-scheme: light dark;
       }
 
       * {
         box-sizing: border-box;
       }
 
-      html,
       body {
         margin: 0;
         min-height: 100vh;
-        font-family: 'Cinzel', 'Times New Roman', serif;
-        background: radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.1), transparent 55%),
-          linear-gradient(135deg, #0f172a, #1e293b);
-        color: #f8fafc;
-      }
-
-      body {
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        padding: 2rem;
-        text-align: center;
+        display: grid;
+        place-items: center;
+        font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        background: radial-gradient(circle at top, rgba(255, 255, 255, 0.85), rgba(255, 255, 255, 0))
+            top/100% 50% no-repeat,
+          linear-gradient(160deg, #0f172a, #1d3557);
+        color: #0f172a;
       }
 
       main {
-        display: flex;
-        flex-direction: column;
-        gap: 1.5rem;
-        align-items: center;
-        padding: 2.5rem 3rem;
-        border-radius: 1.25rem;
-        background: rgba(15, 23, 42, 0.75);
-        box-shadow: 0 25px 50px -12px rgba(15, 23, 42, 0.8);
-        backdrop-filter: blur(12px);
-        max-width: 32rem;
+        text-align: center;
+        display: grid;
+        gap: 1.25rem;
+        padding: 2.5rem 2rem;
+        border-radius: 1rem;
+        background: rgba(248, 250, 252, 0.92);
+        box-shadow: 0 1.5rem 3rem -2rem rgba(15, 23, 42, 0.8);
       }
 
       h1 {
         margin: 0;
-        font-size: clamp(2rem, 5vw, 2.75rem);
+        font-size: clamp(1.75rem, 4vw, 2.5rem);
         letter-spacing: 0.04em;
       }
 
-      a.cta {
+      p {
+        margin: 0;
+        max-width: 28rem;
+        justify-self: center;
+        color: rgba(15, 23, 42, 0.8);
+        line-height: 1.6;
+      }
+
+      a.enter-button {
         display: inline-flex;
         align-items: center;
         justify-content: center;
-        padding: 0.85rem 2.75rem;
+        padding: 0.9rem 2.5rem;
         border-radius: 999px;
-        font-size: 1.125rem;
+        font-size: 1.1rem;
         font-weight: 600;
         letter-spacing: 0.08em;
         text-transform: uppercase;
         text-decoration: none;
         color: #0f172a;
-        background: linear-gradient(135deg, #fbbf24, #f97316);
-        box-shadow: 0 18px 40px -16px rgba(251, 191, 36, 0.75);
+        background: linear-gradient(135deg, #ffd166, #f77f00);
         transition: transform 0.2s ease, box-shadow 0.2s ease;
+        box-shadow: 0 1rem 2rem -1.25rem rgba(247, 127, 0, 0.75);
       }
 
-      a.cta:hover,
-      a.cta:focus-visible {
+      a.enter-button:focus-visible {
+        outline: 3px solid rgba(15, 23, 42, 0.75);
+        outline-offset: 4px;
+      }
+
+      a.enter-button:hover {
         transform: translateY(-2px);
-        box-shadow: 0 22px 48px -16px rgba(249, 115, 22, 0.8);
-        outline: none;
-      }
-
-      p {
-        margin: 0;
-        font-size: 1.05rem;
-        line-height: 1.6;
-        color: rgba(226, 232, 240, 0.86);
+        box-shadow: 0 1.2rem 2.4rem -1.1rem rgba(247, 127, 0, 0.85);
       }
     </style>
   </head>
   <body>
     <main>
-      <h1>Ancient Athens Awaits</h1>
-      <p>Step through time and experience the city in its classical glory.</p>
-      <a class="cta" href="./dev-boot.html">Enter Ancient Athens</a>
+      <h1>Welcome to Ancient Athens</h1>
+      <p>Launch the interactive experience of the classical city, optimized for every visit.</p>
+      <a class="enter-button" href="./dev-boot.html">Enter Ancient Athens</a>
     </main>
   </body>
 </html>

--- a/src/utils/fail-soft-loaders.js
+++ b/src/utils/fail-soft-loaders.js
@@ -48,7 +48,7 @@ function createSolidColorTexture({ color = DEFAULT_TEXTURE_FALLBACK_COLOR, name 
  * fallback map with the real texture instead of mutating the DataTexture.
  * This avoids writing to read-only fields when the loader resolves.
  */
-function applyLoadedTexture(
+export function applyLoadedTexture(
   material,
   mapKey,
   loadedTex,
@@ -312,7 +312,6 @@ export {
   DEFAULT_MODEL_FALLBACK_COLOR,
   createSolidColorTexture,
   ensureColorSpace,
-  applyLoadedTexture,
   loadTextureWithFallback,
   loadTextureAsyncWithFallback,
   loadGltfWithFallback


### PR DESCRIPTION
## Summary
- refresh the public landing page with a centered "Enter Ancient Athens" button pointing at the dev boot entry point
- deduplicate the applyLoadedTexture export in fail-soft-loaders to avoid syntax errors during parsing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d7dada8b44832792b757ff82799037