### PR TITLE
Add integrated Athens initialization with landmarks

### DIFF
--- a/src/entry/initializeAthens.js
+++ b/src/entry/initializeAthens.js
@@ -1,0 +1,261 @@
+import * as THREE from 'three';
+import { setupGround, updateTrees, initPerformanceStats } from '../main.js';
+import { createEnvironmentController } from '../scene/sky.js';
+import { loadLandmarks } from '../landmarks-loader.js';
+import { createLandmarkOverlay } from '../map/landmarks.js';
+import { buildRoadNetwork } from '../roads/roadNetwork.js';
+import { createNpcManager } from '../npc/npcSystem.js';
+
+const DEFAULT_CONTAINER_ID = 'app';
+const DEFAULT_OVERLAY_ID = 'landmark-overlay';
+const DEFAULT_GEOJSON_URL = 'data/athens_places.geojson';
+
+function ensureContainerElement(options = {}) {
+  if (typeof document === 'undefined') {
+    throw new Error('initializeAthens requires a browser document.');
+  }
+  if (options.container instanceof HTMLElement) {
+    return options.container;
+  }
+  const containerId = options.containerId ?? DEFAULT_CONTAINER_ID;
+  const element = document.getElementById(containerId);
+  if (!element) {
+    throw new Error(`Athens container #${containerId} not found.`);
+  }
+  return element;
+}
+
+function computeContainerSize(element) {
+  const rect = element.getBoundingClientRect?.();
+  const width = rect && rect.width ? rect.width : element.clientWidth || window.innerWidth || 1;
+  const height = rect && rect.height ? rect.height : element.clientHeight || window.innerHeight || 1;
+  return {
+    width: Math.max(1, Math.floor(width)),
+    height: Math.max(1, Math.floor(height))
+  };
+}
+
+function ensureOverlayCanvas(container, overlayCanvasId) {
+  const existing = typeof document !== 'undefined' ? document.getElementById(overlayCanvasId) : null;
+  if (existing instanceof HTMLCanvasElement) {
+    return existing;
+  }
+
+  const canvas = document.createElement('canvas');
+  canvas.id = overlayCanvasId;
+  canvas.style.position = 'absolute';
+  canvas.style.top = '16px';
+  canvas.style.right = '16px';
+  canvas.style.width = 'min(420px, 32vw)';
+  canvas.style.height = 'min(420px, 32vh)';
+  canvas.style.maxWidth = '95vw';
+  canvas.style.maxHeight = '60vh';
+  canvas.style.border = '1px solid rgba(30, 41, 59, 0.35)';
+  canvas.style.background = 'rgba(15, 23, 42, 0.25)';
+  canvas.style.backdropFilter = 'blur(4px)';
+  canvas.style.borderRadius = '12px';
+  canvas.style.zIndex = '4';
+  canvas.style.touchAction = 'none';
+  canvas.style.pointerEvents = 'auto';
+  container.appendChild(canvas);
+  return canvas;
+}
+
+function ensureLights(scene) {
+  if (!scene) {
+    return;
+  }
+  if (!scene.children.some((child) => child.isAmbientLight)) {
+    scene.add(new THREE.AmbientLight(0xfef7e5, 0.55));
+  }
+  if (!scene.children.some((child) => child.isDirectionalLight)) {
+    const sun = new THREE.DirectionalLight(0xffffff, 1.05);
+    sun.position.set(160, 260, 120);
+    sun.castShadow = true;
+    sun.shadow.mapSize.set(2048, 2048);
+    sun.shadow.camera.near = 0.5;
+    sun.shadow.camera.far = 600;
+    sun.shadow.camera.left = -240;
+    sun.shadow.camera.right = 240;
+    sun.shadow.camera.top = 240;
+    sun.shadow.camera.bottom = -240;
+    scene.add(sun);
+  }
+}
+
+export async function initializeAthens(options = {}) {
+  const container = ensureContainerElement(options);
+  container.style.position = container.style.position || 'relative';
+
+  const { width: initialWidth, height: initialHeight } = computeContainerSize(container);
+
+  const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
+  renderer.shadowMap.enabled = true;
+  renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
+  renderer.setSize(initialWidth, initialHeight, false);
+  renderer.domElement.style.width = '100%';
+  renderer.domElement.style.height = '100%';
+  renderer.domElement.style.display = 'block';
+  renderer.domElement.style.zIndex = '0';
+
+  if (!container.contains(renderer.domElement)) {
+    container.appendChild(renderer.domElement);
+  }
+
+  const scene = new THREE.Scene();
+  const camera = new THREE.PerspectiveCamera(60, initialWidth / initialHeight, 0.1, 2000);
+  camera.position.set(90, 110, 180);
+  camera.lookAt(new THREE.Vector3(0, 0, 0));
+  scene.add(camera);
+
+  ensureLights(scene);
+
+  const stats = initPerformanceStats?.();
+  if (stats?.dom) {
+    stats.dom.style.position = 'absolute';
+    stats.dom.style.left = '16px';
+    stats.dom.style.top = '16px';
+    stats.dom.style.zIndex = '5';
+    stats.dom.style.pointerEvents = 'none';
+    if (!container.contains(stats.dom)) {
+      container.appendChild(stats.dom);
+    }
+  }
+
+  const environmentController = createEnvironmentController(renderer, scene);
+  await environmentController.setMode?.('high_noon');
+
+  await setupGround(scene, renderer);
+
+  const landmarks = await loadLandmarks({
+    scene,
+    geoJsonUrl: options.geoJsonUrl ?? DEFAULT_GEOJSON_URL
+  });
+
+  const overlayCanvasId = options.overlayCanvasId ?? DEFAULT_OVERLAY_ID;
+  const overlayCanvas = ensureOverlayCanvas(container, overlayCanvasId);
+  const overlay = await createLandmarkOverlay(overlayCanvas, {
+    geoJsonUrl: options.geoJsonUrl ?? DEFAULT_GEOJSON_URL
+  });
+  landmarks.featureLines?.updateResolution?.();
+
+  let roadNetwork = null;
+  if (options.enableRoads !== false) {
+    roadNetwork = buildRoadNetwork({ scene, landmarks: landmarks.markers });
+  }
+
+  let npcManager = null;
+  if (options.enableNpcs !== false) {
+    npcManager = createNpcManager(scene);
+    const npcConfigs = Array.isArray(options.npcConfigs) && options.npcConfigs.length
+      ? options.npcConfigs
+      : [
+          {
+            modelUrl: 'models/npc_athenian.glb',
+            initialPosition: { x: 8, y: 0, z: -6 },
+            waypoints: [
+              { x: 8, y: 0, z: -6 },
+              { x: -6, y: 0, z: -8 },
+              { x: -4, y: 0, z: 6 },
+              { x: 10, y: 0, z: 4 }
+            ]
+          },
+          {
+            modelUrl: 'models/hoplite_npc.glb',
+            initialPosition: { x: -12, y: 0, z: 12 },
+            waypoints: [
+              { x: -12, y: 0, z: 12 },
+              { x: -2, y: 0, z: 18 },
+              { x: 6, y: 0, z: 10 },
+              { x: -4, y: 0, z: 4 }
+            ]
+          }
+        ];
+    npcConfigs.slice(0, 3).forEach((config) => {
+      npcManager.spawn(config);
+    });
+  }
+
+  const resizeHandler = () => {
+    const { width, height } = computeContainerSize(container);
+    renderer.setSize(width, height, false);
+    camera.aspect = width / height;
+    camera.updateProjectionMatrix();
+    overlay.requestRender();
+    landmarks.featureLines?.updateResolution?.();
+  };
+
+  window.addEventListener('resize', resizeHandler);
+
+  const clock = new THREE.Clock();
+  let disposed = false;
+  let frameId = 0;
+
+  const frame = () => {
+    if (disposed) {
+      return;
+    }
+    const delta = clock.getDelta();
+    try {
+      updateTrees?.(delta);
+    } catch (error) {
+      console.warn('[Athens] Tree animation update failed.', error);
+    }
+    npcManager?.update(delta);
+    landmarks.update?.(camera);
+    stats?.update?.();
+    renderer.render(scene, camera);
+    frameId = requestAnimationFrame(frame);
+  };
+
+  frameId = requestAnimationFrame(frame);
+
+  const context = {
+    renderer,
+    scene,
+    camera,
+    stats,
+    overlay,
+    overlayCanvas,
+    landmarks,
+    roadNetwork,
+    npcManager,
+    environmentController,
+    container,
+    setEnvironmentMode(mode, envOptions = {}) {
+      return environmentController?.setMode?.(mode, envOptions);
+    },
+    dispose() {
+      if (disposed) {
+        return;
+      }
+      disposed = true;
+      if (frameId) {
+        cancelAnimationFrame(frameId);
+      }
+      window.removeEventListener('resize', resizeHandler);
+      overlay?.destroy?.();
+      if (overlayCanvas.parentNode === container) {
+        container.removeChild(overlayCanvas);
+      }
+      npcManager?.dispose?.();
+      roadNetwork?.dispose?.();
+      landmarks?.dispose?.();
+      environmentController?.dispose?.();
+      if (stats?.dom && stats.dom.parentNode === container) {
+        container.removeChild(stats.dom);
+      }
+      renderer.dispose();
+    }
+  };
+
+  if (typeof window !== 'undefined') {
+    window.__athens = window.__athens || {};
+    window.__athens.environment = context.environmentController;
+    window.__athens.setSkyMode = (mode, envOptions) => context.setEnvironmentMode(mode, envOptions);
+  }
+
+  return context;
+}
+
+export default initializeAthens;

