### PR TITLE
Use character.glb for player and spawn remaining models as NPCs

### DIFF
--- a/src/entry/initializeAthens.js
+++ b/src/entry/initializeAthens.js
@@ -5,10 +5,53 @@ import { loadLandmarks } from '../landmarks-loader.js';
 import { createLandmarkOverlay } from '../map/landmarks.js';
 import { buildRoadNetwork } from '../roads/roadNetwork.js';
 import { createNpcManager } from '../npc/npcSystem.js';
+import { createMainCharacter } from '../npc/mainCharacter.js';
 
 const DEFAULT_CONTAINER_ID = 'app';
 const DEFAULT_OVERLAY_ID = 'landmark-overlay';
 const DEFAULT_GEOJSON_URL = 'data/athens_places.geojson';
+
+const DEFAULT_NPC_MODEL_URLS = [
+  'models/Adventurer.glb',
+  'models/Adventurer1.glb',
+  'models/brokenCHar.glb',
+  'models/character2.glb',
+  'models/character3.glb',
+  'models/hoplite_npc.glb',
+  'models/npc_athenian.glb'
+];
+
+function buildNpcPatrolPath(radius, angle, height = 0) {
+  const baseX = Math.cos(angle) * radius;
+  const baseZ = Math.sin(angle) * radius;
+  const offset = Math.max(2, radius * 0.25);
+
+  const waypoint = (x, z) => ({ x, y: height, z });
+
+  return [
+    waypoint(baseX, baseZ),
+    waypoint(baseX + Math.cos(angle + Math.PI / 4) * offset, baseZ + Math.sin(angle + Math.PI / 4) * offset),
+    waypoint(baseX + Math.cos(angle - Math.PI / 4) * offset, baseZ + Math.sin(angle - Math.PI / 4) * offset)
+  ];
+}
+
+function createDefaultNpcConfigs(modelUrls = DEFAULT_NPC_MODEL_URLS) {
+  if (!Array.isArray(modelUrls) || modelUrls.length === 0) {
+    return [];
+  }
+
+  const radius = 18;
+
+  return modelUrls.map((modelUrl, index) => {
+    const angle = (index / modelUrls.length) * Math.PI * 2;
+    const waypoints = buildNpcPatrolPath(radius, angle);
+    return {
+      modelUrl,
+      initialPosition: waypoints[0],
+      waypoints
+    };
+  });
+}
 
 function ensureContainerElement(options = {}) {
   if (typeof document === 'undefined') {
@@ -147,34 +190,30 @@ export async function initializeAthens(options = {}) {
   let npcManager = null;
   if (options.enableNpcs !== false) {
     npcManager = createNpcManager(scene);
+    const defaultNpcConfigs = createDefaultNpcConfigs(
+      Array.isArray(options.npcModelUrls) && options.npcModelUrls.length
+        ? options.npcModelUrls
+        : DEFAULT_NPC_MODEL_URLS
+    );
     const npcConfigs = Array.isArray(options.npcConfigs) && options.npcConfigs.length
       ? options.npcConfigs
-      : [
-          {
-            modelUrl: 'models/npc_athenian.glb',
-            initialPosition: { x: 8, y: 0, z: -6 },
-            waypoints: [
-              { x: 8, y: 0, z: -6 },
-              { x: -6, y: 0, z: -8 },
-              { x: -4, y: 0, z: 6 },
-              { x: 10, y: 0, z: 4 }
-            ]
-          },
-          {
-            modelUrl: 'models/hoplite_npc.glb',
-            initialPosition: { x: -12, y: 0, z: 12 },
-            waypoints: [
-              { x: -12, y: 0, z: 12 },
-              { x: -2, y: 0, z: 18 },
-              { x: 6, y: 0, z: 10 },
-              { x: -4, y: 0, z: 4 }
-            ]
-          }
-        ];
-    npcConfigs.slice(0, 3).forEach((config) => {
+      : defaultNpcConfigs;
+
+    npcConfigs.forEach((config) => {
+      if (!config || typeof config !== 'object') {
+        return;
+      }
       npcManager.spawn(config);
     });
   }
+
+  const mainCharacterOptions = options.mainCharacter ?? options.mainCharacterConfig ?? null;
+  const mainCharacter = options.enableMainCharacter === false
+    ? null
+    : createMainCharacter(scene, {
+        initialPosition: { x: 4, y: 0, z: 4 },
+        ...(mainCharacterOptions || {})
+      });
 
   const resizeHandler = () => {
     const { width, height } = computeContainerSize(container);
@@ -201,6 +240,7 @@ export async function initializeAthens(options = {}) {
     } catch (error) {
       console.warn('[Athens] Tree animation update failed.', error);
     }
+    mainCharacter?.update(delta);
     npcManager?.update(delta);
     landmarks.update?.(camera);
     stats?.update?.();
@@ -220,6 +260,7 @@ export async function initializeAthens(options = {}) {
     landmarks,
     roadNetwork,
     npcManager,
+    mainCharacter,
     environmentController,
     container,
     setEnvironmentMode(mode, envOptions = {}) {
@@ -238,6 +279,7 @@ export async function initializeAthens(options = {}) {
       if (overlayCanvas.parentNode === container) {
         container.removeChild(overlayCanvas);
       }
+      mainCharacter?.dispose?.();
       npcManager?.dispose?.();
       roadNetwork?.dispose?.();
       landmarks?.dispose?.();
@@ -252,6 +294,7 @@ export async function initializeAthens(options = {}) {
   if (typeof window !== 'undefined') {
     window.__athens = window.__athens || {};
     window.__athens.environment = context.environmentController;
+    window.__athens.mainCharacter = context.mainCharacter;
     window.__athens.setSkyMode = (mode, envOptions) => context.setEnvironmentMode(mode, envOptions);
   }
 

--- a/src/npc/mainCharacter.js
+++ b/src/npc/mainCharacter.js
@@ -1,0 +1,79 @@
+import { createNpc } from './npcSystem.js';
+
+function sanitizeVector(input) {
+  if (!input) {
+    return { x: 0, y: 0, z: 0 };
+  }
+
+  if (typeof input.isVector3 === 'boolean' && input.isVector3) {
+    return { x: input.x, y: input.y, z: input.z };
+  }
+
+  const { x = 0, y = 0, z = 0 } = input;
+  const toNumber = (value) => (Number.isFinite(value) ? Number(value) : 0);
+
+  return { x: toNumber(x), y: toNumber(y), z: toNumber(z) };
+}
+
+function applyScale(object3d, scale) {
+  if (!object3d) {
+    return;
+  }
+
+  if (typeof scale === 'number' && Number.isFinite(scale) && scale > 0) {
+    object3d.scale.setScalar(scale);
+    return;
+  }
+
+  if (scale && typeof scale === 'object') {
+    const { x = 1, y = 1, z = 1 } = scale;
+    const toNumber = (value) => (Number.isFinite(value) ? Number(value) : 1);
+    object3d.scale.set(toNumber(x), toNumber(y), toNumber(z));
+  }
+}
+
+/**
+ * Creates the primary controllable character using the NPC loader so it shares
+ * animation handling and GLTF loading with ambient agents.
+ *
+ * @param {import('three').Scene | null | undefined} scene
+ * @param {object} [options]
+ * @param {string} [options.modelUrl]
+ * @param {{x?:number,y?:number,z?:number} | import('three').Vector3} [options.initialPosition]
+ * @param {number} [options.headingRadians]
+ * @param {number|{x?:number,y?:number,z?:number}} [options.scale]
+ * @returns {{ object3d: import('three').Object3D; update(deltaSeconds: number): void; dispose(): void; ready: Promise<any>; }}
+ */
+export function createMainCharacter(scene, options = {}) {
+  const {
+    modelUrl = 'models/character.glb',
+    initialPosition = { x: 0, y: 0, z: 0 },
+    headingRadians = 0,
+    scale = 1
+  } = options;
+
+  const start = sanitizeVector(initialPosition);
+
+  const npc = createNpc({
+    modelUrl,
+    initialPosition: start,
+    waypoints: [start]
+  });
+
+  npc.object3d.name = 'MainCharacter';
+  npc.object3d.userData.isMainCharacter = true;
+
+  if (typeof headingRadians === 'number' && Number.isFinite(headingRadians)) {
+    npc.object3d.rotation.y = headingRadians;
+  }
+
+  applyScale(npc.object3d, scale);
+
+  if (scene && typeof scene.add === 'function') {
+    scene.add(npc.object3d);
+  }
+
+  return npc;
+}
+
+export default createMainCharacter;


### PR DESCRIPTION
## Summary
- add a main character factory that loads character.glb via the shared NPC pipeline
- update Athens initialization to spawn the main character and generate NPCs from all other model files
- expose the new character handle on the window context and allow overriding model lists via options

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d8e7706efc8327bdc8a52b139409aa