### PR TITLE
Make landing bootstrap idempotent and expose context getter

### DIFF
--- a/src/entry/landing.ts
+++ b/src/entry/landing.ts
@@ -8,11 +8,14 @@ type StatsLike = {
   dom?: HTMLElement;
 } | null;
 
-type RunAthensHandle = () => Promise<{
+type RunAthensResult = {
   scene: THREE.Scene;
   renderer: THREE.WebGLRenderer;
   camera: THREE.PerspectiveCamera;
-}>;
+};
+
+type RunAthensHandle = () => Promise<RunAthensResult>;
+type GetAthensContextHandle = () => Promise<RunAthensResult | undefined>;
 
 let container: HTMLElement | null = null;
 let renderer: THREE.WebGLRenderer | null = null;
@@ -20,93 +23,158 @@ let scene: THREE.Scene | null = null;
 let camera: THREE.PerspectiveCamera | null = null;
 let stats: StatsLike = null;
 let previousTime = performance.now();
+let initializationTask: Promise<RunAthensResult> | null = null;
+let initializedContext: RunAthensResult | null = null;
+let resizeListenerAttached = false;
+let loggedRenderLoop = false;
+
+console.log('[Athens] boot starting');
+try {
+  await boot?.();
+} catch (error) {
+  console.error('[Athens] Boot invocation failed.', error);
+}
+await whenBootReady().catch(() => {});
 
 declare global {
   interface Window {
     runAthens?: RunAthensHandle;
+    getAthensContext?: GetAthensContextHandle;
   }
 }
 
