### PR TITLE
Configure Vite for Athens subpath build

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,33 +1,31 @@
-import { defineConfig, loadEnv } from 'vite';
+import { defineConfig } from 'vite';
 import { fileURLToPath, URL } from 'node:url';
 
-export default defineConfig(({ mode }) => {
-  const env = loadEnv(mode, process.cwd(), '');
-  const rawBase = env.VITE_BASE ?? env.BASE ?? '/';
-  const normalizedBase = (() => {
-    if (!rawBase) return '/';
-    const withLeading = rawBase.startsWith('/') ? rawBase : `/${rawBase}`;
-    return withLeading.endsWith('/') ? withLeading : `${withLeading}/`;
-  })();
-
-  return {
-    cacheDir: 'node_modules/.vite-athens',
-    base: normalizedBase,
-    optimizeDeps: {
-      force: true,
+export default defineConfig(({ mode }) => ({
+  base: '/Athens/',
+  cacheDir: 'node_modules/.vite-athens',
+  optimizeDeps: {
+    force: true,
+  },
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
     },
-    resolve: {
-      alias: {
-        '@': fileURLToPath(new URL('./src', import.meta.url)),
+  },
+  server: {
+    port: 4173,
+    open: true,
+    strictPort: true,
+    headers: {
+      'Cache-Control': 'no-store',
+    },
+  },
+  build: {
+    rollupOptions: {
+      input: {
+        index: 'index.html',
+        boot: 'boot.html',
       },
     },
-    server: {
-      port: 4173,
-      open: true,
-      strictPort: true,
-      headers: {
-        'Cache-Control': 'no-store',
-      },
-    },
-  };
-});
+  },
+}));


### PR DESCRIPTION
## Summary
- set the Vite base path to `/Athens/` and enable cache reuse via a dedicated cache directory
- retain existing resolve and dev server settings while enforcing strict port and no-store cache headers
- configure Rollup inputs to build both index and boot HTML entry points

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d7e42962208327aa820bca03dee9a2