### PR TITLE
Add textured grass ground and time-of-day sky controller

### DIFF
--- a/src/buildings/createCity.js
+++ b/src/buildings/createCity.js
@@ -16,7 +16,7 @@ export async function createCity({ renderer, scene } = {}) {
     scene.add(root);
   }
 
-  const ground = createGround(materials, { size: 1000, repeat: 80 });
+  const ground = await createGround(materials, { size: 1000, repeat: 80, renderer });
   root.add(ground);
 
   const registryRoot = scene ?? root;

--- a/src/buildings/ground.js
+++ b/src/buildings/ground.js
@@ -1,4 +1,5 @@
 import * as THREE from 'three';
+import { loadGrassMaterial } from '../materials/groundGrass.js';
 
 function cloneMaterial(source, fallbackColor = 0xffffff) {
   if (source && typeof source.clone === 'function') {
@@ -19,7 +20,7 @@ function setTextureRepeat(material, repeatX = 1, repeatY = 1) {
   }
 }
 
-export function createGround(materials = {}, opts = {}) {
+export async function createGround(materials = {}, opts = {}) {
   const group = new THREE.Group();
   group.name = 'Ground';
 
@@ -29,9 +30,33 @@ export function createGround(materials = {}, opts = {}) {
   const grassMaterial = cloneMaterial(materials.grass, 0x5a8f3a);
   setTextureRepeat(grassMaterial, repeat, repeat);
   const groundPlane = new THREE.Mesh(new THREE.PlaneGeometry(size, size, 1, 1), grassMaterial);
+  groundPlane.name = 'Ground:MainGrass';
   groundPlane.rotation.x = -Math.PI / 2;
   groundPlane.receiveShadow = true;
+  groundPlane.userData.applyGrassMaterial = async (renderer, options = {}) => {
+    try {
+      const appliedRepeat = typeof options.repeat === 'number' ? options.repeat : repeat;
+      const material = await loadGrassMaterial(renderer, { repeat: appliedRepeat });
+      if (material) {
+        const previous = groundPlane.material;
+        groundPlane.material = material;
+        if (previous && previous !== material && typeof previous.dispose === 'function') {
+          previous.dispose();
+        }
+      }
+      return groundPlane.material;
+    } catch (error) {
+      console.warn('[Ground] Failed to apply grass material.', error);
+      return groundPlane.material;
+    }
+  };
   group.add(groundPlane);
+
+  if (opts.renderer) {
+    groundPlane.userData.applyGrassMaterial(opts.renderer, { repeat }).catch((error) => {
+      console.warn('[Ground] Grass material application deferred.', error);
+    });
+  }
 
   const plateauRadius = opts.plateauRadius ?? 46;
   const plateauHeight = opts.plateauHeight ?? 2.4;

--- a/src/entry/initializeAthens.js
+++ b/src/entry/initializeAthens.js
@@ -1,6 +1,5 @@
 import * as THREE from 'three';
 import { setupGround, updateTrees, initPerformanceStats } from '../main.js';
-import { createEnvironmentController } from '../scene/sky.js';
 import { loadLandmarks } from '../landmarks-loader.js';
 import { createLandmarkOverlay } from '../map/landmarks.js';
 import { buildRoadNetwork } from '../roads/roadNetwork.js';
@@ -14,13 +13,17 @@ import { markGround, collectGround } from '../physics/groundRegistry.js';
 import { snapGroupToGround, snapObjectToGround, snapChildrenToGround } from '../physics/groundProject.js';
 import { createCity } from '../buildings/createCity.js';
 import { createOriginalUi } from '../ui/originalUi.js';
+import { createTimeSky, setTimeOfDay, getTimeOfDay, attachTimeHotkeys } from '../sky/timeSky.js';
+import { loadGrassMaterial } from '../materials/groundGrass.js';
 
 const ENVIRONMENT_LABELS = {
   high_noon: 'High Noon',
+  day: 'High Noon',
   golden_hour: 'Golden Hour',
   dawn: 'Golden Dawn',
   dusk: 'Dusk',
-  midnight: 'Midnight'
+  midnight: 'Midnight',
+  night: 'Midnight'
 };
 
 const formatEnvironmentLabel = (mode) => {
@@ -217,12 +220,53 @@ export async function initializeAthens(options = {}) {
     }
   }
 
-  const environmentController = createEnvironmentController(renderer, scene);
-  await environmentController.setMode?.('high_noon');
+  await createTimeSky(renderer, scene, 'day');
+  if (typeof attachTimeHotkeys === 'function') {
+    try {
+      attachTimeHotkeys();
+    } catch (error) {
+      console.warn('[Athens] Failed to attach sky hotkeys.', error);
+    }
+  }
+
+  const environmentController = {
+    mode: getTimeOfDay() || 'day',
+    async setMode(mode) {
+      try {
+        const resolved = await setTimeOfDay(mode);
+        if (resolved) {
+          this.mode = resolved;
+        }
+        return this.mode;
+      } catch (error) {
+        console.warn('[Athens] Failed to set time of day.', error);
+        return this.mode;
+      }
+    },
+    dispose() {
+      // placeholder for compatibility
+    }
+  };
 
   await setupGround(scene, renderer);
 
   const city = await createCity({ renderer, scene });
+
+  const mainGround = city?.root?.getObjectByName?.('Ground:MainGrass');
+  if (mainGround?.isMesh) {
+    try {
+      const grassMaterial = await loadGrassMaterial(renderer, { repeat: 80 });
+      if (grassMaterial) {
+        const previous = mainGround.material;
+        mainGround.material = grassMaterial;
+        if (previous && previous !== grassMaterial && typeof previous.dispose === 'function') {
+          previous.dispose();
+        }
+      }
+    } catch (error) {
+      console.warn('[Athens] Unable to apply grass material to main ground plane.', error);
+    }
+  }
 
   markGround(scene);
   const groundMeshes = collectGround(scene);
@@ -380,12 +424,13 @@ export async function initializeAthens(options = {}) {
     city,
     container,
     ui,
-    setEnvironmentMode(mode, envOptions = {}) {
-      const label = formatEnvironmentLabel(mode);
+    async setEnvironmentMode(mode, envOptions = {}) {
+      const result = await environmentController?.setMode?.(mode, envOptions);
+      const label = formatEnvironmentLabel(result || mode);
       if (label) {
         ui?.setTimeLabel?.(label);
       }
-      return environmentController?.setMode?.(mode, envOptions);
+      return result;
     },
     dispose() {
       if (disposed) {

--- a/src/materials/groundGrass.js
+++ b/src/materials/groundGrass.js
@@ -1,0 +1,77 @@
+import * as THREE from 'three';
+import { assetUrl } from '../utils/assetUrl.js';
+
+const FALLBACK_COLOR = 0x5a8f3a;
+const GRASS_URL = 'assets/textures/grass.jpg';
+const textureLoader = new THREE.TextureLoader();
+let cachedPromise = null;
+
+function ensureColorSpace(texture) {
+  if (!texture) {
+    return;
+  }
+  if ('colorSpace' in texture) {
+    texture.colorSpace = THREE.SRGBColorSpace;
+  } else if ('encoding' in texture) {
+    texture.encoding = THREE.sRGBEncoding;
+  }
+}
+
+function computeAnisotropy(renderer) {
+  try {
+    if (renderer?.capabilities && typeof renderer.capabilities.getMaxAnisotropy === 'function') {
+      return renderer.capabilities.getMaxAnisotropy() || 1;
+    }
+  } catch (error) {
+    console.warn('[groundGrass] Failed to determine renderer anisotropy.', error);
+  }
+  return 1;
+}
+
+async function loadGrassTexture() {
+  if (cachedPromise) {
+    return cachedPromise;
+  }
+  const url = assetUrl(GRASS_URL);
+  cachedPromise = new Promise((resolve, reject) => {
+    textureLoader.load(
+      url,
+      (texture) => {
+        try {
+          ensureColorSpace(texture);
+          texture.wrapS = texture.wrapT = THREE.RepeatWrapping;
+          texture.needsUpdate = true;
+          resolve(texture);
+        } catch (error) {
+          reject(error);
+        }
+      },
+      undefined,
+      (error) => {
+        reject(error instanceof Error ? error : new Error(String(error)));
+      }
+    );
+  }).catch((error) => {
+    console.warn('[groundGrass] Failed to load grass texture.', error);
+    return null;
+  });
+  return cachedPromise;
+}
+
+export async function loadGrassMaterial(renderer, { repeat = 80 } = {}) {
+  const anisotropy = computeAnisotropy(renderer);
+  const texture = await loadGrassTexture();
+
+  if (texture) {
+    texture.repeat.set(repeat, repeat);
+    texture.anisotropy = anisotropy;
+    texture.needsUpdate = true;
+    return new THREE.MeshStandardMaterial({
+      map: texture,
+      roughness: 1.0,
+      metalness: 0.0
+    });
+  }
+
+  return new THREE.MeshStandardMaterial({ color: FALLBACK_COLOR, roughness: 1.0, metalness: 0.0 });
+}

--- a/src/sky/timeSky.js
+++ b/src/sky/timeSky.js
@@ -1,0 +1,221 @@
+import * as THREE from 'three';
+import { assetUrl } from '../utils/assetUrl.js';
+
+const MODE_CONFIG = {
+  dawn: { path: 'assets/sky/dawn.jpg', fallbackColor: 0x335577 },
+  day: { path: 'assets/sky/day.jpg', fallbackColor: 0x87ceeb },
+  dusk: { path: 'assets/sky/dusk.jpg', fallbackColor: 0x553344 },
+  night: { path: 'assets/sky/night.jpg', fallbackColor: 0x0b0e19 }
+};
+
+const MODE_ALIASES = new Map(
+  Object.entries({
+    dawn: 'dawn',
+    sunrise: 'dawn',
+    golden_dawn: 'dawn',
+    goldenhour: 'dusk',
+    golden_hour: 'dusk',
+    golden_dusk: 'dusk',
+    blue_hour: 'dusk',
+    bluehour: 'dusk',
+    sunset: 'dusk',
+    dusk: 'dusk',
+    evening: 'dusk',
+    day: 'day',
+    high_noon: 'day',
+    noon: 'day',
+    midday: 'day',
+    night: 'night',
+    midnight: 'night',
+    starlit_night: 'night'
+  })
+);
+
+const loader = new THREE.TextureLoader();
+const cache = new Map();
+const loadTasks = new Map();
+const loggedFailures = new Set();
+let pmremGenerator = null;
+let activeRenderer = null;
+let activeScene = null;
+let currentMode = null;
+let hotkeyAttached = false;
+
+function ensureColorSpace(texture) {
+  if (!texture) {
+    return;
+  }
+  if ('colorSpace' in texture) {
+    texture.colorSpace = THREE.SRGBColorSpace;
+  } else if ('encoding' in texture) {
+    texture.encoding = THREE.sRGBEncoding;
+  }
+}
+
+function ensurePmrem(renderer) {
+  if (!pmremGenerator && renderer) {
+    pmremGenerator = new THREE.PMREMGenerator(renderer);
+    pmremGenerator.compileEquirectangularShader();
+  }
+  return pmremGenerator;
+}
+
+function normalizeMode(mode) {
+  if (!mode) {
+    return 'day';
+  }
+  const key = `${mode}`.trim().toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '');
+  const alias = MODE_ALIASES.get(key);
+  if (alias) {
+    return alias;
+  }
+  if (MODE_CONFIG[key]) {
+    return key;
+  }
+  return 'day';
+}
+
+function fallbackEntry(mode) {
+  const config = MODE_CONFIG[mode] || {};
+  const color = new THREE.Color(config.fallbackColor ?? 0x000000);
+  return { background: color, envMap: null, mode };
+}
+
+async function loadSky(mode) {
+  if (cache.has(mode)) {
+    return cache.get(mode);
+  }
+  if (loadTasks.has(mode)) {
+    return loadTasks.get(mode);
+  }
+
+  const task = new Promise((resolve) => {
+    const config = MODE_CONFIG[mode];
+    if (!config?.path) {
+      const entry = fallbackEntry(mode);
+      cache.set(mode, entry);
+      resolve(entry);
+      return;
+    }
+
+    const url = assetUrl(config.path);
+
+    loader.load(
+      url,
+      (texture) => {
+        ensureColorSpace(texture);
+        texture.mapping = THREE.EquirectangularReflectionMapping;
+        texture.needsUpdate = true;
+
+        const generator = ensurePmrem(activeRenderer);
+        let envTarget = null;
+        let envMap = null;
+        if (generator) {
+          envTarget = generator.fromEquirectangular(texture);
+          envMap = envTarget.texture;
+        }
+
+        const entry = {
+          background: texture,
+          envMap,
+          envTarget,
+          mode
+        };
+        cache.set(mode, entry);
+        resolve(entry);
+      },
+      undefined,
+      () => {
+        if (!loggedFailures.has(mode)) {
+          console.warn(`[timeSky] Failed to load sky texture for "${mode}" (${url}). Falling back to solid color.`);
+          loggedFailures.add(mode);
+        }
+        const entry = fallbackEntry(mode);
+        cache.set(mode, entry);
+        resolve(entry);
+      }
+    );
+  }).finally(() => {
+    loadTasks.delete(mode);
+  });
+
+  loadTasks.set(mode, task);
+  return task;
+}
+
+function applySky(entry) {
+  if (!activeScene || !entry) {
+    return;
+  }
+  if (entry.background?.isTexture) {
+    activeScene.background = entry.background;
+  } else if (entry.background instanceof THREE.Color) {
+    activeScene.background = entry.background;
+  } else {
+    activeScene.background = null;
+  }
+  activeScene.environment = entry.envMap || null;
+  currentMode = entry.mode;
+}
+
+export async function createTimeSky(renderer, scene, initial = 'day') {
+  activeRenderer = renderer || activeRenderer;
+  activeScene = scene || activeScene;
+  ensurePmrem(activeRenderer);
+  const normalized = normalizeMode(initial);
+  const entry = await loadSky(normalized);
+  applySky(entry);
+
+  // Prefetch other modes without blocking.
+  Object.keys(MODE_CONFIG).forEach((mode) => {
+    if (mode !== normalized) {
+      loadSky(mode).catch(() => {});
+    }
+  });
+
+  return { mode: currentMode };
+}
+
+export async function setTimeOfDay(mode) {
+  const normalized = normalizeMode(mode);
+  const entry = await loadSky(normalized);
+  applySky(entry);
+  return currentMode;
+}
+
+export function getTimeOfDay() {
+  return currentMode;
+}
+
+export function attachTimeHotkeys(win = typeof window !== 'undefined' ? window : null) {
+  if (!win || hotkeyAttached) {
+    return undefined;
+  }
+  const handler = (event) => {
+    if (event.defaultPrevented || event.altKey || event.metaKey || event.ctrlKey) {
+      return;
+    }
+    switch (event.key) {
+      case '1':
+        setTimeOfDay('dawn');
+        break;
+      case '2':
+        setTimeOfDay('day');
+        break;
+      case '3':
+        setTimeOfDay('dusk');
+        break;
+      case '4':
+        setTimeOfDay('night');
+        break;
+      default:
+        return;
+    }
+  };
+  win.addEventListener('keydown', handler);
+  hotkeyAttached = true;
+  return () => {
+    win.removeEventListener('keydown', handler);
+    hotkeyAttached = false;
+  };
+}

--- a/src/utils/assetUrl.js
+++ b/src/utils/assetUrl.js
@@ -1,4 +1,4 @@
 export function assetUrl(rel) {
   const base = import.meta.env.BASE_URL || '/';
-  return (base + rel.replace(/^\/+/g, '')).replace(/\/{2,}/g, '/');
+  return (base + rel.replace(/^\/+/, '')).replace(/\/{2,}/g, '/');
 }


### PR DESCRIPTION
## Summary
- add reusable assetUrl helper and grass material loader that tiles the new texture
- integrate async grass material application into ground creation and city assembly
- implement photo-based time-of-day sky manager with hotkeys and hook it into initialization

## Testing
- npm run build *(fails: missing optional dependency @gltf-transform/core required by project build script)*

------
https://chatgpt.com/codex/tasks/task_b_68d9067a266c8327b96e8348b41af195