-console.log('[Athens] boot starting');
-await boot?.();
-await whenBootReady();
-
-const runAthens: RunAthensHandle = async () => {
-  if (scene && renderer && camera) {
-    return { scene, renderer, camera };
+async function runAthens(): Promise<RunAthensResult> {
+  if (initializedContext) {
+    return initializedContext;
   }
 
-  container = document.getElementById('app') as HTMLElement | null;
-  if (!container) {
-    throw new Error('Missing #app container for Athens renderer.');
+  if (initializationTask) {
+    return initializationTask;
   }
 
-  renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
-  renderer.shadowMap.enabled = true;
-  renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
-  renderer.domElement.style.width = '100%';
-  renderer.domElement.style.height = '100%';
-  renderer.domElement.style.display = 'block';
-  container.appendChild(renderer.domElement);
-
-  scene = new THREE.Scene();
-
-  camera = new THREE.PerspectiveCamera(60, 1, 0.1, 2000);
-  camera.position.set(90, 110, 180);
-  camera.lookAt(new THREE.Vector3(0, 0, 0));
-  scene.add(camera);
-
-  const ambientLight = new THREE.AmbientLight(0xffffff, 0.6);
-  scene.add(ambientLight);
-
-  const directionalLight = new THREE.DirectionalLight(0xffffff, 1.1);
-  directionalLight.position.set(120, 180, 60);
-  directionalLight.castShadow = true;
-  directionalLight.shadow.mapSize.set(2048, 2048);
-  const shadowCamera = directionalLight.shadow.camera as THREE.OrthographicCamera;
-  shadowCamera.near = 0.5;
-  shadowCamera.far = 500;
-  shadowCamera.left = -200;
-  shadowCamera.right = 200;
-  shadowCamera.top = 200;
-  shadowCamera.bottom = -200;
-  scene.add(directionalLight);
-
-  resizeRenderer();
-  window.addEventListener('resize', resizeRenderer);
-
-  try {
-    setEnvironment(renderer, scene, 'day');
-  } catch (error) {
-    console.warn('[Athens] Failed to configure sky environment.', error);
-  }
-
-  await setupGround(scene, renderer);
-
-  try {
-    stats = initPerformanceStats() as StatsLike;
-    if (stats?.dom) {
-      stats.dom.style.position = 'absolute';
-      stats.dom.style.left = '0';
-      stats.dom.style.top = '0';
+  initializationTask = (async () => {
+    container = document.getElementById('app') as HTMLElement | null;
+    if (!container) {
+      initializationTask = null;
+      throw new Error('Missing #app container for Athens renderer.');
     }
-  } catch (error) {
-    console.warn('[Athens] Performance stats are unavailable.', error);
-    stats = null;
+
+    renderer = renderer ?? new THREE.WebGLRenderer({ antialias: true, alpha: true });
+    renderer.shadowMap.enabled = true;
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
+    renderer.domElement.style.width = '100%';
+    renderer.domElement.style.height = '100%';
+    renderer.domElement.style.display = 'block';
+    if (!container.contains(renderer.domElement)) {
+      container.appendChild(renderer.domElement);
+    }
+
+    scene = scene ?? new THREE.Scene();
+
+    camera = camera ?? new THREE.PerspectiveCamera(60, 1, 0.1, 2000);
+    camera.position.set(90, 110, 180);
+    camera.lookAt(new THREE.Vector3(0, 0, 0));
+    if (!scene.children.includes(camera)) {
+      scene.add(camera);
+    }
+
+    if (!scene.children.find((child) => child instanceof THREE.AmbientLight)) {
+      scene.add(new THREE.AmbientLight(0xffffff, 0.6));
+    }
+
+    if (!scene.children.find((child) => child instanceof THREE.DirectionalLight)) {
+      const light = new THREE.DirectionalLight(0xffffff, 1.1);
+      light.position.set(120, 180, 60);
+      light.castShadow = true;
+      light.shadow.mapSize.set(2048, 2048);
+      const shadowCamera = light.shadow.camera as THREE.OrthographicCamera;
+      shadowCamera.near = 0.5;
+      shadowCamera.far = 500;
+      shadowCamera.left = -200;
+      shadowCamera.right = 200;
+      shadowCamera.top = 200;
+      shadowCamera.bottom = -200;
+      scene.add(light);
+    }
+
+    resizeRenderer();
+    if (!resizeListenerAttached) {
+      window.addEventListener('resize', resizeRenderer);
+      resizeListenerAttached = true;
+    }
+
+    try {
+      setEnvironment(renderer, scene, 'day');
+    } catch (error) {
+      console.warn('[Athens] Failed to configure sky environment.', error);
+    }
+
+    await setupGround(scene, renderer);
+
+    try {
+      stats = initPerformanceStats() as StatsLike;
+      if (stats?.dom) {
+        stats.dom.style.position = 'absolute';
+        stats.dom.style.left = '0';
+        stats.dom.style.top = '0';
+      }
+    } catch (error) {
+      console.warn('[Athens] Performance stats are unavailable.', error);
+      stats = null;
+    }
+
+    previousTime = performance.now();
+    requestAnimationFrame(frame);
+
+    if (!loggedRenderLoop) {
+      console.log('[Athens] render loop running');
+      loggedRenderLoop = true;
+    }
+
+    const context: RunAthensResult = {
+      scene: scene!,
+      renderer: renderer!,
+      camera: camera!
+    };
+
+    initializedContext = context;
+    return context;
+  })();
+
+  try {
+    return await initializationTask;
+  } finally {
+    initializationTask = null;
+  }
+}
+
+async function getAthensContext(): Promise<RunAthensResult | undefined> {
+  if (initializedContext) {
+    return initializedContext;
   }
 
-  previousTime = performance.now();
-  requestAnimationFrame(frame);
-  console.log('[Athens] render loop running');
+  if (initializationTask) {
+    return initializationTask;
+  }
 
-  return {
-    scene: scene as THREE.Scene,
-    renderer: renderer as THREE.WebGLRenderer,
-    camera: camera as THREE.PerspectiveCamera
-  };
-};
+  const ready = (window as any).__AthensBootReady as Promise<unknown> | undefined;
+  if (ready && typeof (ready as any).then === 'function') {
+    console.warn('[Athens] Delaying until boot finishes…');
+    await ready.catch(() => {});
+    if (initializedContext) {
+      return initializedContext;
+    }
+    if (initializationTask) {
+      return initializationTask;
+    }
+  }
+
+  console.warn('[Athens] Boot not ready; proceeding cautiously.');
+  return undefined;
+}
 
 (window as any).runAthens = runAthens;
+(window as any).getAthensContext = getAthensContext;
 window.dispatchEvent(
   new CustomEvent('athens:initializer-ready', {
     detail: { initializer: (window as any).runAthens, source: 'index.html' }
@@ -155,4 +223,3 @@ function frame(now: number) {
 
   requestAnimationFrame(frame);
 }
-


### PR DESCRIPTION
## Summary
- make the landing bootstrap idempotent by reusing the existing renderer, scene, and camera instances
- expose helper handles on `window` and wait for the deterministic boot-ready signal before initializing
- harden runtime setup with guarded event listeners, optional stats wiring, and clearer logging

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d877f1eed883278ddae66022cb2d9d