### PR TITLE
Add keyboard player controls and follow camera

### DIFF
--- a/src/camera/followCamera.js
+++ b/src/camera/followCamera.js
@@ -1,0 +1,53 @@
+import * as THREE from 'three';
+
+const tempPosition = new THREE.Vector3();
+const tempQuaternion = new THREE.Quaternion();
+const desiredPosition = new THREE.Vector3();
+const lookOffset = new THREE.Vector3();
+const targetWorldPosition = new THREE.Vector3();
+
+export function createFollowCamera(
+  camera,
+  target,
+  {
+    offset = new THREE.Vector3(0, 2.2, -6),
+    lerp = 0.12,
+    lookAtOffset = new THREE.Vector3(0, 1.5, 0)
+  } = {}
+) {
+  const options = {
+    offset: offset.clone(),
+    lerp: Number.isFinite(lerp) ? lerp : 0.12,
+    lookAtOffset: lookAtOffset.clone()
+  };
+
+  let currentTarget = target || null;
+
+  const update = () => {
+    if (!camera || !currentTarget) {
+      return;
+    }
+
+    currentTarget.getWorldPosition(targetWorldPosition);
+    currentTarget.getWorldQuaternion(tempQuaternion);
+
+    desiredPosition.copy(options.offset).applyQuaternion(tempQuaternion).add(targetWorldPosition);
+    camera.position.lerp(desiredPosition, THREE.MathUtils.clamp(options.lerp, 0, 1));
+
+    lookOffset.copy(options.lookAtOffset).applyQuaternion(tempQuaternion);
+    tempPosition.copy(targetWorldPosition).add(lookOffset);
+    camera.lookAt(tempPosition);
+  };
+
+  const setTarget = (nextTarget) => {
+    currentTarget = nextTarget || currentTarget;
+  };
+
+  return {
+    update,
+    setTarget,
+    options
+  };
+}
+
+export default createFollowCamera;

--- a/src/entry/initializeAthens.js
+++ b/src/entry/initializeAthens.js
@@ -6,6 +6,9 @@ import { createLandmarkOverlay } from '../map/landmarks.js';
 import { buildRoadNetwork } from '../roads/roadNetwork.js';
 import { createNpcManager } from '../npc/npcSystem.js';
 import { createMainCharacter } from '../npc/mainCharacter.js';
+import { createKeyboard } from '../input/keyboard.js';
+import { createFollowCamera } from '../camera/followCamera.js';
+import { createPlayerController } from '../player/playerController.js';
 
 const DEFAULT_CONTAINER_ID = 'app';
 const DEFAULT_OVERLAY_ID = 'landmark-overlay';
@@ -126,6 +129,34 @@ function ensureLights(scene) {
   }
 }
 
+function createPlaceholderPlayer() {
+  const group = new THREE.Group();
+  group.name = 'Player';
+
+  const bodyMaterial = new THREE.MeshStandardMaterial({ color: 0x2563eb, roughness: 0.65, metalness: 0.15 });
+  const accentMaterial = new THREE.MeshStandardMaterial({ color: 0xfacc15, roughness: 0.5, metalness: 0.1 });
+
+  if (typeof THREE.CapsuleGeometry === 'function') {
+    const capsule = new THREE.Mesh(new THREE.CapsuleGeometry(0.45, 1.6, 12, 24), bodyMaterial);
+    capsule.castShadow = true;
+    capsule.receiveShadow = true;
+    group.add(capsule);
+  } else {
+    const cylinder = new THREE.Mesh(new THREE.CylinderGeometry(0.5, 0.5, 1.6, 16), bodyMaterial);
+    cylinder.castShadow = true;
+    cylinder.receiveShadow = true;
+    group.add(cylinder);
+  }
+
+  const head = new THREE.Mesh(new THREE.SphereGeometry(0.42, 16, 16), accentMaterial);
+  head.position.y = 1.1;
+  head.castShadow = true;
+  head.receiveShadow = true;
+  group.add(head);
+
+  return group;
+}
+
 export async function initializeAthens(options = {}) {
   const container = ensureContainerElement(options);
   container.style.position = container.style.position || 'relative';
@@ -215,6 +246,45 @@ export async function initializeAthens(options = {}) {
         ...(mainCharacterOptions || {})
       });
 
