### PR TITLE
Enable flight controls and restore classic HUD

### DIFF
--- a/src/entry/initializeAthens.js
+++ b/src/entry/initializeAthens.js
@@ -11,6 +11,23 @@ import { createFollowCamera } from '../camera/followCamera.js';
 import { createPlayerController } from '../player/playerController.js';
 import { assetUrl } from '../utils/assetUrl.js';
 import { createCity } from '../buildings/createCity.js';
+import { createOriginalUi } from '../ui/originalUi.js';
+
+const ENVIRONMENT_LABELS = {
+  high_noon: 'High Noon',
+  golden_hour: 'Golden Hour',
+  dawn: 'Golden Dawn',
+  dusk: 'Dusk',
+  midnight: 'Midnight'
+};
+
+const formatEnvironmentLabel = (mode) => {
+  if (!mode) {
+    return '';
+  }
+  const normalized = String(mode).toLowerCase();
+  return ENVIRONMENT_LABELS[normalized] || normalized.replace(/_/g, ' ');
+};
 
 const DEFAULT_CONTAINER_ID = 'app';
 const DEFAULT_OVERLAY_ID = 'landmark-overlay';
@@ -216,6 +233,8 @@ export async function initializeAthens(options = {}) {
     geoJsonUrl: options.geoJsonUrl ?? DEFAULT_GEOJSON_URL
   });
   landmarks.featureLines?.updateResolution?.();