--- a/src/entry/landing.js
+++ b/src/entry/landing.js
@@ -1,54 +1,25 @@
-import * as THREE from 'three';
-import { setupGround, updateTrees, initPerformanceStats } from '../main.js';
-import { setEnvironment } from '../scene/sky.js';
+import initializeAthens from './initializeAthens.js';
 import boot, { whenBootReady } from '../core/bootstrap.js';
 
 /**
- * @typedef {{
- *   update?: () => void;
- *   dom?: HTMLElement;
- * } | null} StatsLike
+ * @typedef {ReturnType<typeof initializeAthens> extends Promise<infer T> ? T : never} AthensContext
  */
 
-/**
- * @typedef {{
- *   scene: THREE.Scene;
- *   renderer: THREE.WebGLRenderer;
- *   camera: THREE.PerspectiveCamera;
- * }} RunAthensResult
- */
-
-/** @typedef {() => Promise<RunAthensResult>} RunAthensHandle */
-/** @typedef {() => Promise<RunAthensResult | undefined>} GetAthensContextHandle */
-
-/** @type {HTMLElement | null} */
-let container = null;
-/** @type {THREE.WebGLRenderer | null} */
-let renderer = null;
-/** @type {THREE.Scene | null} */
-let scene = null;
-/** @type {THREE.PerspectiveCamera | null} */
-let camera = null;
-/** @type {StatsLike} */
-let stats = null;
-let previousTime = performance.now();
-/** @type {Promise<RunAthensResult> | null} */
+/** @type {Promise<AthensContext> | null} */
 let initializationTask = null;
-/** @type {RunAthensResult | null} */
+/** @type {AthensContext | null} */
 let initializedContext = null;
-let resizeListenerAttached = false;
-let loggedRenderLoop = false;
 /** @type {Promise<any> | null} */
 let bootPromise = null;
 let bootLogEmitted = false;
 