+  const findPlayerObject = () => scene.getObjectByName('Player') || scene.getObjectByName('Hero');
+
+  let playerObject = findPlayerObject() || mainCharacter?.object3d || null;
+  let placeholderPlayer = null;
+
+  if (!playerObject) {
+    placeholderPlayer = createPlaceholderPlayer();
+    scene.add(placeholderPlayer);
+    playerObject = placeholderPlayer;
+  }
+
+  const keyboard = createKeyboard();
+  const controller = createPlayerController(playerObject, keyboard, {
+    walkSpeed: 4.0,
+    runMultiplier: 1.7,
+    turnLerp: 0.18
+  });
+  const followCamera = createFollowCamera(camera, playerObject, {
+    offset: new THREE.Vector3(0, 2.2, -6),
+    lerp: 0.12,
+    lookAtOffset: new THREE.Vector3(0, 1.5, 0)
+  });
+
+  if (mainCharacter?.ready?.then) {
+    mainCharacter.ready.then(() => {
+      const resolvedPlayer = mainCharacter.object3d || findPlayerObject() || scene.getObjectByName('MainCharacter');
+      if (resolvedPlayer) {
+        controller.setObject(resolvedPlayer);
+        followCamera.setTarget(resolvedPlayer);
+        playerObject = resolvedPlayer;
+        if (placeholderPlayer && placeholderPlayer.parent) {
+          placeholderPlayer.parent.remove(placeholderPlayer);
+        }
+      }
+    });
+  }
+
+  followCamera.update();
+
   const resizeHandler = () => {
     const { width, height } = computeContainerSize(container);
     renderer.setSize(width, height, false);
@@ -244,6 +314,8 @@ export async function initializeAthens(options = {}) {
     npcManager?.update(delta);
     landmarks.update?.(camera);
     stats?.update?.();
+    controller?.update(delta, camera);
+    followCamera?.update();
     renderer.render(scene, camera);
     frameId = requestAnimationFrame(frame);
   };
@@ -288,6 +360,7 @@ export async function initializeAthens(options = {}) {
         container.removeChild(stats.dom);
       }
       renderer.dispose();
+      keyboard?.dispose?.();
     }
   };
 

--- a/src/input/keyboard.js
+++ b/src/input/keyboard.js
@@ -1,0 +1,111 @@
+const INV_SQRT2 = 1 / Math.sqrt(2);
+
+const RELEVANT_KEYS = new Set([
+  'KeyW',
+  'KeyA',
+  'KeyS',
+  'KeyD',
+  'ArrowUp',
+  'ArrowDown',
+  'ArrowLeft',
+  'ArrowRight',
+  'ShiftLeft',
+  'ShiftRight'
+]);
+
+export function createKeyboard(target = typeof window !== 'undefined' ? window : null) {
+  const pressed = new Set();
+  const listeners = new Map();
+  const axisVector = { x: 0, z: 0 };
+
+  const handleKeyDown = (event) => {
+    if (!RELEVANT_KEYS.has(event.code)) {
+      return;
+    }
+    pressed.add(event.code);
+  };
+
+  const handleKeyUp = (event) => {
+    if (!RELEVANT_KEYS.has(event.code)) {
+      return;
+    }
+    pressed.delete(event.code);
+  };
+
+  if (target && target.addEventListener) {
+    target.addEventListener('keydown', handleKeyDown);
+    target.addEventListener('keyup', handleKeyUp);
+    listeners.set('keydown', handleKeyDown);
+    listeners.set('keyup', handleKeyUp);
+  }
+
+  const isDown = (code) => pressed.has(code);
+
+  const computeAxis = () => {
+    let x = 0;
+    let z = 0;
+
+    if (isDown('KeyA') || isDown('ArrowLeft')) {
+      x -= 1;
+    }
+    if (isDown('KeyD') || isDown('ArrowRight')) {
+      x += 1;
+    }
+    if (isDown('KeyW') || isDown('ArrowUp')) {
+      z -= 1;
+    }
+    if (isDown('KeyS') || isDown('ArrowDown')) {
+      z += 1;
+    }
+
+    if (x !== 0 && z !== 0) {
+      x *= INV_SQRT2;
+      z *= INV_SQRT2;
+    }
+
+    axisVector.x = x;
+    axisVector.z = z;
+    return axisVector;
+  };
+
+  const axis = {};
+  Object.defineProperties(axis, {
+    x: {
+      enumerable: true,
+      get() {
+        return computeAxis().x;
+      }
+    },
+    z: {
+      enumerable: true,
+      get() {
+        return computeAxis().z;
+      }
+    },
+    running: {
+      enumerable: true,
+      get() {
+        return isDown('ShiftLeft') || isDown('ShiftRight');
+      }
+    }
+  });
+
+  const dispose = () => {
+    if (!target || !target.removeEventListener) {
+      return;
+    }
+    listeners.forEach((handler, type) => {
+      target.removeEventListener(type, handler);
+    });
+    listeners.clear();
+    pressed.clear();
+  };
+
+  return {
+    isDown,
+    axis,
+    dispose
+  };
+}
+
+export default createKeyboard;

