### PR TITLE
Add early initializer shim for runAthens

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,43 @@
   </head>
   <body>
     <div id="app"></div>
+    <script>
+      // Early initializer shim
+      (function () {
+        if (window.runAthens) {
+          return;
+        }
+
+        const pendingCalls = [];
+
+        window.runAthens = function (...args) {
+          pendingCalls.push(args);
+        };
+
+        window.dispatchEvent(
+          new CustomEvent('athens:initializer-ready', {
+            detail: { initializer: window.runAthens, source: 'shim' },
+          }),
+        );
+
+        function handleInitializerReady(event) {
+          const detail = event && event.detail;
+          if (!detail || detail.source === 'shim' || typeof detail.initializer !== 'function') {
+            return;
+          }
+
+          window.removeEventListener('athens:initializer-ready', handleInitializerReady);
+
+          window.runAthens = detail.initializer;
+
+          while (pendingCalls.length) {
+            window.runAthens.apply(window, pendingCalls.shift());
+          }
+        }
+
+        window.addEventListener('athens:initializer-ready', handleInitializerReady);
+      })();
+    </script>
     <script type="module" src="./src/entry/landing.ts"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add an inline early initializer shim in index.html to ensure window.runAthens exists before the module bundle loads
- dispatch an initializer-ready event from the shim and hand off to the real initializer once available

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d8a4ad98d88327874917b1d49d3117