### PR TITLE
Fix three.js circular dependency by removing wrapper

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,11 +45,11 @@
     window.__AthensDevBootstrapPath = '/dev-boot.html';
 </script>
 <script type="module">
-        import { threeReady } from './src/three.js';
+        import * as THREE from 'three';
         import { Sky } from 'three/examples/jsm/objects/Sky.js';
 
         window.Sky = Sky;
-        window.threeJSReady = threeReady;
+        window.threeJSReady = Promise.resolve(THREE);
     </script>
 <style>
         @import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@400;600;700&family=Cormorant+Garamond:wght@300;400;600&display=swap');
@@ -614,7 +614,7 @@ const findFirstMaterial = (candidate, visited = new Set()) => {
     return null;
 };
 
-        import THREE from './src/three.js';
+        import * as THREE from 'three';
         import { makeTemple, makeStoa, makeTholos, makeAltar, MAT, setCityWallMaterial } from './src/building-kit.js';
         import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
         import { clone } from 'three/examples/jsm/utils/SkeletonUtils.js';
@@ -8354,7 +8354,7 @@ const asArray = (v) => (Array.isArray(v) ? v : (v == null ? [] : [v]));
   }
 </script>
 <script type="module">
-        import THREE from './src/three.js';
+        import * as THREE from 'three';
         import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
         import { clone } from 'three/examples/jsm/utils/SkeletonUtils.js';
         import { retargetBuildingMaterials } from './src/scene/materials.js';

