### PR TITLE
Refactor three wrapper module into pure re-export

### DIFF
--- a/src/three.js
+++ b/src/three.js
@@ -1,14 +1,5 @@
+export * from 'three';
 import * as THREE from 'three';
-
-const globalScope = typeof globalThis !== 'undefined' ? globalThis : undefined;
-
-if (globalScope && !globalScope.THREE) {
-  try {
-    globalScope.THREE = THREE;
-  } catch (error) {
-    console.warn('Unable to expose THREE on the global scope:', error);
-  }
-}
 
 const threeReady = Promise.resolve(THREE);
 


### PR DESCRIPTION
## Summary
- convert src/three.js into a pure re-export of the three package
- remove global scope mutation while keeping the THREE and threeReady exports

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d84f93f59c8327b0dc0b9712e5eb2e