### PR TITLE
Snap city content and landmarks to ground terrain

### DIFF
--- a/src/buildings/createCity.js
+++ b/src/buildings/createCity.js
@@ -4,22 +4,60 @@ import { createParthenon } from './parthenon.js';
 import { createAgora } from './agora.js';
 import { createCityWalls } from './cityWalls.js';
 import { createGround } from './ground.js';
+import { markGround, collectGround } from '../physics/groundRegistry.js';
+import { snapGroupToGround } from '../physics/groundProject.js';
 
 export async function createCity({ renderer, scene } = {}) {
   const materials = await loadMaterials(renderer);
   const root = new THREE.Group();
   root.name = 'AthensCity';
 
+  if (scene && typeof scene.add === 'function' && !scene.children.includes(root)) {
+    scene.add(root);
+  }
+
   const ground = createGround(materials, { size: 1000, repeat: 80 });
   root.add(ground);
 
+  const registryRoot = scene ?? root;
+  markGround(registryRoot);
+  let groundMeshes = collectGround(registryRoot);
+
+  const ensureGroundMeshes = () => {
+    if (!groundMeshes?.length) {
+      groundMeshes = collectGround(registryRoot);
+    }
+    return groundMeshes;
+  };
+
+  const updateWorldMatrices = () => {
+    if (scene?.updateMatrixWorld) {
+      scene.updateMatrixWorld(true);
+    } else {
+      root.updateMatrixWorld(true);
+    }
+  };
+
+  const addAndSnap = (group) => {
+    if (!group) {
+      return;
+    }
+    root.add(group);
+    updateWorldMatrices();
+    const grounds = ensureGroundMeshes();
+    if (grounds.length) {
+      snapGroupToGround(group, grounds, { hover: 0.03, fromY: 300 });
+      updateWorldMatrices();
+    }
+  };
+
   const parthenonPosition = new THREE.Vector3(0, 6, 0);
   const parthenon = createParthenon(materials, { position: parthenonPosition });
-  root.add(parthenon);
+  addAndSnap(parthenon);
 
   const agoraPosition = new THREE.Vector3(80, 0, -40);
   const agora = createAgora(materials, { position: agoraPosition });
-  root.add(agora);
+  addAndSnap(agora);
 
   const wallsPath = [
     new THREE.Vector3(-200, 0, -200),
@@ -29,11 +67,9 @@ export async function createCity({ renderer, scene } = {}) {
     new THREE.Vector3(-200, 0, -200)
   ];
   const walls = createCityWalls(materials, { path: wallsPath });
-  root.add(walls);
+  addAndSnap(walls);
 
-  if (scene && typeof scene.add === 'function') {
-    scene.add(root);
-  }
+  updateWorldMatrices();
 
   return { root, materials };
 }

--- a/src/entry/initializeAthens.js
+++ b/src/entry/initializeAthens.js
@@ -11,6 +11,7 @@ import { createFollowCamera } from '../camera/followCamera.js';
 import { createPlayerController } from '../player/playerController.js';
 import { assetUrl } from '../utils/assetUrl.js';
 import { markGround, collectGround } from '../physics/groundRegistry.js';
+import { snapGroupToGround, snapObjectToGround, snapChildrenToGround } from '../physics/groundProject.js';
 import { createCity } from '../buildings/createCity.js';
 
 const DEFAULT_CONTAINER_ID = 'app';
@@ -204,15 +205,19 @@ export async function initializeAthens(options = {}) {
 
   await setupGround(scene, renderer);
 
-  // Combine both branches: ground registry for NPC snapping AND city creation
+  const city = await createCity({ renderer, scene });
+
   markGround(scene);
   const groundMeshes = collectGround(scene);
-
-  const city = await createCity({ renderer, scene });
+  if (city?.root && groundMeshes.length) {
+    snapChildrenToGround(city.root, groundMeshes, { hover: 0.03, fromY: 300 });
+    snapGroupToGround(city.root, groundMeshes, { hover: 0.03, fromY: 300 });
+  }
 
   const landmarks = await loadLandmarks({
     scene,
-    geoJsonUrl: options.geoJsonUrl ?? DEFAULT_GEOJSON_URL
+    geoJsonUrl: options.geoJsonUrl ?? DEFAULT_GEOJSON_URL,
+    groundMeshes
   });
 
   const overlayCanvasId = options.overlayCanvasId ?? DEFAULT_OVERLAY_ID;
@@ -264,6 +269,9 @@ export async function initializeAthens(options = {}) {
     placeholderPlayer = createPlaceholderPlayer();
     scene.add(placeholderPlayer);
     playerObject = placeholderPlayer;
+    if (groundMeshes?.length) {
+      snapObjectToGround(placeholderPlayer, groundMeshes, { hover: 0.05, fromY: 300 });
+    }
   }
 
   const keyboard = createKeyboard();

--- a/src/landmarks-loader.js
+++ b/src/landmarks-loader.js
@@ -3,6 +3,7 @@ import { applyFeatureOffset } from './geo/featureOffsets.js';
 import { createFeatureLines } from './scene/feature-lines.js';
 import { applyCompressionToVector3 } from './world/scale.js';
 import { resolveAssetUrl } from './utils/asset-paths.js';
+import { snapObjectToGround } from './physics/groundProject.js';
 
 /**
  * Load every feature from a GeoJSON file and add to the scene.
@@ -41,7 +42,8 @@ export async function loadLandmarks({
   scene,
   geoJsonUrl = 'data/athens_places.geojson',
   projector = null,
-  onPoint = null
+  onPoint = null,
+  groundMeshes = null
 }) {
   const root = new THREE.Group();
   root.name = 'Landmarks';
@@ -74,6 +76,23 @@ export async function loadLandmarks({
     projector ? projector(lon, lat) : lonLatToLocal(lon, lat)
   );
 
+  const updateWorldMatrices = () => {
+    if (scene?.updateMatrixWorld) {
+      scene.updateMatrixWorld(true);
+    } else {
+      root.updateMatrixWorld(true);
+    }
+  };
+
+  const snapLandmarkObject = (object) => {
+    if (!object || !groundMeshes?.length) {
+      return;
+    }
+    updateWorldMatrices();
+    snapObjectToGround(object, groundMeshes, { hover: 0.02, fromY: 300 });
+    updateWorldMatrices();
+  };
+
   for (const f of geo.features || []) {
     const props = f.properties || {};
     const name = props.title || props.name || 'Unnamed';
@@ -101,6 +120,7 @@ export async function loadLandmarks({
       pin.name = `LandmarkPin:${id}`;
       pin.userData = { name, props, id, isLandmark: true };
       targetGroup.add(pin);
+      snapLandmarkObject(pin);
       markers.push(pin);
 
       const label = makeLabelSprite(name);

--- a/src/physics/groundProject.js
+++ b/src/physics/groundProject.js
@@ -1,0 +1,71 @@
+import * as THREE from 'three';
+
+const _ray = new THREE.Raycaster();
+const _box = new THREE.Box3();
+
+// Find ground Y under a world-space (x,z) by raycasting down from a safe height.
+export function sampleGroundY(x, z, groundMeshes, { fromY = 200, far = 500 } = {}) {
+  _ray.set(new THREE.Vector3(x, fromY, z), new THREE.Vector3(0, -1, 0));
+  _ray.far = far;
+  const hit = _ray.intersectObjects(groundMeshes, true)[0];
+  return hit ? hit.point.y : null;
+}
+
+// Snap a single object so its bottom touches ground under its pivot.
+export function snapObjectToGround(obj, groundMeshes, { hover = 0.02, fromY = 200 } = {}) {
+  if (!obj || !groundMeshes?.length) return false;
+  const y = sampleGroundY(obj.position.x, obj.position.z, groundMeshes, { fromY });
+  if (y == null) return false;
+
+  // Compute object's bottom Y in world to account for pivot not at base.
+  _box.setFromObject(obj);
+  const bottomY = _box.min.y;
+  const delta = (y + hover) - bottomY;
+  obj.position.y += delta;
+  obj.updateMatrixWorld?.();
+  return true;
+}
+
+// Snap a group using multiple footprint samples (center + corners of its bbox).
+export function snapGroupToGround(group, groundMeshes, { hover = 0.02, fromY = 200 } = {}) {
+  if (!group || !groundMeshes?.length) return false;
+  _box.setFromObject(group);
+  const cx = (_box.min.x + _box.max.x) * 0.5;
+  const cz = (_box.min.z + _box.max.z) * 0.5;
+  const sx = (_box.max.x - _box.min.x) * 0.5;
+  const sz = (_box.max.z - _box.min.z) * 0.5;
+
+  const points = [
+    [cx, cz],
+    [cx - sx, cz - sz],
+    [cx + sx, cz - sz],
+    [cx + sx, cz + sz],
+    [cx - sx, cz + sz],
+  ];
+
+  const ys = points.map(([x,z]) => sampleGroundY(x, z, groundMeshes, { fromY })).filter(y => y != null);
+  if (!ys.length) return false;
+
+  // Use the median of samples to avoid single high rock pushing whole group up.
+  ys.sort((a,b)=>a-b);
+  const median = ys[Math.floor(ys.length/2)];
+
+  // Shift the entire group so its bottom rests on the median ground height.
+  _box.setFromObject(group);
+  const bottomY = _box.min.y;
+  const delta = (median + hover) - bottomY;
+  group.position.y += delta;
+  group.updateMatrixWorld?.();
+  return true;
+}
+
+// Convenience: snap all direct children meshes/groups under a root.
+export function snapChildrenToGround(root, groundMeshes, options) {
+  if (!root || !groundMeshes?.length) return;
+  root.children.forEach(child => {
+    if (!child.visible) return;
+    // Prefer group-level snap; fallback to object snap if very small
+    const ok = snapGroupToGround(child, groundMeshes, options);
+    if (!ok) snapObjectToGround(child, groundMeshes, options);
+  });
+}

--- a/src/physics/groundRegistry.js
+++ b/src/physics/groundRegistry.js
@@ -1,36 +1,10 @@
+// Mark meshes that represent terrain/ground so we can raycast against them.
 import * as THREE from 'three';
 
-const GROUND_KEYWORDS = [
-  'ground',
-  'terrain',
-  'plaza',
-  'agora',
-  'acropolis',
-  'city',
-  'wall',
-  'road'
-];
-
-function looksLikeGround(object) {
-  if (!object || !object.name) {
-    return false;
-  }
-  const name = String(object.name).toLowerCase();
-  return GROUND_KEYWORDS.some((keyword) => name.includes(keyword));
-}
-
-function tagGround(object) {
-  if (!object) {
-    return;
-  }
-  object.userData = object.userData || {};
-  object.userData.isGround = true;
-}
+const NAME_HINTS = ['ground','terrain','plaza','agora','acropolis','city','wall','road','plateau','floor','soil','dirt','grass'];
 
 function traverse(root, callback) {
-  if (!root) {
-    return;
-  }
+  if (!root) return;
   if (typeof root.traverse === 'function') {
     root.traverse(callback);
   } else {
@@ -39,30 +13,18 @@ function traverse(root, callback) {
 }
 
 export function markGround(root) {
-  traverse(root, (child) => {
-    if (!child || !child.visible) {
-      return;
-    }
-    if (child.isMesh || child.isSkinnedMesh || child instanceof THREE.Mesh) {
-      if (child.userData?.isGround) {
-        return;
-      }
-      if (looksLikeGround(child)) {
-        tagGround(child);
-      }
-    }
+  traverse(root, (obj) => {
+    if (!(obj?.isMesh || obj instanceof THREE.Mesh)) return;
+    const n = (obj.name || '').toLowerCase();
+    if (obj.userData?.isGround === true) return;
+    if (NAME_HINTS.some((k) => n.includes(k))) obj.userData.isGround = true;
   });
 }
 
 export function collectGround(rootOrScene) {
-  const grounds = [];
-  traverse(rootOrScene, (child) => {
-    if (!child) {
-      return;
-    }
-    if ((child.isMesh || child.isSkinnedMesh || child instanceof THREE.Mesh) && child.userData?.isGround) {
-      grounds.push(child);
-    }
+  const out = [];
+  traverse(rootOrScene, (obj) => {
+    if ((obj?.isMesh || obj instanceof THREE.Mesh) && obj.userData?.isGround) out.push(obj);
   });
-  return grounds;
+  return out;
 }


### PR DESCRIPTION
## Summary
- add reusable ground projection helpers for sampling terrain height and snapping objects
- mark ground meshes during city creation and snap major building groups to the terrain
- snap spawned landmarks and placeholder players to ground meshes collected at initialization

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d904a261c0832794604accf4cb7115