### PR TITLE
Fix stats.js module import resolution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "cannon": "^0.6.2",
+        "stats.js": "^0.17.0",
         "three": "^0.180.0",
         "tone": "^14.7.77"
       },
@@ -1240,6 +1241,12 @@
         "automation-events": "^7.0.9",
         "tslib": "^2.7.0"
       }
+    },
+    "node_modules/stats.js": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/stats.js/-/stats.js-0.17.0.tgz",
+      "integrity": "sha512-hNKz8phvYLPEcRkeG1rsGmV5ChMjKDAWU7/OJJdDErPBNChQXxCo3WZurGpnWc6gZhAzEPFad1aVgyOANH1sMw==",
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "5.1.2",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "cannon": "^0.6.2",
+    "stats.js": "^0.17.0",
     "three": "^0.180.0",
     "tone": "^14.7.77"
   },

--- a/src/main.js
+++ b/src/main.js
@@ -5,7 +5,7 @@ import { getAssetBase } from './utils/asset-paths.js';
 const ATHENS_MAIN_SENTINEL = Symbol.for('athens.main.entrypoint');
 const isAthensMainEntrypoint = (fn) => typeof fn === 'function' && fn[ATHENS_MAIN_SENTINEL];
 
-const STATS_MODULE_ID = 'three/examples/jsm/libs/stats.module.js';
+const STATS_MODULE_ID = 'stats.js';
 const DEV_HOSTS = new Set(['localhost', '127.0.0.1', '0.0.0.0', '']);
 
 let StatsConstructor = null;


### PR DESCRIPTION
## Summary
- import Stats.js from the published package instead of the three.js example path
- declare the stats.js dependency so it is bundled consistently

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d8c36833d48327bef267c6769ca55d