--- a/src/player/playerController.js
+++ b/src/player/playerController.js
@@ -1,0 +1,78 @@
+import * as THREE from 'three';
+
+const WORLD_UP = new THREE.Vector3(0, 1, 0);
+const cameraForward = new THREE.Vector3();
+const cameraRight = new THREE.Vector3();
+const moveDirection = new THREE.Vector3();
+const targetQuaternion = new THREE.Quaternion();
+const referenceForward = new THREE.Vector3(0, 0, 1);
+
+export function createPlayerController(
+  object3d,
+  keyboard,
+  {
+    walkSpeed = 4.0,
+    runMultiplier = 1.7,
+    turnLerp = 0.18
+  } = {}
+) {
+  let controlledObject = object3d || null;
+
+  const getSpeed = () => {
+    const base = Number.isFinite(walkSpeed) ? walkSpeed : 4.0;
+    const multiplier = keyboard?.axis?.running ? runMultiplier : 1;
+    return base * (Number.isFinite(multiplier) && multiplier > 0 ? multiplier : 1);
+  };
+
+  const update = (deltaSeconds, camera) => {
+    if (!controlledObject || !keyboard || !camera) {
+      return;
+    }
+
+    camera.getWorldDirection(cameraForward);
+    cameraForward.y = 0;
+    if (cameraForward.lengthSq() < 1e-6) {
+      cameraForward.set(0, 0, -1);
+    } else {
+      cameraForward.normalize();
+    }
+
+    cameraRight.copy(cameraForward).cross(WORLD_UP).normalize();
+
+    moveDirection.set(0, 0, 0);
+    const axisX = keyboard.axis?.x || 0;
+    const axisZ = keyboard.axis?.z || 0;
+
+    if (axisZ !== 0) {
+      moveDirection.addScaledVector(cameraForward, -axisZ);
+    }
+    if (axisX !== 0) {
+      moveDirection.addScaledVector(cameraRight, axisX);
+    }
+
+    const lengthSq = moveDirection.lengthSq();
+    if (lengthSq > 1e-6) {
+      moveDirection.normalize();
+      const speed = getSpeed();
+      const distance = speed * (Number.isFinite(deltaSeconds) ? deltaSeconds : 0);
+      controlledObject.position.addScaledVector(moveDirection, distance);
+
+      targetQuaternion.setFromUnitVectors(referenceForward, moveDirection);
+      controlledObject.quaternion.slerp(targetQuaternion, THREE.MathUtils.clamp(turnLerp, 0, 1));
+    }
+  };
+
+  const setObject = (nextObject) => {
+    if (!nextObject) {
+      return;
+    }
+    controlledObject = nextObject;
+  };
+
+  return {
+    update,
+    setObject
+  };
+}
+
+export default createPlayerController;


### PR DESCRIPTION
## Summary
- add keyboard input helper for WASD/arrow/shift states
- introduce player controller with camera-relative movement and smooth rotation
- integrate smooth follow camera into the Athens bootstrap with placeholder fallback for the player

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d8eae8a38083279f961abb9be4e4d5