--- a/src/audio/ambient-zones.js
+++ b/src/audio/ambient-zones.js
@@ -1,4 +1,4 @@
-import * as THREE from '@/three';
+import * as THREE from 'three';
 
 function clamp(value, min, max) {
   return Math.min(max, Math.max(min, value));

--- a/src/building-kit.js
+++ b/src/building-kit.js
@@ -1,4 +1,4 @@
-import * as THREE from '@/three';
+import * as THREE from 'three';
 import { getAssetBase, resolveAssetUrl } from './utils/asset-paths.js';
 import { loadTextureWithFallback } from './utils/fail-soft-loaders.js';
 

--- a/src/buildings-from-geojson.js
+++ b/src/buildings-from-geojson.js
@@ -1,4 +1,4 @@
-import * as THREE from '@/three';
+import * as THREE from 'three';
 import {
   makeTemple, makeStoa, makeTheatre, makeTholos, makeWallPath,
   makePropylon, makeBlock, makeAltar, makeExedra

--- a/src/entry/boot.ts
+++ b/src/entry/boot.ts
@@ -1,4 +1,4 @@
-import * as THREE from '@/three';
+import * as THREE from 'three';
 import { setupGround, updateTrees, initPerformanceStats } from '../main.js';
 import { setEnvironment } from '../scene/sky.js';
 import boot from '../core/bootstrap.js';

--- a/src/ground/dirt.js
+++ b/src/ground/dirt.js
@@ -1,4 +1,4 @@
-import * as THREE from '@/three';
+import * as THREE from 'three';
 import { resolveAssetUrl } from '../utils/asset-paths.js';
 import {
   loadTextureWithFallback,

--- a/src/ground/double-sided.js
+++ b/src/ground/double-sided.js
@@ -1,4 +1,4 @@
-import * as THREE from '@/three';
+import * as THREE from 'three';
 
 function applyDoubleSideToMaterial(material) {
   if (!material || typeof material !== 'object') return;

--- a/src/ground/grass.js
+++ b/src/ground/grass.js
@@ -1,4 +1,4 @@
-import * as THREE from '@/three';
+import * as THREE from 'three';
 import { resolveAssetUrl } from '../utils/asset-paths.js';
 import {
   loadTextureWithFallback,

--- a/src/ground/index.js
+++ b/src/ground/index.js
@@ -1,5 +1,5 @@
 // src/ground/index.js
-import * as THREE from '@/three';
+import * as THREE from 'three';
 import { createDirtGround } from './dirt.js';
 import { createGrassGround } from './grass.js';
 

--- a/src/horizon/mountainRim.js
+++ b/src/horizon/mountainRim.js
@@ -4,7 +4,7 @@
  * - Disable the rim by switching the HORIZON_ENABLE flag in the scene bootstrap.
  * - Designed to sit behind gameplay objects but in front of the sky for cheap depth layering.
  */
-import * as THREE from '@/three';
+import * as THREE from 'three';
 
 export function createSeededRandom(seed = 1) {
   let state = seed >>> 0;

--- a/src/landmarks-loader.js
+++ b/src/landmarks-loader.js
@@ -1,4 +1,4 @@
-import * as THREE from '@/three';
+import * as THREE from 'three';
 import { applyFeatureOffset } from './geo/featureOffsets.js';
 import { createFeatureLines } from './scene/feature-lines.js';
 import { applyCompressionToVector3 } from './world/scale.js';

--- a/src/roads/hybridRoads.js
+++ b/src/roads/hybridRoads.js
@@ -1,4 +1,4 @@
-import * as THREE from '@/three';
+import * as THREE from 'three';
 import { resolveAssetUrl } from '../utils/asset-paths.js';
 import { loadTextureAsyncWithFallback } from '../utils/fail-soft-loaders.js';
 

--- a/src/roads/hybridroads.js
+++ b/src/roads/hybridroads.js
@@ -1,4 +1,4 @@
-import * as THREE from '@/three';
+import * as THREE from 'three';
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 import { resolveAssetUrl } from '../utils/asset-paths.js';
 import {

--- a/src/roads/roadNetwork.js
+++ b/src/roads/roadNetwork.js
@@ -15,7 +15,7 @@
  * - scatterProps: enable prop scattering when hybridRoads integration is available.
  * - propsConfigPath: JSON config for prop scattering.
  */
-import * as THREE from '@/three';
+import * as THREE from 'three';
 import { resolveAssetUrl } from '../utils/asset-paths.js';
 
 const DEFAULT_OPTIONS = {

--- a/src/scene/city-wall.js
+++ b/src/scene/city-wall.js
@@ -1,4 +1,4 @@
-import * as THREE from '@/three';
+import * as THREE from 'three';
 import { makeWallPath, MAT } from '../building-kit.js';
 
 const WALL_HEIGHT = 10;

--- a/src/scene/dirt1.DISABLED.js
+++ b/src/scene/dirt1.DISABLED.js
@@ -1,4 +1,4 @@
-import * as THREE from '@/three';
+import * as THREE from 'three';
 import { resolveAssetUrl } from '../utils/asset-paths.js';
 
 export function createDirtGround({

--- a/src/scene/districts.js
+++ b/src/scene/districts.js
@@ -1,4 +1,4 @@
-import * as THREE from '@/three';
+import * as THREE from 'three';
 import { Line2 } from 'three/examples/jsm/lines/Line2.js';
 import { LineMaterial } from 'three/examples/jsm/lines/LineMaterial.js';
 import { LineGeometry } from 'three/examples/jsm/lines/LineGeometry.js';

--- a/src/scene/feature-lines.js
+++ b/src/scene/feature-lines.js
@@ -10,7 +10,7 @@
  * adjust the balance between day readability and nighttime glow.
  */
 
-import * as THREE from '@/three';
+import * as THREE from 'three';
 import { Line2 } from 'three/examples/jsm/lines/Line2.js';
 import { LineGeometry } from 'three/examples/jsm/lines/LineGeometry.js';
 import { LineMaterial } from 'three/examples/jsm/lines/LineMaterial.js';

--- a/src/scene/grass1.DISABLED.js
+++ b/src/scene/grass1.DISABLED.js
@@ -1,4 +1,4 @@
-import * as THREE from '@/three';
+import * as THREE from 'three';
 import { resolveAssetUrl } from '../utils/asset-paths.js';
 
 export function createGrassGround({

--- a/src/scene/index1.js
+++ b/src/scene/index1.js
@@ -1,4 +1,4 @@
-import * as THREE from '@/three';
+import * as THREE from 'three';
 import { createDirtGround } from './dirt.js';
 import { createGrassGround } from './grass.js';
 

--- a/src/scene/materials.js
+++ b/src/scene/materials.js
@@ -1,4 +1,4 @@
-import * as THREE from '@/three';
+import * as THREE from 'three';
 import { resolveAssetUrl } from '../utils/asset-paths.js';
 import { loadTextureWithFallback } from '../utils/fail-soft-loaders.js';
 

--- a/src/scene/sky.js
+++ b/src/scene/sky.js
@@ -1,4 +1,4 @@
-import * as THREE from '@/three';
+import * as THREE from 'three';
 import { resolveAssetUrl } from '../utils/asset-paths.js';
 import { loadTextureWithFallback } from '../utils/fail-soft-loaders.js';
 

--- a/src/sky/moon.js
+++ b/src/sky/moon.js
@@ -1,4 +1,4 @@
-import * as THREE from '@/three';
+import * as THREE from 'three';
 
 const ORIGIN = new THREE.Vector3();
 

--- a/src/sky/mountainRim.js
+++ b/src/sky/mountainRim.js
@@ -1,4 +1,4 @@
-import * as THREE from '@/three';
+import * as THREE from 'three';
 
 function createPeakProfile(radialSegments, noise) {
   const peaks = new Float32Array(radialSegments + 1);

--- a/src/sky/photoSkydome.js
+++ b/src/sky/photoSkydome.js
@@ -1,5 +1,5 @@
 // src/sky/photoSkydome.js
-import * as THREE from '@/three';
+import * as THREE from 'three';
 import { loadTextureAsyncWithFallback } from '../utils/fail-soft-loaders.js';
 
 const sharedTextureLoader = new THREE.TextureLoader();

--- a/src/sky/starField.js
+++ b/src/sky/starField.js
@@ -1,4 +1,4 @@
-import * as THREE from '@/three';
+import * as THREE from 'three';
 
 const defaultTempColor = new THREE.Color();
 

--- a/src/three.js
+++ b/src/three.js
@@ -1,7 +1,0 @@
-export * from 'three';
-import * as THREE from 'three';
-
-const threeReady = Promise.resolve(THREE);
-
-export { THREE, threeReady };
-export default THREE;

--- a/src/utils/fail-soft-loaders.js
+++ b/src/utils/fail-soft-loaders.js
@@ -1,4 +1,4 @@
-import * as THREE from '@/three';
+import * as THREE from 'three';
 
 const DEFAULT_TEXTURE_FALLBACK_COLOR = 0x999999;
 const DEFAULT_MODEL_FALLBACK_COLOR = 0xff4477;

--- a/src/vegetation/procTree.js
+++ b/src/vegetation/procTree.js
@@ -1,4 +1,4 @@
-import * as THREE from '@/three';
+import * as THREE from 'three';
 
 const TRUNK_COLOR = new THREE.Color('#8b5a2b');
 const LEAF_COLOR = new THREE.Color('#4f7c46');

--- a/src/vegetation/trees.js
+++ b/src/vegetation/trees.js
@@ -1,4 +1,4 @@
-import * as THREE from '@/three';
+import * as THREE from 'three';
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 import { createProceduralTree } from './procTree.js';
 import { resolveAssetUrl } from '../utils/asset-paths.js';


### PR DESCRIPTION
## Summary
- remove the custom three.js wrapper module and import the npm package directly
- update entrypoint scripts to keep three.js readiness on window without the wrapper
- normalize three.js imports across scene, terrain, audio, and utility modules

## Testing
- npx madge --circular src
- npm run build *(fails: `vite: not found` in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d8560b5fcc83279feda01fdb4945d9