-/**
- * @returns {Promise<void>}
- */
 async function waitForDomReady() {
-  if (typeof document === 'undefined') return;
-  if (document.readyState === 'complete' || document.readyState === 'interactive') return;
-
+  if (typeof document === 'undefined') {
+    return;
+  }
+  if (document.readyState === 'complete' || document.readyState === 'interactive') {
+    return;
+  }
   await new Promise((resolve) => {
     const handleReady = () => {
       document.removeEventListener('DOMContentLoaded', handleReady);
@@ -58,42 +29,37 @@ async function waitForDomReady() {
   });
 }
 
-/**
- * @returns {{ promise: Promise<any>; started: boolean } | null}
- */
 function ensureBootStarted() {
-  if (typeof boot !== 'function') return null;
+  if (typeof boot !== 'function') {
+    return null;
+  }
 
   let started = false;
 
   if (!bootPromise) {
     started = true;
-
     if (!bootLogEmitted) {
       console.log('[Athens] boot starting');
       bootLogEmitted = true;
     }
-
-    const promise = Promise.resolve()
+    bootPromise = Promise.resolve()
       .then(() => boot())
       .catch((error) => {
         console.error('[Athens] Boot invocation failed.', error);
-        throw error;
+        throw error instanceof Error ? error : new Error(String(error));
       });
-
-    bootPromise = promise;
   }
 
-  if (!bootPromise) return null;
   return { promise: bootPromise, started };
 }
 
-/**
- * @returns {Promise<RunAthensResult>}
- */
 async function runAthens() {
-  if (initializedContext) return initializedContext;
-  if (initializationTask) return initializationTask;
+  if (initializedContext) {
+    return initializedContext;
+  }
+  if (initializationTask) {
+    return initializationTask;
+  }
 
   initializationTask = (async () => {
     const bootState = ensureBootStarted();
@@ -101,116 +67,20 @@ async function runAthens() {
     const bootStartedHere = bootState?.started ?? false;
 
     if (bootTask && !bootStartedHere) {
-      try {
-        await bootTask;
-      } catch (error) {
-        initializationTask = null;
-        throw error instanceof Error ? error : new Error(String(error));
-      }
-    }
-
-    if (bootTask) {
-      const bootReady = whenBootReady();
-      if (!bootStartedHere) {
-        try {
-          await bootReady;
-        } catch (error) {
-          initializationTask = null;
-          throw error instanceof Error ? error : new Error(String(error));
-        }
-      } else {
-        // if we started boot here, don't block; just observe readiness
-        bootReady.catch(() => {});
-      }
+      await bootTask;
+      await whenBootReady();
+    } else if (bootTask) {
+      whenBootReady().catch(() => {});
     }
 
     await waitForDomReady();
 
-    container = document.getElementById('app');
+    const container = document.getElementById('app');
     if (!container) {
-      initializationTask = null;
       throw new Error('Missing #app container for Athens renderer.');
     }
 
-    renderer = renderer ?? new THREE.WebGLRenderer({ antialias: true, alpha: true });
-    renderer.shadowMap.enabled = true;
-    renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
-    renderer.domElement.style.width = '100%';
-    renderer.domElement.style.height = '100%';
-    renderer.domElement.style.display = 'block';
-    if (!container.contains(renderer.domElement)) {
-      container.appendChild(renderer.domElement);
-    }
-
-    scene = scene ?? new THREE.Scene();
-
-    camera = camera ?? new THREE.PerspectiveCamera(60, 1, 0.1, 2000);
-    camera.position.set(90, 110, 180);
-    camera.lookAt(new THREE.Vector3(0, 0, 0));
-    if (!scene.children.includes(camera)) {
-      scene.add(camera);
-    }
-
-    if (!scene.children.find((child) => child instanceof THREE.AmbientLight)) {
-      scene.add(new THREE.AmbientLight(0xffffff, 0.6));
-    }
-
-    if (!scene.children.find((child) => child instanceof THREE.DirectionalLight)) {
-      const light = new THREE.DirectionalLight(0xffffff, 1.1);
-      light.position.set(120, 180, 60);
-      light.castShadow = true;
-      light.shadow.mapSize.set(2048, 2048);
-      const shadowCamera = light.shadow.camera;
-      shadowCamera.near = 0.5;
-      shadowCamera.far = 500;
-      shadowCamera.left = -200;
-      shadowCamera.right = 200;
-      shadowCamera.top = 200;
-      shadowCamera.bottom = -200;
-      scene.add(light);
-    }
-
-    resizeRenderer();
-    if (!resizeListenerAttached) {
-      window.addEventListener('resize', resizeRenderer);
-      resizeListenerAttached = true;
-    }
-
-    try {
-      await setEnvironment(renderer, scene, 'day');
-    } catch (error) {
-      console.warn('[Athens] Failed to configure sky environment.', error);
-    }
-
-    await setupGround(scene, renderer);
-
-    try {
-      stats = /** @type {StatsLike} */ (initPerformanceStats());
-      if (stats?.dom) {
-        stats.dom.style.position = 'absolute';
-        stats.dom.style.left = '0';
-        stats.dom.style.top = '0';
-      }
-    } catch (error) {
-      console.warn('[Athens] Performance stats are unavailable.', error);
-      stats = null;
-    }
-
-    previousTime = performance.now();
-    requestAnimationFrame(frame);
-
-    if (!loggedRenderLoop) {
-      console.log('[Athens] render loop running');
-      loggedRenderLoop = true;
-    }
-
-    /** @type {RunAthensResult} */
-    const context = {
-      scene,
-      renderer,
-      camera,
-    };
-
+    const context = await initializeAthens({ container });
     initializedContext = context;
     return context;
   })();
@@ -222,12 +92,13 @@ async function runAthens() {
   }
 }
 
-const globalWindow = /** @type {Window & { runAthens?: RunAthensHandle; getAthensContext?: GetAthensContextHandle; }} */ (window);
+const globalWindow = /** @type {Window & { runAthens?: typeof runAthens; getAthensContext?: () => Promise<AthensContext | undefined>; }} */ (window);
 
 globalWindow.runAthens = runAthens;
 globalWindow.getAthensContext = async () => {
-  if (initializedContext) return initializedContext;
-
+  if (initializedContext) {
+    return initializedContext;
+  }
   if (initializationTask) {
     try {
       return await initializationTask;
@@ -235,13 +106,12 @@ globalWindow.getAthensContext = async () => {
       return undefined;
     }
   }
-
   return undefined;
 };
 
 window.dispatchEvent(
   new CustomEvent('athens:initializer-ready', {
-    detail: { initializer: runAthens, source: 'index.html' },
+    detail: { initializer: runAthens, source: 'index.html' }
   })
 );
 console.log('[Athens] initializer ready');
@@ -250,41 +120,4 @@ try {
   await runAthens();
 } catch (error) {
   console.error('[Athens] Failed to initialize.', error);
-}
-
-function resizeRenderer() {
-  if (!container || !renderer || !camera) return;
-
-  const { clientWidth, clientHeight } = container;
-  const width = clientWidth || window.innerWidth || 1;
-  const height = clientHeight || window.innerHeight || 1;
-
-  renderer.setSize(width, height, false);
-  camera.aspect = width / height;
-  camera.updateProjectionMatrix();
-}
-
-/**
- * @param {number} now
- */
-function frame(now) {
-  if (!renderer || !scene || !camera) {
-    previousTime = now;
-    requestAnimationFrame(frame);
-    return;
-  }
-
-  const deltaSeconds = (now - previousTime) / 1000;
-  previousTime = now;
-
-  try {
-    updateTrees(deltaSeconds);
-  } catch (error) {
-    console.warn('[Athens] Tree update failed.', error);
-  }
-
-  stats?.update?.();
-  renderer.render(scene, camera);
-
-  requestAnimationFrame(frame);
 }

--- a/src/geo/geoLoader.js
+++ b/src/geo/geoLoader.js
@@ -1,4 +1,23 @@
-const DEFAULT_GEOJSON_PATH = './data/athens_places.geojson';
+import { resolveAssetUrl } from '../utils/asset-paths.js';
+
+const DEFAULT_GEOJSON_PATH = 'data/athens_places.geojson';
+
+function normalizeGeoJsonUrl(url) {
+    if (typeof url !== 'string' || !url) {
+        return resolveAssetUrl(DEFAULT_GEOJSON_PATH);
+    }
+
+    const trimmed = url.trim();
+    if (!trimmed) {
+        return resolveAssetUrl(DEFAULT_GEOJSON_PATH);
+    }
+
+    if (/^https?:\/\//i.test(trimmed)) {
+        return trimmed;
+    }
+
+    return resolveAssetUrl(trimmed);
+}
 
 /**
  * Fetches a GeoJSON feature collection containing places around Athens.
@@ -12,14 +31,16 @@ export async function loadGeoJson(url = DEFAULT_GEOJSON_PATH, fetchImpl = global
         throw new TypeError('A valid fetch implementation must be provided');
     }
 
-    const response = await fetchImpl(url, {
+    const targetUrl = normalizeGeoJsonUrl(url);
+
+    const response = await fetchImpl(targetUrl, {
         headers: {
             'Accept': 'application/geo+json, application/json'
         }
     });
 
     if (!response.ok) {
-        throw new Error(`Failed to load GeoJSON from ${url}: ${response.status} ${response.statusText}`);
+        throw new Error(`Failed to load GeoJSON from ${targetUrl}: ${response.status} ${response.statusText}`);
     }
 
     return response.json();

--- a/src/landmarks-loader.js
+++ b/src/landmarks-loader.js
@@ -45,14 +45,21 @@ export async function loadLandmarks({
 }) {
   const root = new THREE.Group();
   root.name = 'Landmarks';
-  scene.add(root);
+  if (scene) {
+    scene.add(root);
+  }
 
   const groups = {
     democracy: new THREE.Group(),
     cultural: new THREE.Group(),
     natural: new THREE.Group()
   };
-  Object.entries(groups).forEach(([k, g]) => { g.name = `Landmarks_${k}`; root.add(g); });
+  Object.entries(groups).forEach(([k, g]) => {
+    g.name = `Landmarks_${k}`;
+    root.add(g);
+  });
+
+  const LABEL_Y_OFFSET = 12;
 
   const url = resolveGeoJsonUrl(geoJsonUrl);
   const res = await fetch(url);
@@ -91,12 +98,15 @@ export async function loadLandmarks({
         ?? props?.uid
         ?? name
       );
+      pin.name = `LandmarkPin:${id}`;
       pin.userData = { name, props, id, isLandmark: true };
       targetGroup.add(pin);
       markers.push(pin);
 
       const label = makeLabelSprite(name);
-      label.position.copy(pos).add(new THREE.Vector3(0, 15, 0));
+      label.position.copy(pos).add(new THREE.Vector3(0, LABEL_Y_OFFSET, 0));
+      label.name = `LandmarkLabel:${id}`;
+      label.userData = { name, id, isLandmarkLabel: true, props };
       targetGroup.add(label);
       labels.push(label);
 
@@ -137,7 +147,49 @@ export async function loadLandmarks({
     featureLines?.updateResolution?.();
   };
 
-  return { root, groups, markers, labels, update, featureLines };
+  const dispose = () => {
+    if (featureLines?.root?.userData?.onDisposeFeatureLines) {
+      try {
+        featureLines.root.userData.onDisposeFeatureLines();
+      } catch (error) {
+        console.warn('[landmarks] Failed to dispose feature line listeners.', error);
+      }
+    }
+    if (featureLines?.root) {
+      featureLines.root.traverse((child) => {
+        if (child.isLine2 || child.isLine) {
+          child.geometry?.dispose?.();
+          if (Array.isArray(child.material)) {
+            child.material.forEach((mat) => mat?.dispose?.());
+          } else {
+            child.material?.dispose?.();
+          }
+        }
+      });
+      if (featureLines.root.parent) {
+        featureLines.root.parent.remove(featureLines.root);
+      }
+    }
+    if (root.parent) {
+      root.parent.remove(root);
+    }
+    root.traverse((child) => {
+      if (child.isMesh) {
+        child.geometry?.dispose?.();
+        if (Array.isArray(child.material)) {
+          child.material.forEach((mat) => mat?.dispose?.());
+        } else {
+          child.material?.dispose?.();
+        }
+      }
+      if (child.isSprite) {
+        child.material?.map?.dispose?.();
+        child.material?.dispose?.();
+      }
+    });
+  };
+
+  return { root, groups, markers, labels, update, featureLines, dispose };
 }
 
 /* ---------- helpers ---------- */
@@ -207,3 +259,4 @@ function makeLabelSprite(text) {
   s.renderOrder = 10;
   return s;
 }
+

--- a/src/map/landmarks.js
+++ b/src/map/landmarks.js
@@ -1,4 +1,4 @@
-import { loadGeoJson } from '../geo/geoLoader.js';
+import { loadGeoJson, DEFAULT_GEOJSON_PATH } from '../geo/geoLoader.js';
 import { LocalEquirectangularProjection } from '../geo/projection.js';
 import { applyFeatureOffset } from '../geo/featureOffsets.js';
 import { AgoraLayer } from './agoraLayer.js';
@@ -255,7 +255,8 @@ export class LandmarkOverlay {
         if (this._initialized) {
             return;
         }
-        const geoJson = await loadGeoJson(this.options.geoJsonUrl, this.options.fetchImpl);
+        const url = this.options.geoJsonUrl ?? DEFAULT_GEOJSON_PATH;
+        const geoJson = await loadGeoJson(url, this.options.fetchImpl);
         this._prepareData(geoJson);
         if (this.agoraLayer) {
             try {

--- a/src/npc/npcSystem.js
+++ b/src/npc/npcSystem.js
@@ -1,0 +1,279 @@
+import * as THREE from 'three';
+import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
+import { resolveAssetUrl } from '../utils/asset-paths.js';
+
+const loader = new GLTFLoader();
+const DEFAULT_SPEED = 1.6; // meters per second
+const DEFAULT_IDLE_SECONDS = 2.5;
+const tempDirection = new THREE.Vector3();
+const tempQuaternion = new THREE.Quaternion();
+
+function toVector3(value) {
+  if (!value) {
+    return null;
+  }
+  if (value.isVector3) {
+    return value.clone();
+  }
+  const { x, y, z } = value;
+  if (typeof x === 'number' && typeof y === 'number' && typeof z === 'number') {
+    return new THREE.Vector3(x, y, z);
+  }
+  if (Array.isArray(value) && value.length >= 3) {
+    return new THREE.Vector3(Number(value[0]) || 0, Number(value[1]) || 0, Number(value[2]) || 0);
+  }
+  return null;
+}
+
+function buildPlaceholderModel() {
+  const group = new THREE.Group();
+  const bodyMaterial = new THREE.MeshStandardMaterial({ color: 0x9ca3af, roughness: 0.8, metalness: 0.1 });
+  const headMaterial = new THREE.MeshStandardMaterial({ color: 0xfef3c7, roughness: 0.5, metalness: 0.05 });
+
+  const body = new THREE.Mesh(new THREE.CapsuleGeometry(0.6, 2.0, 8, 16), bodyMaterial);
+  body.castShadow = true;
+  body.receiveShadow = true;
+
+  const head = new THREE.Mesh(new THREE.SphereGeometry(0.6, 16, 16), headMaterial);
+  head.position.y = 1.6;
+  head.castShadow = true;
+  head.receiveShadow = true;
+
+  group.add(body, head);
+  return group;
+}
+
+function disposeObject3D(object) {
+  object.traverse((child) => {
+    if (child.isMesh || child.isSkinnedMesh) {
+      child.geometry?.dispose?.();
+      if (Array.isArray(child.material)) {
+        child.material.forEach((mat) => mat?.dispose?.());
+      } else {
+        child.material?.dispose?.();
+      }
+    }
+    if (child.isSprite) {
+      child.material?.map?.dispose?.();
+      child.material?.dispose?.();
+    }
+  });
+}
+
+export function createNpc({
+  modelUrl = null,
+  initialPosition = null,
+  waypoints = [],
+  speed = DEFAULT_SPEED,
+  idleSeconds = DEFAULT_IDLE_SECONDS
+} = {}) {
+  const object3d = new THREE.Group();
+  object3d.name = 'NPC';
+  object3d.userData.isNpc = true;
+
+  const path = Array.isArray(waypoints)
+    ? waypoints.map((point) => toVector3(point)).filter((point) => point && point.isVector3)
+    : [];
+
+  const startPosition = toVector3(initialPosition) || path[0]?.clone() || new THREE.Vector3();
+  object3d.position.copy(startPosition);
+
+  if (!path.length) {
+    path.push(startPosition.clone());
+  }
+
+  let nextIndex = path.length > 1 ? 1 : 0;
+  let dwellTime = 0;
+  let disposed = false;
+
+  const npcState = {
+    mixer: null,
+    root: null,
+    ready: null
+  };
+
+  const normalizedSpeed = Number.isFinite(speed) && speed > 0 ? speed : DEFAULT_SPEED;
+  const normalizedIdle = Number.isFinite(idleSeconds) && idleSeconds >= 0 ? idleSeconds : DEFAULT_IDLE_SECONDS;
+
+  const attachModel = (modelGroup) => {
+    if (!modelGroup) {
+      return;
+    }
+    npcState.root = modelGroup;
+    object3d.add(modelGroup);
+  };
+
+  const loadModel = async () => {
+    if (!modelUrl) {
+      attachModel(buildPlaceholderModel());
+      return null;
+    }
+
+    try {
+      const resolvedUrl = resolveAssetUrl(modelUrl);
+      const gltf = await loader.loadAsync(resolvedUrl);
+      const scene = gltf?.scene || gltf?.scenes?.[0];
+      if (scene) {
+        scene.traverse((child) => {
+          if (child.isMesh || child.isSkinnedMesh) {
+            child.castShadow = true;
+            child.receiveShadow = true;
+          }
+        });
+        attachModel(scene);
+      } else {
+        attachModel(buildPlaceholderModel());
+      }
+
+      if (Array.isArray(gltf?.animations) && gltf.animations.length) {
+        npcState.mixer = new THREE.AnimationMixer(scene || object3d);
+        const clip = gltf.animations[0];
+        const action = npcState.mixer.clipAction(clip);
+        action.play();
+      }
+    } catch (error) {
+      console.warn('[npc] Failed to load NPC model, using placeholder instead.', error);
+      attachModel(buildPlaceholderModel());
+    }
+
+    return npcState.root;
+  };
+
+  npcState.ready = loadModel();
+
+  const update = (deltaSeconds) => {
+    if (disposed) {
+      return;
+    }
+    const dt = Number.isFinite(deltaSeconds) ? deltaSeconds : 0;
+    npcState.mixer?.update(dt);
+
+    if (path.length < 2) {
+      return;
+    }
+
+    if (dwellTime > 0) {
+      dwellTime -= dt;
+      return;
+    }
+
+    const target = path[nextIndex];
+    if (!target) {
+      return;
+    }
+
+    tempDirection.subVectors(target, object3d.position);
+    const distance = tempDirection.length();
+    if (distance < 1e-4) {
+      object3d.position.copy(target);
+      nextIndex = (nextIndex + 1) % path.length;
+      dwellTime = normalizedIdle;
+      return;
+    }
+
+    tempDirection.normalize();
+    const step = normalizedSpeed * dt;
+    if (step >= distance) {
+      object3d.position.copy(target);
+      nextIndex = (nextIndex + 1) % path.length;
+      dwellTime = normalizedIdle;
+    } else {
+      object3d.position.addScaledVector(tempDirection, step);
+    }
+
+    // Face movement direction smoothly
+    if (tempDirection.lengthSq() > 0) {
+      const yaw = Math.atan2(tempDirection.x, tempDirection.z);
+      tempQuaternion.setFromEuler(new THREE.Euler(0, yaw, 0));
+      object3d.quaternion.slerp(tempQuaternion, Math.min(1, dt * 6));
+    }
+  };
+
+  const dispose = () => {
+    if (disposed) {
+      return;
+    }
+    disposed = true;
+    npcState.mixer?.stopAllAction?.();
+    if (object3d.parent) {
+      object3d.parent.remove(object3d);
+    }
+    if (npcState.root) {
+      disposeObject3D(npcState.root);
+    }
+    disposeObject3D(object3d);
+  };
+
+  return {
+    object3d,
+    update,
+    dispose,
+    ready: npcState.ready
+  };
+}
+
+export function createNpcManager(scene) {
+  const group = new THREE.Group();
+  group.name = 'NPCs';
+  group.userData.isNpcContainer = true;
+  if (scene) {
+    scene.add(group);
+  }
+
+  const npcs = new Set();
+  let disposed = false;
+
+  return {
+    group,
+    spawn(config = {}) {
+      if (disposed) {
+        return null;
+      }
+      const npc = createNpc(config);
+      group.add(npc.object3d);
+      npcs.add(npc);
+      const originalDispose = npc.dispose;
+      npc.dispose = () => {
+        npcs.delete(npc);
+        originalDispose();
+      };
+      return npc;
+    },
+    update(deltaSeconds) {
+      if (disposed) {
+        return;
+      }
+      for (const npc of npcs) {
+        npc.update?.(deltaSeconds);
+      }
+    },
+    dispose() {
+      if (disposed) {
+        return;
+      }
+      disposed = true;
+      for (const npc of npcs) {
+        npc.dispose?.();
+      }
+      npcs.clear();
+      if (group.parent) {
+        group.parent.remove(group);
+      }
+    }
+  };
+}
+
+/**
+ * Example NPC configuration:
+ *
+ * createNpcManager(scene).spawn({
+ *   modelUrl: 'models/npc_athenian.glb',
+ *   initialPosition: { x: 12, y: 0, z: -6 },
+ *   waypoints: [
+ *     { x: 12, y: 0, z: -6 },
+ *     { x: -4, y: 0, z: -8 },
+ *     { x: -2, y: 0, z: 10 },
+ *     { x: 14, y: 0, z: 8 }
+ *   ]
+ * });
+ */

--- a/src/roads/roadNetwork.js
+++ b/src/roads/roadNetwork.js
@@ -506,16 +506,35 @@ export function buildRoadNetwork({ scene, landmarks = [], options = {} } = {}) {
     scatterToken: 0
   };
 
+  if (scene) {
+    scene.add(root);
+  }
+
   rebuildNetwork(state);
 
   return {
     root,
     rebuild(newOptions = {}) {
-      state.options = normalizeOptions({ ...state.options, ...newOptions });
+      if (Array.isArray(newOptions.landmarks)) {
+        state.landmarks = newOptions.landmarks;
+      }
+      const { landmarks: _ignored, ...optionPatch } = newOptions || {};
+      state.options = normalizeOptions({ ...state.options, ...optionPatch });
       rebuildNetwork(state);
     },
     setVisible(visible) {
       root.visible = Boolean(visible);
+    },
+    dispose() {
+      removeScatteredProps(state);
+      disposeRoadMeshes(root);
+      if (state.sharedMaterial) {
+        state.sharedMaterial.dispose?.();
+        state.sharedMaterial = null;
+      }
+      if (root.parent) {
+        root.parent.remove(root);
+      }
     }
   };
 }

--- a/src/scene/sky.js
+++ b/src/scene/sky.js
@@ -1,13 +1,8 @@
 import * as THREE from 'three';
 import { resolveAssetUrl } from '../utils/asset-paths.js';
-import { loadTextureWithFallback } from '../utils/fail-soft-loaders.js';
+import { loadTextureAsyncWithFallback } from '../utils/fail-soft-loaders.js';
 import { createPhotoSkydome } from '../sky/photoSkydome.js';
 import { resolvePreset as resolveSkyPreset } from '../sky/presets.js';
-
-const SKY_PATHS = {
-  sunset: resolveAssetUrl('assets/sky/sunset_4k.jpg'),
-  night: resolveAssetUrl('assets/sky/night_sky_4k.jpg')
-};
 
 const BUNDLED_SKY_BASE = new URL('../sky/', import.meta.url);
 
@@ -20,66 +15,215 @@ function bundledSkyAsset(path) {
   }
 }
 
-const PHOTO_SKY_PRESETS = Object.freeze({
-  'High Noon': {
+function normalizeSkyAlias(value) {
+  if (!value || typeof value !== 'string') {
+    return null;
+  }
+  const trimmed = value.trim().toLowerCase();
+  if (!trimmed) {
+    return null;
+  }
+  return trimmed.replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '');
+}
+
+function externalSkyAsset(filename) {
+  if (!filename) {
+    return null;
+  }
+  const sanitized = `${filename}`.trim().replace(/^\/+/, '');
+  if (!sanitized) {
+    return null;
+  }
+  return resolveAssetUrl(`assets/sky/${sanitized}`);
+}
+
+function createSkySources(primaryFiles = [], fallbackBundled = [], labelPrefix = 'Sky panorama') {
+  const seen = new Set();
+  const sources = [];
+  const pushEntry = (url, label) => {
+    if (!url || seen.has(url)) {
+      return;
+    }
+    seen.add(url);
+    sources.push(label ? { url, label } : { url });
+  };
+
+  const formatLabel = (file, prefix) => {
+    if (!prefix) {
+      return file ? `Sky panorama (${file})` : 'Sky panorama';
+    }
+    return file ? `${prefix} (${file})` : prefix;
+  };
+
+  (Array.isArray(primaryFiles) ? primaryFiles : [primaryFiles]).forEach((entry) => {
+    if (!entry) return;
+    if (typeof entry === 'string') {
+      pushEntry(externalSkyAsset(entry), formatLabel(entry, labelPrefix));
+      return;
+    }
+    if (typeof entry === 'object') {
+      const url = entry.url ?? externalSkyAsset(entry.file ?? entry.path ?? '');
+      const label = entry.label ?? labelPrefix;
+      pushEntry(url, label);
+    }
+  });
+
+  const fallbackLabelPrefix = labelPrefix ? `${labelPrefix} fallback` : 'Sky panorama fallback';
+  (Array.isArray(fallbackBundled) ? fallbackBundled : [fallbackBundled]).forEach((entry) => {
+    if (!entry) return;
+    if (typeof entry === 'string') {
+      pushEntry(bundledSkyAsset(entry), formatLabel(entry, fallbackLabelPrefix));
+      return;
+    }
+    if (typeof entry === 'object') {
+      const url = entry.url ?? bundledSkyAsset(entry.file ?? entry.path ?? '');
+      const label = entry.label ?? fallbackLabelPrefix;
+      pushEntry(url, label);
+    }
+  });
+
+  return sources;
+}
+
+const PHOTO_PRESET_DEFINITIONS = [
+  {
+    key: 'high_noon',
+    name: 'High Noon',
     environment: 'day',
-    sources: [
-      { url: resolveAssetUrl('assets/sky/high_noon.jpg'), label: 'High Noon photo sky' },
-      { url: bundledSkyAsset('high_noon.jpg'), label: 'Bundled high noon fallback' },
-      { url: bundledSkyAsset('sunset.jpg'), label: 'Bundled sunset fallback' }
-    ],
-    radius: 18000
+    baseFiles: ['high_noon.jpg'],
+    fallbackBundled: ['high_noon.jpg', 'sunset.jpg'],
+    radius: 18000,
+    aliases: ['day', 'noon', 'midday', 'high noon', 'high-noon', 'high_noon']
   },
-  'Golden Dawn': {
+  {
+    key: 'golden_dawn',
+    name: 'Golden Dawn',
     environment: 'sunset',
-    sources: [
-      { url: resolveAssetUrl('assets/sky/golden_hour.jpg'), label: 'Golden hour dawn photo sky' },
-      { url: bundledSkyAsset('golden_hour.jpg'), label: 'Bundled golden hour fallback' },
-      { url: bundledSkyAsset('sunset.jpg'), label: 'Bundled sunset fallback' }
-    ],
+    baseFiles: ['golden_hour.jpg', 'sunset_4k.jpg'],
+    fallbackBundled: ['golden_hour.jpg', 'sunset.jpg'],
+    radius: 20000,
     yawDeg: -25,
-    radius: 20000
+    aliases: ['sunrise', 'dawn', 'golden dawn', 'golden_dawn']
   },
-  'Golden Dusk': {
+  {
+    key: 'golden_dusk',
+    name: 'Golden Dusk',
     environment: 'sunset',
-    sources: [
-      { url: resolveAssetUrl('assets/sky/golden_hour.jpg'), label: 'Golden hour dusk photo sky' },
-      { url: bundledSkyAsset('golden_hour.jpg'), label: 'Bundled golden hour fallback' },
-      { url: bundledSkyAsset('sunset.jpg'), label: 'Bundled sunset fallback' }
-    ],
+    baseFiles: ['golden_hour.jpg', 'sunset_4k.jpg'],
+    fallbackBundled: ['golden_hour.jpg', 'sunset.jpg'],
+    radius: 20000,
     yawDeg: 35,
-    radius: 20000
+    aliases: ['sunset', 'dusk', 'evening', 'golden hour', 'golden_hour', 'golden-dusk']
   },
-  'Blue Hour': {
+  {
+    key: 'blue_hour',
+    name: 'Blue Hour',
     environment: 'sunset',
-    sources: [
-      { url: resolveAssetUrl('assets/sky/blue_hour.jpg'), label: 'Blue hour photo sky' },
-      { url: bundledSkyAsset('blue_hour.jpg'), label: 'Bundled blue hour fallback' },
-      { url: bundledSkyAsset('sunset.jpg'), label: 'Bundled sunset fallback' }
-    ],
-    radius: 20000
+    baseFiles: ['blue_hour.jpg', 'sunset_4k.jpg'],
+    fallbackBundled: ['blue_hour.jpg', 'sunset.jpg'],
+    radius: 20000,
+    aliases: ['blue hour', 'blue_hour', 'blue-hour']
   },
-  'Starlit Night': {
+  {
+    key: 'starlit_night',
+    name: 'Starlit Night',
     environment: 'night',
-    sources: [
-      { url: resolveAssetUrl('assets/sky/night_sky_4k.jpg'), label: 'Night sky photo panorama' },
-      { url: resolveAssetUrl('assets/sky/night_sky.jpg'), label: 'Night sky (optional external)' },
-      { url: bundledSkyAsset('night_sky.jpg'), label: 'Bundled night sky fallback' }
-    ],
+    baseFiles: ['night_sky_4k.jpg', 'night_sky.jpg'],
+    fallbackBundled: ['night_sky.jpg'],
+    radius: 22000,
     opacity: 1,
-    radius: 22000
+    aliases: ['night', 'night sky', 'night_sky', 'night-sky', 'starlit night', 'starlit_night']
+  }
+];
+
+const PHOTO_PRESET_ALIAS = new Map();
+const PHOTO_PRESET_BY_ALIAS = new Map();
+const ENVIRONMENT_ALIAS = new Map();
+const FALLBACK_ENVIRONMENT_SOURCES = new Map();
+
+function registerFallbackSources(key, baseFiles, fallbackFiles, label) {
+  const normalizedKey = normalizeSkyAlias(key);
+  if (!normalizedKey || FALLBACK_ENVIRONMENT_SOURCES.has(normalizedKey)) {
+    return;
+  }
+  const sources = Object.freeze(createSkySources(baseFiles, fallbackFiles, label));
+  FALLBACK_ENVIRONMENT_SOURCES.set(normalizedKey, sources);
+}
+
+const BUILT_PHOTO_PRESETS = {};
+
+for (const definition of PHOTO_PRESET_DEFINITIONS) {
+  const {
+    name,
+    key,
+    aliases = [],
+    baseFiles = [],
+    fallbackBundled = [],
+    ...rest
+  } = definition;
+
+  const sources = Object.freeze(createSkySources(baseFiles, fallbackBundled, `${name} photo sky`));
+  const preset = Object.freeze({ ...rest, name, sources });
+  BUILT_PHOTO_PRESETS[name] = preset;
+
+  const aliasSet = new Set([name, key, ...aliases]);
+  aliasSet.forEach((alias) => {
+    const normalized = normalizeSkyAlias(alias);
+    if (!normalized) {
+      return;
+    }
+    PHOTO_PRESET_ALIAS.set(normalized, name);
+    PHOTO_PRESET_BY_ALIAS.set(normalized, preset);
+    if (!ENVIRONMENT_ALIAS.has(normalized)) {
+      ENVIRONMENT_ALIAS.set(normalized, preset.environment ?? 'day');
+    }
+  });
+
+  registerFallbackSources(key ?? name, baseFiles, fallbackBundled, `${name} sky panorama`);
+}
+
+const fallbackLinks = [
+  ['day', 'high_noon'],
+  ['golden_hour', 'golden_dusk'],
+  ['sunset', 'golden_dusk'],
+  ['dusk', 'golden_dusk'],
+  ['evening', 'golden_dusk'],
+  ['dawn', 'golden_dawn'],
+  ['sunrise', 'golden_dawn'],
+  ['blue_hour', 'blue_hour'],
+  ['night', 'starlit_night'],
+  ['night_sky', 'starlit_night'],
+  ['starlit_night', 'starlit_night']
+];
+
+fallbackLinks.forEach(([alias, target]) => {
+  const normalizedAlias = normalizeSkyAlias(alias);
+  const normalizedTarget = normalizeSkyAlias(target);
+  if (!normalizedAlias || !normalizedTarget) {
+    return;
+  }
+  if (FALLBACK_ENVIRONMENT_SOURCES.has(normalizedAlias)) {
+    return;
+  }
+  const sources = FALLBACK_ENVIRONMENT_SOURCES.get(normalizedTarget);
+  if (sources) {
+    FALLBACK_ENVIRONMENT_SOURCES.set(normalizedAlias, sources);
   }
 });
 
-const ENVIRONMENT_ALIAS = new Map([
-  ['day', 'day'],
-  ['sunrise', 'sunset'],
-  ['sunset', 'sunset'],
-  ['dawn', 'sunset'],
-  ['dusk', 'sunset'],
-  ['evening', 'sunset'],
-  ['night', 'night'],
-  ['starlit night', 'night']
+['day', 'sunset', 'night'].forEach((key) => {
+  const normalized = normalizeSkyAlias(key);
+  if (normalized && !ENVIRONMENT_ALIAS.has(normalized)) {
+    ENVIRONMENT_ALIAS.set(normalized, key);
+  }
+});
+
+const PHOTO_SKY_PRESETS = Object.freeze(BUILT_PHOTO_PRESETS);
+
+const DEFAULT_ENVIRONMENT_PRESET = new Map([
+  ['day', 'High Noon'],
+  ['sunset', 'Golden Dusk'],
+  ['night', 'Starlit Night']
 ]);
 
 let activePhotoSkydome = null;
@@ -100,42 +244,75 @@ function disposeActivePhotoSky() {
   activePhotoPreset = null;
 }
 
+function resolvePhotoPresetName(mode) {
+  if (!mode || typeof mode !== 'string') {
+    return null;
+  }
+
+  const trimmed = mode.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  if (PHOTO_SKY_PRESETS[trimmed]) {
+    return trimmed;
+  }
+
+  const normalized = normalizeSkyAlias(trimmed);
+  if (!normalized) {
+    return null;
+  }
+
+  const aliasMatch = PHOTO_PRESET_ALIAS.get(normalized);
+  if (aliasMatch && PHOTO_SKY_PRESETS[aliasMatch]) {
+    return aliasMatch;
+  }
+
+  try {
+    const preset = resolveSkyPreset(mode);
+    if (preset && PHOTO_SKY_PRESETS[preset]) {
+      return preset;
+    }
+    const presetAlias = normalizeSkyAlias(preset);
+    if (presetAlias) {
+      const resolvedAlias = PHOTO_PRESET_ALIAS.get(presetAlias);
+      if (resolvedAlias && PHOTO_SKY_PRESETS[resolvedAlias]) {
+        return resolvedAlias;
+      }
+    }
+  } catch (error) {
+    console.warn('[sky] Unable to resolve photo sky preset.', error);
+  }
+
+  return null;
+}
+
 function resolveEnvironmentKey(mode) {
   if (!mode || typeof mode !== 'string') {
     return 'day';
   }
 
-  const normalized = mode.trim().toLowerCase();
-  if (!normalized) {
-    return 'day';
-  }
-
-  const directPreset = PHOTO_SKY_PRESETS[mode];
-  if (directPreset?.environment) {
-    return directPreset.environment;
-  }
-
-  for (const [name, preset] of Object.entries(PHOTO_SKY_PRESETS)) {
-    if (name.toLowerCase() === normalized && preset?.environment) {
+  const photoPresetName = resolvePhotoPresetName(mode);
+  if (photoPresetName) {
+    const preset = PHOTO_SKY_PRESETS[photoPresetName];
+    if (preset?.environment) {
       return preset.environment;
     }
   }
 
-  if (ENVIRONMENT_ALIAS.has(normalized)) {
+  const normalized = normalizeSkyAlias(mode);
+  if (normalized && ENVIRONMENT_ALIAS.has(normalized)) {
     return ENVIRONMENT_ALIAS.get(normalized);
   }
 
   try {
     const preset = resolveSkyPreset(mode);
-    if (preset && typeof preset === 'string') {
-      const presetKey = preset.trim().toLowerCase();
-      if (ENVIRONMENT_ALIAS.has(presetKey)) {
-        return ENVIRONMENT_ALIAS.get(presetKey);
-      }
-      const presetConfig = PHOTO_SKY_PRESETS[preset];
-      if (presetConfig?.environment) {
-        return presetConfig.environment;
-      }
+    if (preset && PHOTO_SKY_PRESETS[preset]?.environment) {
+      return PHOTO_SKY_PRESETS[preset].environment;
+    }
+    const resolvedAlias = normalizeSkyAlias(preset);
+    if (resolvedAlias && ENVIRONMENT_ALIAS.has(resolvedAlias)) {
+      return ENVIRONMENT_ALIAS.get(resolvedAlias);
     }
   } catch (error) {
     console.warn('[sky] Failed to resolve environment preset.', error);
@@ -199,122 +376,253 @@ async function ensurePhotoSky(renderer, scene, presetName, options = {}) {
   }
 }
 
-function resolvePhotoPresetName(mode) {
-  if (!mode || typeof mode !== 'string') {
-    return null;
-  }
-
-  const trimmed = mode.trim();
-  if (!trimmed) {
-    return null;
-  }
-
-  if (PHOTO_SKY_PRESETS[trimmed]) {
-    return trimmed;
-  }
-
-  const normalized = trimmed.toLowerCase();
-  for (const name of Object.keys(PHOTO_SKY_PRESETS)) {
-    if (name.toLowerCase() === normalized) {
-      return name;
+function getEnvironmentSources(presetName, environmentKey) {
+  const normalizedPreset = normalizeSkyAlias(presetName);
+  if (normalizedPreset) {
+    const preset = PHOTO_PRESET_BY_ALIAS.get(normalizedPreset);
+    if (preset?.sources?.length) {
+      return preset.sources;
+    }
+    const fallbackPresetSources = FALLBACK_ENVIRONMENT_SOURCES.get(normalizedPreset);
+    if (fallbackPresetSources) {
+      return fallbackPresetSources;
     }
   }
 
-  switch (normalized) {
-    case 'day':
-      return 'High Noon';
-    case 'sunrise':
-    case 'dawn':
-      return 'Golden Dawn';
-    case 'sunset':
-    case 'dusk':
-    case 'evening':
-      return 'Golden Dusk';
-    case 'blue hour':
-      return 'Blue Hour';
-    case 'night':
-    case 'night sky':
-    case 'starlit night':
-      return 'Starlit Night';
-    default:
-      break;
-  }
-
-  try {
-    const preset = resolveSkyPreset(mode);
-    if (preset && PHOTO_SKY_PRESETS[preset]) {
-      return preset;
+  const normalizedEnvironment = normalizeSkyAlias(environmentKey);
+  if (normalizedEnvironment) {
+    const fallbackEnvironmentSources = FALLBACK_ENVIRONMENT_SOURCES.get(normalizedEnvironment);
+    if (fallbackEnvironmentSources) {
+      return fallbackEnvironmentSources;
     }
-  } catch (error) {
-    console.warn('[sky] Unable to resolve photo sky preset.', error);
   }
 
   return null;
 }
 
 const environmentCache = new Map();
+const environmentLoaders = new Map();
 const DAY_COLOR = new THREE.Color('#87c5eb');
 
-export function loadEquirectSky(renderer, scene, path, onDone, options = {}) {
-  if (!renderer || !scene) {
-    onDone?.(null);
+function applyEnvironmentResult(scene, result, { preserveBackground } = {}) {
+  if (!scene) {
     return;
   }
 
+  if (!result || !result.environment) {
+    scene.environment = null;
+    if (!preserveBackground) {
+      scene.background = DAY_COLOR.clone();
+    }
+    return;
+  }
+
+  scene.environment = result.environment;
+  if (!preserveBackground && result.background) {
+    scene.background = result.background;
+  }
+}
+
+function normalizeSkySources(input) {
+  if (!input) {
+    return [];
+  }
+  const list = Array.isArray(input) ? input : [input];
+  const normalized = [];
+  const seen = new Set();
+  list.forEach((entry) => {
+    if (!entry) return;
+    const item = typeof entry === 'string' ? { url: entry } : entry;
+    const url = item?.url;
+    if (!url || seen.has(url)) return;
+    seen.add(url);
+    normalized.push({ ...item });
+  });
+  return normalized;
+}
+
+async function loadSkyTextureSequence(sources, loader, options = {}) {
+  const normalized = normalizeSkySources(sources);
+  let fallbackResult = null;
+
+  for (const source of normalized) {
+    if (!source?.url) {
+      continue;
+    }
+    const label = source.label ? `sky texture "${source.label}"` : 'sky texture';
+    try {
+      const texture = await loadTextureAsyncWithFallback(source.url, {
+        ...options,
+        loader,
+        label
+      });
+      if (texture?.userData?.isFallbackTexture) {
+        fallbackResult = fallbackResult ?? { texture, source };
+        console.warn(`[sky] ${label} unavailable at ${source.url}; using fallback placeholder.`);
+        continue;
+      }
+      return { texture, source };
+    } catch (error) {
+      console.warn(`[sky] Failed to load ${label} from ${source.url}`, error);
+    }
+  }
+
+  return fallbackResult;
+}
+
+export function loadEquirectSky(renderer, scene, sources, onDone, options = {}) {
+  if (!renderer || !scene) {
+    if (typeof onDone === 'function') {
+      onDone(null);
+    }
+    return Promise.resolve(null);
+  }
+
   const {
+    loader: loaderOption = null,
     applyBackground = true,
     applyEnvironment = true
   } = options;
 
-  const loader = new THREE.TextureLoader();
-  loadTextureWithFallback(path, {
-    loader,
-    label: 'sky texture',
-    fallbackColor: DAY_COLOR.getHex(),
-    onLoad: (texture, { fallback }) => {
-      if (fallback) {
-        if (applyBackground) {
-          scene.background = DAY_COLOR.clone();
-        }
-        if (applyEnvironment) {
-          scene.environment = null;
-        }
-        onDone?.(null);
-        return;
-      }
+  const textureLoader = loaderOption instanceof THREE.Loader ? loaderOption : new THREE.TextureLoader();
+  const candidateSources = normalizeSkySources(sources);
 
-      texture.mapping = THREE.EquirectangularReflectionMapping;
-      if ('colorSpace' in texture && THREE.SRGBColorSpace) {
-        texture.colorSpace = THREE.SRGBColorSpace;
-      } else {
-        const srgbEncoding = Reflect.get(THREE, 'sRGBEncoding');
-        if ('encoding' in texture && srgbEncoding) {
-          texture.encoding = srgbEncoding;
-        }
-      }
+  if (candidateSources.length === 0) {
+    if (applyBackground) {
+      scene.background = DAY_COLOR.clone();
+    }
+    if (applyEnvironment) {
+      scene.environment = null;
+    }
+    if (typeof onDone === 'function') {
+      onDone(null);
+    }
+    return Promise.resolve(null);
+  }
 
-      const pmrem = new THREE.PMREMGenerator(renderer);
-      const envTarget = pmrem.fromEquirectangular(texture);
-      pmrem.dispose();
-
-      const environmentTexture = envTarget.texture;
-
+  const promise = (async () => {
+    const loaded = await loadSkyTextureSequence(candidateSources, textureLoader);
+    if (!loaded || !loaded.texture || loaded.texture.userData?.isFallbackTexture) {
       if (applyBackground) {
-        scene.background = texture;
+        scene.background = DAY_COLOR.clone();
       }
-
       if (applyEnvironment) {
-        scene.environment = environmentTexture;
+        scene.environment = null;
       }
+      return null;
+    }
 
-      onDone?.({ background: texture, environment: environmentTexture });
-    },
-    onFallback: (error) => {
-      if (error) {
-        console.warn(`[sky] Failed to load sky texture: ${path}`, error);
+    const { texture, source } = loaded;
+    texture.mapping = THREE.EquirectangularReflectionMapping;
+    if ('colorSpace' in texture && THREE.SRGBColorSpace) {
+      texture.colorSpace = THREE.SRGBColorSpace;
+    } else {
+      const srgbEncoding = Reflect.get(THREE, 'sRGBEncoding');
+      if ('encoding' in texture && srgbEncoding) {
+        texture.encoding = srgbEncoding;
       }
     }
+    texture.needsUpdate = true;
+
+    const pmrem = new THREE.PMREMGenerator(renderer);
+    const target = pmrem.fromEquirectangular(texture);
+    pmrem.dispose();
+
+    const result = {
+      background: texture,
+      environment: target.texture,
+      renderTarget: target,
+      source
+    };
+
+    if (applyBackground) {
+      scene.background = texture;
+    }
+    if (applyEnvironment) {
+      scene.environment = target.texture;
+    }
+
+    return result;
+  })().catch((error) => {
+    console.warn('[sky] Failed to load sky texture.', error);
+    if (applyBackground) {
+      scene.background = DAY_COLOR.clone();
+    }
+    if (applyEnvironment) {
+      scene.environment = null;
+    }
+    return null;
   });
+
+  if (typeof onDone === 'function') {
+    promise.then((result) => onDone(result ?? null));
+  }
+
+  return promise;
+}
+
+async function ensureEnvironment(renderer, scene, {
+  cacheKey,
+  presetName,
+  environmentKey,
+  preserveBackground
+} = {}) {
+  if (!renderer || !scene) {
+    return null;
+  }
+
+  const normalizedCacheKey =
+    cacheKey ??
+    normalizeSkyAlias(presetName) ??
+    normalizeSkyAlias(environmentKey) ??
+    'day';
+
+  const cached = environmentCache.get(normalizedCacheKey);
+  if (cached) {
+    applyEnvironmentResult(scene, cached, { preserveBackground });
+    return cached;
+  }
+
+  const inflight = environmentLoaders.get(normalizedCacheKey);
+  if (inflight) {
+    const result = await inflight;
+    applyEnvironmentResult(scene, result, { preserveBackground });
+    return result;
+  }
+
+  const sources = getEnvironmentSources(presetName, environmentKey);
+  if (!sources || sources.length === 0) {
+    applyEnvironmentResult(scene, null, { preserveBackground });
+    return null;
+  }
+
+  const loadPromise = loadEquirectSky(renderer, scene, sources, null, {
+    applyBackground: !preserveBackground,
+    applyEnvironment: true
+  })
+    .then((result) => {
+      if (result && result.environment) {
+        environmentCache.set(normalizedCacheKey, result);
+      }
+      return result;
+    })
+    .catch((error) => {
+      console.warn(`[sky] Failed to load sky environment for ${presetName ?? environmentKey}.`, error);
+      return null;
+    });
+
+  environmentLoaders.set(normalizedCacheKey, loadPromise);
+
+  const result = await loadPromise;
+  environmentLoaders.delete(normalizedCacheKey);
+
+  if (!result) {
+    applyEnvironmentResult(scene, null, { preserveBackground });
+    return null;
+  }
+
+  applyEnvironmentResult(scene, result, { preserveBackground });
+  return result;
 }
 
 export async function setEnvironment(renderer, scene, mode = 'day', options = {}) {
@@ -331,55 +639,115 @@ export async function setEnvironment(renderer, scene, mode = 'day', options = {}
   const photoPresetName = resolvePhotoPresetName(mode);
   const presetName = photoPresetName ?? (typeof mode === 'string' ? resolveSkyPreset(mode) : null);
   const environmentKey = resolveEnvironmentKey(mode);
+  const environmentPresetName =
+    photoPresetName && PHOTO_SKY_PRESETS[photoPresetName]
+      ? photoPresetName
+      : DEFAULT_ENVIRONMENT_PRESET.get(environmentKey) ?? photoPresetName ?? environmentKey;
+  const cacheKey = normalizeSkyAlias(environmentPresetName) ?? normalizeSkyAlias(environmentKey) ?? 'day';
   const shouldUsePhotoSky = Boolean(enablePhotoSky && photoPresetName && PHOTO_SKY_PRESETS[photoPresetName]);
 
-  if (environmentKey === 'day') {
-    if (!preserveBackground) {
-      scene.background = DAY_COLOR.clone();
-    }
-    scene.environment = null;
-  } else if (!shouldUsePhotoSky) {
-    const cached = environmentCache.get(environmentKey);
-    if (cached) {
-      if (!preserveBackground) {
-        scene.background = cached.background;
-      }
-      scene.environment = cached.environment;
-    } else {
-      const texturePath = SKY_PATHS[environmentKey];
-      if (!texturePath) {
-        console.warn(`[sky] Unknown mode "${mode}", defaulting to day.`);
-        if (!preserveBackground) {
-          scene.background = DAY_COLOR.clone();
-        }
-        scene.environment = null;
-      } else {
-        loadEquirectSky(
-          renderer,
-          scene,
-          texturePath,
-          (result) => {
-            if (result) {
-              environmentCache.set(environmentKey, result);
-            } else if (!environmentCache.has(environmentKey)) {
-              if (!preserveBackground) {
-                scene.background = DAY_COLOR.clone();
-              }
-              scene.environment = null;
-            }
-          },
-          { applyBackground: !preserveBackground }
-        );
-      }
-    }
+  if (shouldUsePhotoSky && !preserveBackground) {
+    scene.background = null;
+  }
+
+  let environmentResult = null;
+
+  if (!shouldUsePhotoSky) {
+    environmentResult = await ensureEnvironment(renderer, scene, {
+      cacheKey,
+      presetName: environmentPresetName,
+      environmentKey,
+      preserveBackground
+    });
   }
 
   let photoResult = null;
   if (shouldUsePhotoSky) {
     photoResult = await ensurePhotoSky(renderer, scene, photoPresetName, photoSkyOptions);
+    if (!photoResult) {
+      environmentResult = await ensureEnvironment(renderer, scene, {
+        cacheKey,
+        presetName: environmentPresetName,
+        environmentKey,
+        preserveBackground
+      });
+    }
   } else {
     disposeActivePhotoSky();
   }
 
-  return { environment: scene.environment, photoSky: photoResult, preset: presetName, mode: environmentKey };
+  if (!shouldUsePhotoSky && !environmentResult) {
+    applyEnvironmentResult(scene, null, { preserveBackground });
+  }
+
+  return {
+    environment: scene.environment,
+    environmentPreset: environmentPresetName,
+    photoSky: photoResult,
+    preset: presetName,
+    mode: environmentKey
+  };
+}
+
+export function createEnvironmentController(renderer, scene, controllerOptions = {}) {
+  const { initialMode = null, defaultOptions = {} } = controllerOptions ?? {};
+  let disposed = false;
+  let lastMode = null;
+  let lastOptions = { ...defaultOptions };
+  let lastResult = null;
+  let requestToken = 0;
+
+  const applyMode = async (mode, overrideOptions = {}) => {
+    if (disposed) {
+      return null;
+    }
+    const token = ++requestToken;
+    const mergedOptions = { ...defaultOptions, ...overrideOptions };
+    const result = await setEnvironment(renderer, scene, mode, mergedOptions);
+    if (disposed) {
+      return null;
+    }
+    if (token === requestToken) {
+      lastMode = mode;
+      lastOptions = mergedOptions;
+      lastResult = result;
+    }
+    return result;
+  };
+
+  const controller = {
+    async setMode(mode, overrideOptions = {}) {
+      return applyMode(mode, overrideOptions);
+    },
+    async refresh(overrideOptions = {}) {
+      if (lastMode == null) {
+        return null;
+      }
+      return applyMode(lastMode, { ...lastOptions, ...overrideOptions });
+    },
+    dispose() {
+      if (disposed) {
+        return;
+      }
+      disposed = true;
+      requestToken++;
+      disposeActivePhotoSky();
+      lastMode = null;
+      lastResult = null;
+    },
+    get mode() {
+      return lastMode;
+    },
+    get lastResult() {
+      return lastResult;
+    }
+  };
+
+  if (initialMode != null) {
+    controller.setMode(initialMode, defaultOptions).catch((error) => {
+      console.warn('[sky] Failed to apply initial environment mode.', error);
+    });
+  }
+
+  return controller;
 }


### PR DESCRIPTION
## Summary
- normalize GeoJSON loading to respect the GitHub Pages base path and ensure landmark overlays draw walls, paths, and labels
- enhance landmark loading with subgroup pins, label metadata, disposal hooks, and add a reusable road network disposer
- introduce an NPC system and new initializeAthens entrypoint that wires environment presets, overlays, 3D landmarks, optional roads, and sample NPCs

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d8dff7afec8327b6a65f30007fd01a