### PR TITLE
Add NPC ground snapping and upright stabilization

### DIFF
--- a/src/entry/initializeAthens.js
+++ b/src/entry/initializeAthens.js
@@ -10,6 +10,7 @@ import { createKeyboard } from '../input/keyboard.js';
 import { createFollowCamera } from '../camera/followCamera.js';
 import { createPlayerController } from '../player/playerController.js';
 import { assetUrl } from '../utils/assetUrl.js';
+import { markGround, collectGround } from '../physics/groundRegistry.js';
 
 const DEFAULT_CONTAINER_ID = 'app';
 const DEFAULT_OVERLAY_ID = 'landmark-overlay';
@@ -202,6 +203,9 @@ export async function initializeAthens(options = {}) {
 
   await setupGround(scene, renderer);
 
+  markGround(scene);
+  const groundMeshes = collectGround(scene);
+
   const landmarks = await loadLandmarks({
     scene,
     geoJsonUrl: options.geoJsonUrl ?? DEFAULT_GEOJSON_URL
@@ -312,7 +316,7 @@ export async function initializeAthens(options = {}) {
       console.warn('[Athens] Tree animation update failed.', error);
     }
     mainCharacter?.update(delta);
-    npcManager?.update(delta);
+    npcManager?.update(delta, { groundMeshes });
     landmarks.update?.(camera);
     stats?.update?.();
     controller?.update(delta, camera);

--- a/src/npc/npcSystem.js
+++ b/src/npc/npcSystem.js
@@ -2,12 +2,13 @@ import * as THREE from 'three';
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 import { resolveAssetUrl } from '../utils/asset-paths.js';
 import { assetUrl } from '../utils/assetUrl.js';
+import { snapToGround } from '../physics/groundSnap.js';
+import { keepUpright } from '../physics/upright.js';
 
 const loader = new GLTFLoader();
 const DEFAULT_SPEED = 1.6; // meters per second
 const DEFAULT_IDLE_SECONDS = 2.5;
 const tempDirection = new THREE.Vector3();
-const tempQuaternion = new THREE.Quaternion();
 
 function toVector3(value) {
   if (!value) {
@@ -90,8 +91,21 @@ export function createNpc({
   const npcState = {
     mixer: null,
     root: null,
-    ready: null
+    ready: null,
+    physics: {
+      vy: 0,
+      lastGoodY: startPosition.y,
+      yaw: 0
+    }
   };
+
+  if (path.length > 1) {
+    tempDirection.subVectors(path[1], startPosition);
+    tempDirection.y = 0;
+    if (tempDirection.lengthSq() > 1e-6) {
+      npcState.physics.yaw = Math.atan2(tempDirection.x, tempDirection.z);
+    }
+  }
 
   const normalizedSpeed = Number.isFinite(speed) && speed > 0 ? speed : DEFAULT_SPEED;
   const normalizedIdle = Number.isFinite(idleSeconds) && idleSeconds >= 0 ? idleSeconds : DEFAULT_IDLE_SECONDS;
@@ -102,6 +116,15 @@ export function createNpc({
     }
     npcState.root = modelGroup;
     object3d.add(modelGroup);
+
+    const euler = new THREE.Euler();
+    euler.setFromQuaternion(modelGroup.quaternion, 'YXZ');
+    const pitch = Math.abs(THREE.MathUtils.radToDeg(euler.x));
+    const roll = Math.abs(THREE.MathUtils.radToDeg(euler.z));
+    if (pitch > 15 || roll > 15) {
+      modelGroup.rotation.x = 0;
+      modelGroup.rotation.z = 0;
+    }
   };
 
   const normalizeModelUrl = (input) => {
@@ -186,7 +209,7 @@ export function createNpc({
 
   npcState.ready = loadModel();
 
-  const update = (deltaSeconds) => {
+  const update = (deltaSeconds, context = {}) => {
     if (disposed) {
       return;
     }
@@ -208,9 +231,11 @@ export function createNpc({
     }
 
     tempDirection.subVectors(target, object3d.position);
+    tempDirection.y = 0;
     const distance = tempDirection.length();
     if (distance < 1e-4) {
-      object3d.position.copy(target);
+      object3d.position.x = target.x;
+      object3d.position.z = target.z;
       nextIndex = (nextIndex + 1) % path.length;
       dwellTime = normalizedIdle;
       return;
@@ -219,19 +244,22 @@ export function createNpc({
     tempDirection.normalize();
     const step = normalizedSpeed * dt;
     if (step >= distance) {
-      object3d.position.copy(target);
+      object3d.position.x = target.x;
+      object3d.position.z = target.z;
       nextIndex = (nextIndex + 1) % path.length;
       dwellTime = normalizedIdle;
     } else {
       object3d.position.addScaledVector(tempDirection, step);
     }
 
-    // Face movement direction smoothly
-    if (tempDirection.lengthSq() > 0) {
-      const yaw = Math.atan2(tempDirection.x, tempDirection.z);
-      tempQuaternion.setFromEuler(new THREE.Euler(0, yaw, 0));
-      object3d.quaternion.slerp(tempQuaternion, Math.min(1, dt * 6));
+    if (tempDirection.lengthSq() > 1e-6) {
+      npcState.physics.yaw = Math.atan2(tempDirection.x, tempDirection.z);
     }
+
+    const groundMeshes = context.groundMeshes;
+    snapToGround(object3d, groundMeshes, npcState.physics, dt);
+
+    keepUpright(object3d, npcState.physics.yaw, 0.18);
   };
 
   const dispose = () => {
@@ -284,12 +312,12 @@ export function createNpcManager(scene) {
       };
       return npc;
     },
-    update(deltaSeconds) {
+    update(deltaSeconds, context = {}) {
       if (disposed) {
         return;
       }
       for (const npc of npcs) {
-        npc.update?.(deltaSeconds);
+        npc.update?.(deltaSeconds, context);
       }
     },
     dispose() {

--- a/src/physics/groundRegistry.js
+++ b/src/physics/groundRegistry.js
@@ -1,0 +1,68 @@
+import * as THREE from 'three';
+
+const GROUND_KEYWORDS = [
+  'ground',
+  'terrain',
+  'plaza',
+  'agora',
+  'acropolis',
+  'city',
+  'wall',
+  'road'
+];
+
+function looksLikeGround(object) {
+  if (!object || !object.name) {
+    return false;
+  }
+  const name = String(object.name).toLowerCase();
+  return GROUND_KEYWORDS.some((keyword) => name.includes(keyword));
+}
+
+function tagGround(object) {
+  if (!object) {
+    return;
+  }
+  object.userData = object.userData || {};
+  object.userData.isGround = true;
+}
+
+function traverse(root, callback) {
+  if (!root) {
+    return;
+  }
+  if (typeof root.traverse === 'function') {
+    root.traverse(callback);
+  } else {
+    callback(root);
+  }
+}
+
+export function markGround(root) {
+  traverse(root, (child) => {
+    if (!child || !child.visible) {
+      return;
+    }
+    if (child.isMesh || child.isSkinnedMesh || child instanceof THREE.Mesh) {
+      if (child.userData?.isGround) {
+        return;
+      }
+      if (looksLikeGround(child)) {
+        tagGround(child);
+      }
+    }
+  });
+}
+
+export function collectGround(rootOrScene) {
+  const grounds = [];
+  traverse(rootOrScene, (child) => {
+    if (!child) {
+      return;
+    }
+    if ((child.isMesh || child.isSkinnedMesh || child instanceof THREE.Mesh) && child.userData?.isGround) {
+      grounds.push(child);
+    }
+  });
+  return grounds;
+}

--- a/src/physics/groundSnap.js
+++ b/src/physics/groundSnap.js
@@ -1,0 +1,97 @@
+import * as THREE from 'three';
+
+const DOWN = new THREE.Vector3(0, -1, 0);
+const RAY_ORIGIN = new THREE.Vector3();
+const RAYCASTER = new THREE.Raycaster();
+const DEFAULT_OPTIONS = {
+  gravity: 12,
+  stepMax: 0.6,
+  hover: 0.03
+};
+
+function ensureState(state, positionY) {
+  if (!state || typeof state !== 'object') {
+    return {
+      vy: 0,
+      lastGoodY: Number.isFinite(positionY) ? positionY : 0
+    };
+  }
+  if (!Number.isFinite(state.vy)) {
+    state.vy = 0;
+  }
+  if (!Number.isFinite(state.lastGoodY)) {
+    state.lastGoodY = Number.isFinite(positionY) ? positionY : 0;
+  }
+  return state;
+}
+
+function chooseHit(intersections) {
+  if (!Array.isArray(intersections) || intersections.length === 0) {
+    return null;
+  }
+  for (let i = 0; i < intersections.length; i += 1) {
+    const hit = intersections[i];
+    if (hit && hit.object && hit.point) {
+      return hit;
+    }
+  }
+  return null;
+}
+
+export function snapToGround(object3d, groundMeshes, inputState, deltaSeconds = 0, options = DEFAULT_OPTIONS) {
+  if (!object3d) {
+    return false;
+  }
+
+  const state = ensureState(inputState, object3d.position?.y ?? 0);
+  const dt = Number.isFinite(deltaSeconds) && deltaSeconds > 0 ? deltaSeconds : 0;
+  const meshes = Array.isArray(groundMeshes) ? groundMeshes : [];
+
+  const gravity = Number.isFinite(options?.gravity) ? options.gravity : DEFAULT_OPTIONS.gravity;
+  const stepMax = Number.isFinite(options?.stepMax) ? options.stepMax : DEFAULT_OPTIONS.stepMax;
+  const hover = Number.isFinite(options?.hover) ? options.hover : DEFAULT_OPTIONS.hover;
+
+  if (dt > 0) {
+    state.vy += gravity * dt;
+  }
+
+  const vy = state.vy;
+  const fallDistance = vy * dt;
+  const position = object3d.position;
+  const predictedY = position.y - fallDistance;
+
+  if (meshes.length > 0) {
+    RAY_ORIGIN.copy(position);
+    RAY_ORIGIN.y += 1.2;
+
+    RAYCASTER.ray.origin.copy(RAY_ORIGIN);
+    RAYCASTER.ray.direction.copy(DOWN);
+    RAYCASTER.near = 0;
+    RAYCASTER.far = Math.max(5, 1.2 + stepMax + hover + Math.abs(vy * 0.5));
+
+    const intersections = RAYCASTER.intersectObjects(meshes, false);
+    const hit = chooseHit(intersections);
+
+    if (hit) {
+      const hitY = hit.point.y;
+      if (hitY >= predictedY && hitY - predictedY <= stepMax) {
+        position.y = hitY + hover;
+        state.vy = 0;
+        state.lastGoodY = hitY;
+        return true;
+      }
+    }
+  }
+
+  position.y = predictedY;
+  state.vy = vy;
+
+  const lastGoodY = Number.isFinite(state.lastGoodY) ? state.lastGoodY : position.y;
+  if (lastGoodY - position.y > 2) {
+    position.y = lastGoodY + hover;
+    state.vy = 0;
+    return true;
+  }
+
+  return false;
+}

--- a/src/physics/upright.js
+++ b/src/physics/upright.js
@@ -1,0 +1,31 @@
+import * as THREE from 'three';
+
+const EULER_HELPER = new THREE.Euler(0, 0, 0, 'YXZ');
+const TARGET_EULER = new THREE.Euler(0, 0, 0, 'YXZ');
+const TARGET_QUATERNION = new THREE.Quaternion();
+const FORWARD = new THREE.Vector3(0, 0, 1);
+const FORWARD_WORLD = new THREE.Vector3();
+
+function deriveYaw(object3d) {
+  if (!object3d) {
+    return 0;
+  }
+  FORWARD_WORLD.copy(FORWARD).applyQuaternion(object3d.quaternion);
+  return Math.atan2(FORWARD_WORLD.x, FORWARD_WORLD.z);
+}
+
+export function keepUpright(object3d, yawTarget, lerp = 0.2) {
+  if (!object3d) {
+    return;
+  }
+
+  const amount = THREE.MathUtils.clamp(Number.isFinite(lerp) ? lerp : 0.2, 0, 1);
+
+  EULER_HELPER.setFromQuaternion(object3d.quaternion, 'YXZ');
+  const desiredYaw = Number.isFinite(yawTarget) ? yawTarget : deriveYaw(object3d);
+
+  TARGET_EULER.set(0, desiredYaw, 0);
+  TARGET_QUATERNION.setFromEuler(TARGET_EULER);
+
+  object3d.quaternion.slerp(TARGET_QUATERNION, amount);
+}


### PR DESCRIPTION
## Summary
- tag terrain meshes in the scene so NPC physics can find ground colliders
- add reusable ground snapping, gravity and upright utilities for NPC controllers
- integrate the physics helpers into the NPC system and scene initialization

## Testing
- npm run build *(fails: cannot find package '@gltf-transform/core')*

------
https://chatgpt.com/codex/tasks/task_b_68d90172ea808327a68efede49c4a42b