### PR TITLE
Redirect landing entry to boot build

### DIFF
--- a/index.html
+++ b/index.html
@@ -510,7 +510,7 @@
 </head>
 <body>
 <div id="start-overlay">
-<button class="overlay-button" id="start-button">Enter Ancient Athens</button>
+<a class="overlay-button" id="enter-btn" href="./boot.html">Enter Ancient Athens</a>
 <p class="debug-tip">Need dev tools? Open <code>/dev-boot.html</code>.</p>
 </div>
 <div id="fps-counter">FPS: <span id="fps-value">60</span></div>
@@ -7433,7 +7433,7 @@ world.addBody(archBody);
         }
 
         function addEventListeners() {
-            const startButton = document.getElementById('start-button');
+            const startButton = document.getElementById('enter-btn');
             const startOverlay = document.getElementById('start-overlay');
             let startSequenceInProgress = false;
 
@@ -7529,9 +7529,7 @@ world.addBody(archBody);
             };
 
             const triggerStartExperience = () => {
-                startExperience().catch((error) => {
-                    console.error('Unexpected error while starting the experience:', error);
-                });
+                window.location.href = './boot.html';
             };
 
             const isStartOverlayVisible = () => {

--- a/public/index.html
+++ b/public/index.html
@@ -81,7 +81,7 @@
     <main>
       <h1>Welcome to Ancient Athens</h1>
       <p>Launch the interactive experience of the classical city, optimized for every visit.</p>
-      <a class="enter-button" href="./dev-boot.html">Enter Ancient Athens</a>
+      <a class="enter-button" href="./boot.html">Enter Ancient Athens</a>
     </main>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- update the main landing overlay button to point to the new boot entry
- retarget the public landing link to the boot build

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d7e35ba6f08327ac7341d54192ec07