### PR TITLE
Fix GitHub Pages deployment to serve Vite build output

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -34,8 +34,14 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Verify HTML does not reference TypeScript sources
+        run: npm run html:no-ts
+
       - name: Build site
         run: npm run build
+
+      - name: Add .nojekyll file
+        run: touch dist/.nojekyll
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "dev:force": "vite --force --open --port 4173",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "node --test"
+    "test": "node --test",
+    "html:no-ts": "./scripts/check-html-no-ts.sh"
   },
   "dependencies": {
     "cannon": "^0.6.2",

--- a/scripts/check-html-no-ts.sh
+++ b/scripts/check-html-no-ts.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+dirs=()
+if [[ -d "public" ]]; then
+  dirs+=("public")
+fi
+if [[ -d "docs" ]]; then
+  dirs+=("docs")
+fi
+
+if [[ ${#dirs[@]} -eq 0 ]]; then
+  exit 0
+fi
+
+if grep -RE "<script[^>]+src=.*\\.ts" --include='*.html' "${dirs[@]}"; then
+  echo "Error: HTML files must not reference TypeScript sources directly." >&2
+  exit 1
+fi

--- a/src/building-kit.js
+++ b/src/building-kit.js
@@ -92,8 +92,11 @@ loadTextureWithFallback(wallURL, {
 
     if ('SRGBColorSpace' in THREE) {
       wallTex.colorSpace = THREE.SRGBColorSpace;
-    } else if ('sRGBEncoding' in THREE) {
-      wallTex.encoding = THREE.sRGBEncoding;
+    } else {
+      const srgbEncoding = Reflect.get(THREE, 'sRGBEncoding');
+      if (srgbEncoding) {
+        wallTex.encoding = srgbEncoding;
+      }
     }
 
     MAT.wall.map = wallTex;

--- a/src/roads/roadNetwork.js
+++ b/src/roads/roadNetwork.js
@@ -90,8 +90,11 @@ function ensureTexture(path = DEFAULT_OPTIONS.texturePath) {
   const texture = textureLoader.load(resolvedPath, (tex) => {
     if ('colorSpace' in tex && THREE.SRGBColorSpace) {
       tex.colorSpace = THREE.SRGBColorSpace;
-    } else if ('encoding' in tex && THREE.sRGBEncoding) {
-      tex.encoding = THREE.sRGBEncoding;
+    } else {
+      const srgbEncoding = Reflect.get(THREE, 'sRGBEncoding');
+      if ('encoding' in tex && srgbEncoding) {
+        tex.encoding = srgbEncoding;
+      }
     }
   });
   texture.wrapS = THREE.RepeatWrapping;

--- a/src/scene/dirt1.DISABLED.js
+++ b/src/scene/dirt1.DISABLED.js
@@ -26,7 +26,10 @@ export function createDirtGround({
   });
 
   if ('SRGBColorSpace' in THREE) color.colorSpace = THREE.SRGBColorSpace;
-  else if ('sRGBEncoding' in THREE) color.encoding = THREE.sRGBEncoding;
+  else {
+    const srgbEncoding = Reflect.get(THREE, 'sRGBEncoding');
+    if (srgbEncoding) color.encoding = srgbEncoding;
+  }
 
   const mat = new THREE.MeshStandardMaterial({
     map: color,

--- a/src/scene/grass1.DISABLED.js
+++ b/src/scene/grass1.DISABLED.js
@@ -26,7 +26,10 @@ export function createGrassGround({
   });
 
   if ('SRGBColorSpace' in THREE) color.colorSpace = THREE.SRGBColorSpace;
-  else if ('sRGBEncoding' in THREE) color.encoding = THREE.sRGBEncoding;
+  else {
+    const srgbEncoding = Reflect.get(THREE, 'sRGBEncoding');
+    if (srgbEncoding) color.encoding = srgbEncoding;
+  }
 
   const mat = new THREE.MeshStandardMaterial({
     map: color,

--- a/src/scene/sky.js
+++ b/src/scene/sky.js
@@ -41,8 +41,11 @@ export function loadEquirectSky(renderer, scene, path, onDone, options = {}) {
       texture.mapping = THREE.EquirectangularReflectionMapping;
       if ('colorSpace' in texture && THREE.SRGBColorSpace) {
         texture.colorSpace = THREE.SRGBColorSpace;
-      } else if ('encoding' in texture && THREE.sRGBEncoding) {
-        texture.encoding = THREE.sRGBEncoding;
+      } else {
+        const srgbEncoding = Reflect.get(THREE, 'sRGBEncoding');
+        if ('encoding' in texture && srgbEncoding) {
+          texture.encoding = srgbEncoding;
+        }
       }
 
       const pmrem = new THREE.PMREMGenerator(renderer);

--- a/src/sky/photoSkydome.js
+++ b/src/sky/photoSkydome.js
@@ -45,8 +45,9 @@ async function loadTextureWithCache(url, loader = sharedTextureLoader, options =
         if (!Number.isFinite(maxAnisotropy) || maxAnisotropy <= 0) {
           maxAnisotropy = 8;
         }
-        if ('encoding' in texture && THREE.sRGBEncoding) {
-          texture.encoding = THREE.sRGBEncoding;
+        const srgbEncoding = Reflect.get(THREE, 'sRGBEncoding');
+        if ('encoding' in texture && srgbEncoding) {
+          texture.encoding = srgbEncoding;
         }
         if ('colorSpace' in texture && THREE.SRGBColorSpace) {
           texture.colorSpace = THREE.SRGBColorSpace;

--- a/vite.config.js
+++ b/vite.config.js
@@ -21,6 +21,7 @@ export default defineConfig(({ mode }) => ({
     },
   },
   build: {
+    target: 'esnext',
     rollupOptions: {
       input: {
         index: 'index.html',


### PR DESCRIPTION
## Summary
- enforce Vite build output deployment via GitHub Pages workflow with `.nojekyll`
- add HTML guard script and npm task to prevent deploying raw TypeScript tags
- update renderers to use Reflect-based sRGB fallback and enable modern build target for successful bundling

## Testing
- npm run html:no-ts
- npm ci
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d8606dabb88327aede4ff673d69159