+  const ui = createOriginalUi({ container, overlayCanvas, environmentController });
+  ui?.setTimeLabel?.(formatEnvironmentLabel(environmentController?.mode) || 'High Noon');
 
   let roadNetwork = null;
   if (options.enableRoads !== false) {
@@ -263,9 +282,11 @@ export async function initializeAthens(options = {}) {
 
   const keyboard = createKeyboard();
   const controller = createPlayerController(playerObject, keyboard, {
-    walkSpeed: 4.0,
-    runMultiplier: 1.7,
-    turnLerp: 0.18
+    walkSpeed: 5.5,
+    runMultiplier: 2.0,
+    flyMultiplier: 1.6,
+    turnLerp: 0.18,
+    flightToggleKey: 'KeyX'
   });
   const followCamera = createFollowCamera(camera, playerObject, {
     offset: new THREE.Vector3(0, 2.2, -6),
@@ -319,6 +340,11 @@ export async function initializeAthens(options = {}) {
     landmarks.update?.(camera);
     stats?.update?.();
     controller?.update(delta, camera);
+    ui?.update?.(delta, {
+      position: playerObject?.position,
+      isFlying: controller?.isFlying?.(),
+      isRunning: controller?.isRunning?.()
+    });
     followCamera?.update();
     renderer.render(scene, camera);
     frameId = requestAnimationFrame(frame);
@@ -340,7 +366,12 @@ export async function initializeAthens(options = {}) {
     environmentController,
     city,
     container,
+    ui,
     setEnvironmentMode(mode, envOptions = {}) {
+      const label = formatEnvironmentLabel(mode);
+      if (label) {
+        ui?.setTimeLabel?.(label);
+      }
       return environmentController?.setMode?.(mode, envOptions);
     },
     dispose() {
@@ -353,14 +384,15 @@ export async function initializeAthens(options = {}) {
       }
       window.removeEventListener('resize', resizeHandler);
       overlay?.destroy?.();
-      if (overlayCanvas.parentNode === container) {
-        container.removeChild(overlayCanvas);
+      if (overlayCanvas.parentNode) {
+        overlayCanvas.parentNode.removeChild(overlayCanvas);
       }
       mainCharacter?.dispose?.();
       npcManager?.dispose?.();
       roadNetwork?.dispose?.();
       landmarks?.dispose?.();
       environmentController?.dispose?.();
+      ui?.dispose?.();
       if (stats?.dom && stats.dom.parentNode === container) {
         container.removeChild(stats.dom);
       }
@@ -375,6 +407,7 @@ export async function initializeAthens(options = {}) {
     window.__athens.mainCharacter = context.mainCharacter;
     window.__athens.setSkyMode = (mode, envOptions) => context.setEnvironmentMode(mode, envOptions);
     window.__athens.city = context.city;
+    window.__athens.ui = context.ui;
   }
 
   return context;

--- a/src/input/keyboard.js
+++ b/src/input/keyboard.js
@@ -10,7 +10,15 @@ const RELEVANT_KEYS = new Set([
   'ArrowLeft',
   'ArrowRight',
   'ShiftLeft',
-  'ShiftRight'
+  'ShiftRight',
+  'Space',
+  'KeyX',
+  'KeyC',
+  'KeyE',
+  'KeyQ',
+  'KeyZ',
+  'ControlLeft',
+  'ControlRight'
 ]);
 
 export function createKeyboard(target = typeof window !== 'undefined' ? window : null) {

--- a/src/player/playerController.js
+++ b/src/player/playerController.js
@@ -4,6 +4,7 @@ const WORLD_UP = new THREE.Vector3(0, 1, 0);
 const cameraForward = new THREE.Vector3();
 const cameraRight = new THREE.Vector3();
 const moveDirection = new THREE.Vector3();
+const horizontalDirection = new THREE.Vector3();
 const targetQuaternion = new THREE.Quaternion();
 const referenceForward = new THREE.Vector3(0, 0, 1);
 
@@ -11,23 +12,37 @@ export function createPlayerController(
   object3d,
   keyboard,
   {
-    walkSpeed = 4.0,
-    runMultiplier = 1.7,
-    turnLerp = 0.18
+    walkSpeed = 5.5,
+    runMultiplier = 2.0,
+    flyMultiplier = 1.6,
+    turnLerp = 0.18,
+    flightToggleKey = 'KeyX'
   } = {}
 ) {
   let controlledObject = object3d || null;
+  let flightEnabled = false;
+  let previousToggleDown = false;
+  let runningState = false;
+
+  const isKeyDown = (code) => (typeof keyboard?.isDown === 'function' ? keyboard.isDown(code) : false);
 
   const getSpeed = () => {
     const base = Number.isFinite(walkSpeed) ? walkSpeed : 4.0;
-    const multiplier = keyboard?.axis?.running ? runMultiplier : 1;
-    return base * (Number.isFinite(multiplier) && multiplier > 0 ? multiplier : 1);
+    const runningMultiplier = runningState && Number.isFinite(runMultiplier) && runMultiplier > 0 ? runMultiplier : 1;
+    const activeFlyMultiplier = flightEnabled && Number.isFinite(flyMultiplier) && flyMultiplier > 0 ? flyMultiplier : 1;
+    return base * runningMultiplier * activeFlyMultiplier;
   };
 
   const update = (deltaSeconds, camera) => {
     if (!controlledObject || !keyboard || !camera) {
       return;
     }
+
+    const toggleDown = flightToggleKey ? isKeyDown(flightToggleKey) : false;
+    if (toggleDown && !previousToggleDown) {
+      flightEnabled = !flightEnabled;
+    }
+    previousToggleDown = toggleDown;
 
     camera.getWorldDirection(cameraForward);
     cameraForward.y = 0;
@@ -50,6 +65,28 @@ export function createPlayerController(
       moveDirection.addScaledVector(cameraRight, axisX);
     }
 
+    const shiftDown = isKeyDown('ShiftLeft') || isKeyDown('ShiftRight');
+    runningState = !flightEnabled && shiftDown;
+
+    if (flightEnabled) {
+      let verticalInput = 0;
+      if (isKeyDown('Space')) {
+        verticalInput += 1;
+      }
+      if (
+        shiftDown ||
+        isKeyDown('ControlLeft') ||
+        isKeyDown('ControlRight') ||
+        isKeyDown('KeyC') ||
+        isKeyDown('KeyZ')
+      ) {
+        verticalInput -= 1;
+      }
+      if (verticalInput !== 0) {
+        moveDirection.y = verticalInput;
+      }
+    }
+
     const lengthSq = moveDirection.lengthSq();
     if (lengthSq > 1e-6) {
       moveDirection.normalize();
@@ -57,8 +94,13 @@ export function createPlayerController(
       const distance = speed * (Number.isFinite(deltaSeconds) ? deltaSeconds : 0);
       controlledObject.position.addScaledVector(moveDirection, distance);
 
-      targetQuaternion.setFromUnitVectors(referenceForward, moveDirection);
-      controlledObject.quaternion.slerp(targetQuaternion, THREE.MathUtils.clamp(turnLerp, 0, 1));
+      horizontalDirection.copy(moveDirection);
+      horizontalDirection.y = 0;
+      if (horizontalDirection.lengthSq() > 1e-6) {
+        horizontalDirection.normalize();
+        targetQuaternion.setFromUnitVectors(referenceForward, horizontalDirection);
+        controlledObject.quaternion.slerp(targetQuaternion, THREE.MathUtils.clamp(turnLerp, 0, 1));
+      }
     }
   };
 
@@ -71,7 +113,13 @@ export function createPlayerController(
 
   return {
     update,
-    setObject
+    setObject,
+    isFlying() {
+      return flightEnabled;
+    },
+    isRunning() {
+      return runningState;
+    }
   };
 }
 

--- a/src/ui/originalUi.js
+++ b/src/ui/originalUi.js
@@ -1,0 +1,464 @@
+const ENVIRONMENT_LABELS = {
+  high_noon: 'High Noon',
+  golden_hour: 'Golden Hour',
+  dawn: 'Golden Dawn',
+  dusk: 'Dusk',
+  midnight: 'Midnight'
+};
+
+const STATUS_UPDATE_INTERVAL = 0.1; // seconds
+
+const applyStyles = (element, styles = {}) => {
+  if (!element) {
+    return;
+  }
+  Object.assign(element.style, styles);
+};
+
+const formatEnvironmentLabel = (mode) => {
+  if (!mode) {
+    return '';
+  }
+  const normalized = String(mode).toLowerCase();
+  return ENVIRONMENT_LABELS[normalized] || normalized.replace(/_/g, ' ');
+};
+
+export function createOriginalUi({
+  container,
+  overlayCanvas,
+  environmentController
+} = {}) {
+  const doc = container?.ownerDocument ?? (typeof document !== 'undefined' ? document : null);
+  if (!container || !doc) {
+    return null;
+  }
+
+  container.style.position = container.style.position || 'relative';
+
+  const createdNodes = [];
+  const cleanupFns = [];
+
+  const root = doc.createElement('div');
+  root.className = 'athens-ui-root';
+  applyStyles(root, {
+    position: 'absolute',
+    inset: '0',
+    pointerEvents: 'none',
+    fontFamily: "'Cormorant Garamond', serif",
+    color: '#fef9e6',
+    textShadow: '0 2px 8px rgba(0, 0, 0, 0.55)',
+    zIndex: '220',
+    display: 'flex',
+    flexDirection: 'column'
+  });
+  container.appendChild(root);
+  createdNodes.push(root);
+
+  const startOverlay = doc.createElement('div');
+  startOverlay.className = 'athens-start-overlay';
+  applyStyles(startOverlay, {
+    position: 'absolute',
+    inset: '0',
+    background: 'rgba(0, 0, 0, 0.72)',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    pointerEvents: 'auto',
+    backdropFilter: 'blur(5px)',
+    transition: 'opacity 0.6s ease',
+    zIndex: '260'
+  });
+  const startButton = doc.createElement('button');
+  startButton.type = 'button';
+  startButton.textContent = 'Enter Ancient Athens';
+  applyStyles(startButton, {
+    background: 'linear-gradient(135deg, rgba(255, 215, 0, 0.85), rgba(255, 165, 0, 0.75))',
+    border: '2px solid rgba(255, 215, 0, 0.95)',
+    color: '#fff',
+    fontFamily: "'Cinzel', serif",
+    padding: '16px 32px',
+    borderRadius: '16px',
+    cursor: 'pointer',
+    fontSize: '20px',
+    letterSpacing: '0.03em',
+    textShadow: '0 0 18px rgba(255, 215, 0, 0.55)',
+    boxShadow: '0 0 25px rgba(255, 215, 0, 0.45)',
+    pointerEvents: 'auto'
+  });
+  startOverlay.appendChild(startButton);
+  container.appendChild(startOverlay);
+  createdNodes.push(startOverlay);
+
+  let overlayHidden = false;
+  const hideStartOverlay = () => {
+    if (!startOverlay.parentNode || overlayHidden) {
+      return;
+    }
+    overlayHidden = true;
+    startOverlay.style.opacity = '0';
+    startOverlay.style.pointerEvents = 'none';
+    const timeout = setTimeout(() => {
+      if (startOverlay.parentNode) {
+        startOverlay.parentNode.removeChild(startOverlay);
+      }
+    }, 650);
+    cleanupFns.push(() => clearTimeout(timeout));
+  };
+
+  const handleStart = (event) => {
+    event?.preventDefault?.();
+    hideStartOverlay();
+  };
+  startButton.addEventListener('click', handleStart);
+  cleanupFns.push(() => startButton.removeEventListener('click', handleStart));
+
+  const hud = doc.createElement('div');
+  hud.id = 'athens-hud';
+  applyStyles(hud, {
+    marginTop: 'auto',
+    width: '100%',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: '18px',
+    padding: '16px 24px 22px',
+    background: 'linear-gradient(to top, rgba(0, 0, 0, 0.82) 0%, rgba(0, 0, 0, 0.55) 55%, transparent 100%)',
+    pointerEvents: 'none',
+    transition: 'transform 0.4s ease-in-out'
+  });
+  root.appendChild(hud);
+
+  const hudLeft = doc.createElement('div');
+  applyStyles(hudLeft, {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '14px',
+    pointerEvents: 'auto'
+  });
+  hud.appendChild(hudLeft);
+
+  const miniMapWrapper = doc.createElement('div');
+  miniMapWrapper.className = 'athens-mini-map-wrapper';
+  applyStyles(miniMapWrapper, {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '8px',
+    alignItems: 'flex-start',
+    transition: 'opacity 0.25s ease, transform 0.25s ease'
+  });
+  hudLeft.appendChild(miniMapWrapper);
+
+  const miniMapContainer = doc.createElement('div');
+  miniMapContainer.className = 'athens-mini-map';
+  applyStyles(miniMapContainer, {
+    width: '180px',
+    height: '180px',
+    borderRadius: '50%',
+    border: '2px solid rgba(255, 215, 0, 0.85)',
+    background: 'rgba(14, 23, 42, 0.45)',
+    boxShadow: '0 0 18px rgba(255, 215, 0, 0.28)',
+    overflow: 'hidden',
+    position: 'relative',
+    pointerEvents: 'auto',
+    transition: 'opacity 0.2s ease, transform 0.2s ease'
+  });
+  miniMapWrapper.appendChild(miniMapContainer);
+
+  const miniMapToggle = doc.createElement('button');
+  miniMapToggle.type = 'button';
+  miniMapToggle.textContent = 'Hide Map';
+  applyStyles(miniMapToggle, {
+    background: 'rgba(0, 0, 0, 0.65)',
+    color: '#fcefb4',
+    fontFamily: "'Cinzel', serif",
+    fontSize: '12px',
+    borderRadius: '999px',
+    padding: '6px 14px',
+    border: '1px solid rgba(255, 215, 0, 0.65)',
+    cursor: 'pointer',
+    pointerEvents: 'auto',
+    letterSpacing: '0.04em'
+  });
+  miniMapWrapper.appendChild(miniMapToggle);
+
+  let miniMapCollapsed = false;
+  const updateMiniMapState = () => {
+    if (miniMapCollapsed) {
+      miniMapWrapper.style.opacity = '0.65';
+      miniMapWrapper.style.transform = 'scale(0.9)';
+      miniMapToggle.textContent = 'Show Map';
+      miniMapContainer.style.pointerEvents = 'none';
+      miniMapContainer.style.opacity = '0';
+    } else {
+      miniMapWrapper.style.opacity = '1';
+      miniMapWrapper.style.transform = 'scale(1)';
+      miniMapToggle.textContent = 'Hide Map';
+      miniMapContainer.style.pointerEvents = 'auto';
+      miniMapContainer.style.opacity = '1';
+    }
+  };
+
+  const handleMiniMapToggle = (event) => {
+    event?.preventDefault?.();
+    miniMapCollapsed = !miniMapCollapsed;
+    updateMiniMapState();
+  };
+  miniMapToggle.addEventListener('click', handleMiniMapToggle);
+  cleanupFns.push(() => miniMapToggle.removeEventListener('click', handleMiniMapToggle));
+
+  const originalCanvasStyle = overlayCanvas instanceof HTMLCanvasElement ? overlayCanvas.getAttribute('style') ?? '' : '';
+  if (overlayCanvas instanceof HTMLCanvasElement) {
+    applyStyles(overlayCanvas, {
+      position: 'absolute',
+      inset: '0',
+      width: '100%',
+      height: '100%',
+      borderRadius: '50%',
+      pointerEvents: 'auto'
+    });
+    miniMapContainer.appendChild(overlayCanvas);
+    cleanupFns.push(() => {
+      if (overlayCanvas.parentNode) {
+        overlayCanvas.parentNode.removeChild(overlayCanvas);
+      }
+      overlayCanvas.setAttribute('style', originalCanvasStyle);
+    });
+  }
+
+  const title = doc.createElement('h3');
+  title.textContent = '⚱️ Ancient Athens';
+  applyStyles(title, {
+    margin: '0',
+    fontSize: '20px',
+    fontFamily: "'Cinzel', serif",
+    letterSpacing: '0.04em'
+  });
+  hudLeft.appendChild(title);
+
+  const currentLocationEl = doc.createElement('div');
+  currentLocationEl.textContent = 'Exploring Athens';
+  applyStyles(currentLocationEl, {
+    fontSize: '14px',
+    color: 'rgba(255, 255, 255, 0.85)',
+    fontWeight: '300'
+  });
+  hudLeft.appendChild(currentLocationEl);
+
+  const hudCenter = doc.createElement('div');
+  applyStyles(hudCenter, {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '6px',
+    pointerEvents: 'none',
+    maxWidth: '40%',
+    fontSize: '13px'
+  });
+  hud.appendChild(hudCenter);
+
+  const instructionRow = doc.createElement('div');
+  applyStyles(instructionRow, {
+    display: 'flex',
+    flexWrap: 'wrap',
+    alignItems: 'center',
+    gap: '6px',
+    rowGap: '8px'
+  });
+  hudCenter.appendChild(instructionRow);
+
+  const createKeyBadge = (label) => {
+    const badge = doc.createElement('span');
+    badge.textContent = label;
+    applyStyles(badge, {
+      background: 'linear-gradient(145deg, rgba(255, 215, 0, 0.25), rgba(255, 215, 0, 0.12))',
+      border: '1px solid rgba(255, 215, 0, 0.35)',
+      borderRadius: '6px',
+      padding: '2px 6px',
+      fontWeight: '600',
+      color: '#FFD700',
+      letterSpacing: '0.02em'
+    });
+    return badge;
+  };
+
+  const appendInstruction = (keys, description) => {
+    if (instructionRow.childNodes.length) {
+      const divider = doc.createElement('span');
+      divider.textContent = '|';
+      applyStyles(divider, { opacity: '0.65' });
+      instructionRow.appendChild(divider);
+    }
+    const keyLabel = Array.isArray(keys) ? keys.join(' / ') : keys;
+    instructionRow.appendChild(createKeyBadge(keyLabel));
+    const text = doc.createElement('span');
+    text.textContent = ` ${description}`;
+    applyStyles(text, { opacity: '0.85' });
+    instructionRow.appendChild(text);
+  };
+
+  appendInstruction('WASD', 'Move');
+  appendInstruction('Arrows', 'Orbit Camera');
+  appendInstruction('Shift', 'Hold to Run');
+  appendInstruction('E', 'Interact');
+  appendInstruction('X', 'Toggle Flight');
+  appendInstruction(['Space', 'Shift'], 'Fly Up / Down');
+  appendInstruction('M', 'Sound');
+  appendInstruction('P', 'FPS');
+  appendInstruction('K', 'Toggle Sky');
+
+  const hudRight = doc.createElement('div');
+  applyStyles(hudRight, {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'flex-end',
+    gap: '6px',
+    pointerEvents: 'auto'
+  });
+  hud.appendChild(hudRight);
+
+  const timeRow = doc.createElement('div');
+  applyStyles(timeRow, {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '8px'
+  });
+  hudRight.appendChild(timeRow);
+
+  const timeLabelPrefix = doc.createElement('span');
+  timeLabelPrefix.textContent = '🌅 Time:';
+  applyStyles(timeLabelPrefix, {
+    fontFamily: "'Cinzel', serif",
+    fontWeight: '600',
+    letterSpacing: '0.05em'
+  });
+  timeRow.appendChild(timeLabelPrefix);
+
+  const timeLabel = doc.createElement('span');
+  timeLabel.textContent = formatEnvironmentLabel(environmentController?.mode) || 'High Noon';
+  applyStyles(timeLabel, {
+    fontSize: '15px',
+    fontWeight: '500'
+  });
+  timeRow.appendChild(timeLabel);
+
+  const statusRow = doc.createElement('div');
+  applyStyles(statusRow, {
+    display: 'flex',
+    gap: '8px',
+    fontSize: '12px',
+    letterSpacing: '0.05em',
+    textTransform: 'uppercase'
+  });
+  hudRight.appendChild(statusRow);
+
+  const flightStatus = doc.createElement('span');
+  flightStatus.textContent = 'Grounded';
+  applyStyles(flightStatus, { opacity: '0.75' });
+  statusRow.appendChild(flightStatus);
+
+  const speedStatus = doc.createElement('span');
+  speedStatus.textContent = 'Walking';
+  applyStyles(speedStatus, { opacity: '0.75' });
+  statusRow.appendChild(speedStatus);
+
+  const toggleHudButton = doc.createElement('button');
+  toggleHudButton.type = 'button';
+  toggleHudButton.textContent = 'Hide UI';
+  applyStyles(toggleHudButton, {
+    position: 'absolute',
+    left: '50%',
+    transform: 'translateX(-50%)',
+    bottom: 'calc(100% - 1px)',
+    padding: '6px 18px',
+    borderRadius: '12px 12px 0 0',
+    background: 'rgba(0, 0, 0, 0.65)',
+    border: '1px solid rgba(255, 255, 255, 0.2)',
+    color: '#fff',
+    fontFamily: "'Cinzel', serif",
+    fontSize: '12px',
+    cursor: 'pointer',
+    pointerEvents: 'auto',
+    letterSpacing: '0.04em'
+  });
+  hud.appendChild(toggleHudButton);
+
+  let hudHidden = false;
+  const updateHudVisibility = () => {
+    hud.style.transform = hudHidden ? 'translateY(100%)' : 'translateY(0)';
+    toggleHudButton.textContent = hudHidden ? 'Show UI' : 'Hide UI';
+  };
+
+  const handleHudToggle = (event) => {
+    event?.preventDefault?.();
+    hudHidden = !hudHidden;
+    updateHudVisibility();
+  };
+  toggleHudButton.addEventListener('click', handleHudToggle);
+  cleanupFns.push(() => toggleHudButton.removeEventListener('click', handleHudToggle));
+
+  updateMiniMapState();
+  updateHudVisibility();
+
+  let statusAccumulator = 0;
+  const updateStatus = (deltaSeconds = 0, { position, isFlying, isRunning } = {}) => {
+    if (!Number.isFinite(deltaSeconds)) {
+      deltaSeconds = 0;
+    }
+    statusAccumulator += Math.max(deltaSeconds, 0);
+    if (statusAccumulator < STATUS_UPDATE_INTERVAL) {
+      return;
+    }
+    statusAccumulator = 0;
+
+    if (position && typeof position.x === 'number' && typeof position.z === 'number') {
+      currentLocationEl.textContent = `Position: X ${Math.round(position.x)} · Z ${Math.round(position.z)}`;
+    }
+
+    if (typeof isFlying === 'boolean') {
+      flightStatus.textContent = isFlying ? 'Flight Mode' : 'Grounded';
+      flightStatus.style.opacity = isFlying ? '1' : '0.75';
+    }
+
+    if (typeof isRunning === 'boolean' || typeof isFlying === 'boolean') {
+      if (isFlying) {
+        speedStatus.textContent = 'Airborne';
+      } else if (isRunning) {
+        speedStatus.textContent = 'Running';
+      } else {
+        speedStatus.textContent = 'Walking';
+      }
+    }
+  };
+
+  const api = {
+    setTimeLabel(value) {
+      timeLabel.textContent = value || '';
+    },
+    setCurrentLocation(value) {
+      currentLocationEl.textContent = value || '';
+    },
+    update(deltaSeconds, state) {
+      updateStatus(deltaSeconds, state);
+    },
+    hideStartOverlay,
+    dispose() {
+      cleanupFns.forEach((fn) => {
+        try {
+          fn();
+        } catch (error) {
+          console.warn('[Athens][UI] Failed to run cleanup handler.', error);
+        }
+      });
+      cleanupFns.length = 0;
+      while (createdNodes.length) {
+        const node = createdNodes.pop();
+        if (node?.parentNode) {
+          node.parentNode.removeChild(node);
+        }
+      }
+    }
+  };
+
+  return api;
+}
+
+export default createOriginalUi;


### PR DESCRIPTION
## Summary
- expand keyboard input to cover flight toggles and modifiers and speed up player movement
- update the player controller to support running, flight mode, and state reporting for the HUD
- restore the classic HUD overlay with mini-map and instructions and integrate it into the Athens initializer

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d90214fd208327b4afb13ad96f7bb1