### PR TITLE
Publish runAthens initializer before auto start

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,43 @@
   </head>
   <body>
     <div id="app"></div>
+    <script>
+      // Early initializer shim
+      (function () {
+        if (window.runAthens) {
+          return;
+        }
+
+        const pendingCalls = [];
+
+        window.runAthens = function (...args) {
+          pendingCalls.push(args);
+        };
+
+        window.dispatchEvent(
+          new CustomEvent('athens:initializer-ready', {
+            detail: { initializer: window.runAthens, source: 'shim' },
+          }),
+        );
+
+        function handleInitializerReady(event) {
+          const detail = event && event.detail;
+          if (!detail || detail.source === 'shim' || typeof detail.initializer !== 'function') {
+            return;
+          }
+
+          window.removeEventListener('athens:initializer-ready', handleInitializerReady);
+
+          window.runAthens = detail.initializer;
+
+          while (pendingCalls.length) {
+            window.runAthens.apply(window, pendingCalls.shift());
+          }
+        }
+
+        window.addEventListener('athens:initializer-ready', handleInitializerReady);
+      })();
+    </script>
     <script type="module" src="./src/entry/landing.ts"></script>
   </body>
 </html>

--- a/src/entry/landing.ts
+++ b/src/entry/landing.ts
@@ -28,14 +28,6 @@ let initializedContext: RunAthensResult | null = null;
 let resizeListenerAttached = false;
 let loggedRenderLoop = false;
 
-console.log('[Athens] boot starting');
-try {
-  await boot?.();
-} catch (error) {
-  console.error('[Athens] Boot invocation failed.', error);
-}
-await whenBootReady().catch(() => {});
-
 declare global {
   interface Window {
     runAthens?: RunAthensHandle;
@@ -53,6 +45,14 @@ async function runAthens(): Promise<RunAthensResult> {
   }
 
   initializationTask = (async () => {
+    console.log('[Athens] boot starting');
+    try {
+      await boot?.();
+    } catch (error) {
+      console.error('[Athens] Boot invocation failed.', error);
+    }
+    await whenBootReady().catch(() => {});
+
     container = document.getElementById('app') as HTMLElement | null;
     if (!container) {
       initializationTask = null;
@@ -148,36 +148,11 @@ async function runAthens(): Promise<RunAthensResult> {
   }
 }
 
-async function getAthensContext(): Promise<RunAthensResult | undefined> {
-  if (initializedContext) {
-    return initializedContext;
-  }
-
-  if (initializationTask) {
-    return initializationTask;
-  }
-
-  const ready = (window as any).__AthensBootReady as Promise<unknown> | undefined;
-  if (ready && typeof (ready as any).then === 'function') {
-    console.warn('[Athens] Delaying until boot finishes…');
-    await ready.catch(() => {});
-    if (initializedContext) {
-      return initializedContext;
-    }
-    if (initializationTask) {
-      return initializationTask;
-    }
-  }
-
-  console.warn('[Athens] Boot not ready; proceeding cautiously.');
-  return undefined;
-}
-
 (window as any).runAthens = runAthens;
-(window as any).getAthensContext = getAthensContext;
+(window as any).getAthensContext = async () => initializedContext ?? initializationTask ?? undefined;
 window.dispatchEvent(
   new CustomEvent('athens:initializer-ready', {
-    detail: { initializer: (window as any).runAthens, source: 'index.html' }
+    detail: { initializer: runAthens, source: 'index.html' }
   })
 );
 console.log('[Athens] initializer ready');


### PR DESCRIPTION
## Summary
- add an inline early initializer shim in index.html to ensure window.runAthens exists before the module bundle loads
- dispatch an initializer-ready event from the shim and hand off to the real initializer once available
- expose the real runAthens initializer from landing.ts immediately, dispatching initializer-ready before auto-starting the app

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d8a4ad98d88327874917b1d49d3117