### PR TITLE
Ensure character GLB models are published with static assets

### DIFF
--- a/scripts/generate-static-assets.js
+++ b/scripts/generate-static-assets.js
@@ -1,5 +1,5 @@
 import { existsSync } from 'node:fs';
-import { mkdir, readFile, writeFile, copyFile } from 'node:fs/promises';
+import { mkdir, readFile, writeFile, copyFile, readdir } from 'node:fs/promises';
 import { basename, dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
@@ -321,11 +321,20 @@ async function copyNpcModel(filename) {
   console.log(`Copied ${filename}`);
 }
 
+async function copyNpcModels() {
+  const entries = await readdir(SOURCE_MODELS_DIR, { withFileTypes: true });
+
+  await Promise.all(
+    entries
+      .filter((entry) => entry.isFile() && entry.name.toLowerCase().endsWith('.glb'))
+      .map((entry) => copyNpcModel(entry.name))
+  );
+}
+
 async function main() {
   await writeGlb(createCypressDocument(), join(PUBLIC_MODELS_DIR, 'cypress.glb'));
   await writeGlb(createPlaneTreeDocument(), join(PUBLIC_MODELS_DIR, 'plane.glb'));
-  await copyNpcModel('hoplite_npc.glb');
-  await copyNpcModel('npc_athenian.glb');
+  await copyNpcModels();
 
   const noticePath = join(PUBLIC_MODELS_DIR, 'README.txt');
   await writeFile(noticePath, `Generated assets.${GENERATED_NOTE}`);

--- a/src/npc/npcSystem.js
+++ b/src/npc/npcSystem.js
@@ -131,9 +131,8 @@ export function createNpc({
     }
 
     const normalized = trimmed.replace(/^\/+/, '');
-    if (/^models\/(hoplite_npc|npc_athenian)\.glb$/i.test(normalized)) {
-      const file = normalized.split('/').pop();
-      return assetUrl(`assets/models/${file}`);
+    if (normalized.toLowerCase().startsWith('models/')) {
+      return assetUrl(`assets/models/${normalized.slice('models/'.length)}`);
     }
 
     return resolveAssetUrl(trimmed);


### PR DESCRIPTION
## Summary
- update the static asset generation script to copy every GLB model from the source models directory into the published assets folder
- normalize NPC model URLs so references to files under `models/` resolve to the copied assets bundle at build time

## Testing
- npm run generate:assets *(fails: missing @gltf-transform/core in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d8fb9552288327a9b9e289b352861c