### PR TITLE
Fix NPC model URL normalization for prefixed asset paths

### DIFF
--- a/scripts/generate-static-assets.js
+++ b/scripts/generate-static-assets.js
@@ -1,5 +1,5 @@
 import { existsSync } from 'node:fs';
-import { mkdir, readFile, writeFile, copyFile } from 'node:fs/promises';
+import { mkdir, readFile, writeFile, copyFile, readdir } from 'node:fs/promises';
 import { basename, dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
@@ -321,11 +321,20 @@ async function copyNpcModel(filename) {
   console.log(`Copied ${filename}`);
 }
 
+async function copyNpcModels() {
+  const entries = await readdir(SOURCE_MODELS_DIR, { withFileTypes: true });
+
+  await Promise.all(
+    entries
+      .filter((entry) => entry.isFile() && entry.name.toLowerCase().endsWith('.glb'))
+      .map((entry) => copyNpcModel(entry.name))
+  );
+}
+
 async function main() {
   await writeGlb(createCypressDocument(), join(PUBLIC_MODELS_DIR, 'cypress.glb'));
   await writeGlb(createPlaneTreeDocument(), join(PUBLIC_MODELS_DIR, 'plane.glb'));
-  await copyNpcModel('hoplite_npc.glb');
-  await copyNpcModel('npc_athenian.glb');
+  await copyNpcModels();
 
   const noticePath = join(PUBLIC_MODELS_DIR, 'README.txt');
   await writeFile(noticePath, `Generated assets.${GENERATED_NOTE}`);

--- a/src/npc/npcSystem.js
+++ b/src/npc/npcSystem.js
@@ -130,10 +130,15 @@ export function createNpc({
       return assetUrl(trimmed);
     }
 
+    const assetsIndex = trimmed.toLowerCase().indexOf('assets/models/');
+    if (assetsIndex >= 0) {
+      const relativeAssetPath = trimmed.slice(assetsIndex).replace(/^\/+/, '');
+      return assetUrl(relativeAssetPath);
+    }
+
     const normalized = trimmed.replace(/^\/+/, '');
-    if (/^models\/(hoplite_npc|npc_athenian)\.glb$/i.test(normalized)) {
-      const file = normalized.split('/').pop();
-      return assetUrl(`assets/models/${file}`);
+    if (normalized.toLowerCase().startsWith('models/')) {
+      return assetUrl(`assets/models/${normalized.slice('models/'.length)}`);
     }
 
     return resolveAssetUrl(trimmed);


### PR DESCRIPTION
## Summary
- normalize NPC model URLs that include a leading site base before `assets/models/` so they resolve via the asset helper

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_b_68d8fb9552288327a9b9e289b352861c