### PR TITLE
Add NPC locomotion stack and ground alignment instrumentation

### DIFF
--- a/src/entry/initializeAthens.js
+++ b/src/entry/initializeAthens.js
@@ -221,11 +221,13 @@ export async function initializeAthens(options = {}) {
 
   await setupGround(scene, renderer);
 
-  // Combine both branches: ground registry for NPC snapping AND city creation
+  const city = await createCity({ renderer, scene });
+
   markGround(scene);
   const groundMeshes = collectGround(scene);
-
-  const city = await createCity({ renderer, scene });
+  if (!groundMeshes.length) {
+    console.warn('[npc] no ground meshes');
+  }
 
   const landmarks = await loadLandmarks({
     scene,
@@ -248,7 +250,22 @@ export async function initializeAthens(options = {}) {
 
   let npcManager = null;
   if (options.enableNpcs !== false) {
-    npcManager = createNpcManager(scene);
+    npcManager = createNpcManager(scene, groundMeshes);
+
+    const p0 = new THREE.Vector3(5, 0, 5);
+    const p1 = new THREE.Vector3(20, 0, 5);
+    const npcRoot = scene.getObjectByName('NPC_1') || new THREE.Object3D();
+    npcRoot.name = 'NPC_1';
+    if (!npcRoot.parent) {
+      scene.add(npcRoot);
+    }
+    npcManager.spawn({
+      object3d: npcRoot,
+      waypoints: [p0, p1],
+      walkSpeed: 1.6,
+      accel: 5.0,
+      turn: 0.18
+    });
     const defaultNpcConfigs = createDefaultNpcConfigs(
       Array.isArray(options.npcModelUrls) && options.npcModelUrls.length
         ? options.npcModelUrls
@@ -340,8 +357,8 @@ export async function initializeAthens(options = {}) {
     } catch (error) {
       console.warn('[Athens] Tree animation update failed.', error);
     }
-    mainCharacter?.update(delta);
-    npcManager?.update(delta, { groundMeshes });
+    mainCharacter?.update(delta, { groundMeshes });
+    npcManager?.update(delta);
     landmarks.update?.(camera);
     stats?.update?.();
     controller?.update(delta, camera);

--- a/src/npc/npcSystem.js
+++ b/src/npc/npcSystem.js
@@ -6,9 +6,17 @@ import { snapToGround } from '../physics/groundSnap.js';
 import { keepUpright } from '../physics/upright.js';
 
 const loader = new GLTFLoader();
-const DEFAULT_SPEED = 1.6; // meters per second
-const DEFAULT_IDLE_SECONDS = 2.5;
-const tempDirection = new THREE.Vector3();
+
+const SNAP_OPTIONS = { gravity: 12, stepMax: 0.6, hover: 0.03 };
+const STEP_EPSILON = 0.05;
+const DEFAULT_WALK_SPEED = 1.5;
+const DEFAULT_RUN_SPEED = 3.0;
+const DEFAULT_ACCEL = 6.0;
+const DEFAULT_TURN = 0.18;
+
+const STEP_DIRECTION = new THREE.Vector3();
+const INIT_DIRECTION = new THREE.Vector3();
+const TMP_EULER = new THREE.Euler(0, 0, 0, 'YXZ');
 
 function toVector3(value) {
   if (!value) {
@@ -17,12 +25,17 @@ function toVector3(value) {
   if (value.isVector3) {
     return value.clone();
   }
-  const { x, y, z } = value;
-  if (typeof x === 'number' && typeof y === 'number' && typeof z === 'number') {
+  if (Array.isArray(value) && value.length >= 3) {
+    const x = Number(value[0]) || 0;
+    const y = Number(value[1]) || 0;
+    const z = Number(value[2]) || 0;
     return new THREE.Vector3(x, y, z);
   }
-  if (Array.isArray(value) && value.length >= 3) {
-    return new THREE.Vector3(Number(value[0]) || 0, Number(value[1]) || 0, Number(value[2]) || 0);
+  if (typeof value === 'object') {
+    const { x = 0, y = 0, z = 0 } = value;
+    if (Number.isFinite(x) && Number.isFinite(y) && Number.isFinite(z)) {
+      return new THREE.Vector3(x, y, z);
+    }
   }
   return null;
 }
@@ -45,7 +58,33 @@ function buildPlaceholderModel() {
   return group;
 }
 
+function enableMeshShadows(root) {
+  if (!root) {
+    return;
+  }
+  root.traverse?.((child) => {
+    if (child.isMesh || child.isSkinnedMesh) {
+      child.castShadow = true;
+      child.receiveShadow = true;
+    }
+  });
+}
+
+function fixModelTilt(object3d) {
+  if (!object3d) {
+    return;
+  }
+  TMP_EULER.setFromQuaternion(object3d.quaternion, 'YXZ');
+  if (Math.abs(TMP_EULER.x) > 0.25 || Math.abs(TMP_EULER.z) > 0.25) {
+    object3d.rotation.x = 0;
+    object3d.rotation.z = 0;
+  }
+}
+
 function disposeObject3D(object) {
+  if (!object) {
+    return;
+  }
   object.traverse((child) => {
     if (child.isMesh || child.isSkinnedMesh) {
       child.geometry?.dispose?.();
@@ -62,291 +101,329 @@ function disposeObject3D(object) {
   });
 }
 
-export function createNpc({
-  modelUrl = null,
-  initialPosition = null,
-  waypoints = [],
-  speed = DEFAULT_SPEED,
-  idleSeconds = DEFAULT_IDLE_SECONDS
-} = {}) {
-  const object3d = new THREE.Group();
-  object3d.name = 'NPC';
-  object3d.userData.isNpc = true;
-
-  const path = Array.isArray(waypoints)
-    ? waypoints.map((point) => toVector3(point)).filter((point) => point && point.isVector3)
-    : [];
-
-  const startPosition = toVector3(initialPosition) || path[0]?.clone() || new THREE.Vector3();
-  object3d.position.copy(startPosition);
-
-  if (!path.length) {
-    path.push(startPosition.clone());
+function normalizeModelUrl(input) {
+  if (!input) {
+    return null;
   }
 
-  let nextIndex = path.length > 1 ? 1 : 0;
-  let dwellTime = 0;
-  let disposed = false;
-
-  const npcState = {
-    mixer: null,
-    root: null,
-    ready: null,
-    physics: {
-      vy: 0,
-      lastGoodY: startPosition.y,
-      yaw: 0
-    }
-  };
-
-  if (path.length > 1) {
-    tempDirection.subVectors(path[1], startPosition);
-    tempDirection.y = 0;
-    if (tempDirection.lengthSq() > 1e-6) {
-      npcState.physics.yaw = Math.atan2(tempDirection.x, tempDirection.z);
-    }
+  if (typeof input !== 'string') {
+    return resolveAssetUrl(input);
   }
 
-  const normalizedSpeed = Number.isFinite(speed) && speed > 0 ? speed : DEFAULT_SPEED;
-  const normalizedIdle = Number.isFinite(idleSeconds) && idleSeconds >= 0 ? idleSeconds : DEFAULT_IDLE_SECONDS;
+  const trimmed = input.trim();
+  if (!trimmed) {
+    return null;
+  }
 
-  const attachModel = (modelGroup) => {
-    if (!modelGroup) {
-      return;
-    }
-    npcState.root = modelGroup;
-    object3d.add(modelGroup);
+  if (/^(https?:)?\/\//i.test(trimmed)) {
+    return trimmed;
+  }
 
-    const euler = new THREE.Euler();
-    euler.setFromQuaternion(modelGroup.quaternion, 'YXZ');
-    const pitch = Math.abs(THREE.MathUtils.radToDeg(euler.x));
-    const roll = Math.abs(THREE.MathUtils.radToDeg(euler.z));
-    if (pitch > 15 || roll > 15) {
-      modelGroup.rotation.x = 0;
-      modelGroup.rotation.z = 0;
-    }
-  };
+  if (/^\/assets\/models\//i.test(trimmed)) {
+    return assetUrl(trimmed);
+  }
 
-  const normalizeModelUrl = (input) => {
-    if (!input) {
-      return null;
-    }
+  if (/^assets\/models\//i.test(trimmed)) {
+    return assetUrl(trimmed);
+  }
 
-    if (typeof input !== 'string') {
-      return resolveAssetUrl(input);
-    }
+  const assetsIndex = trimmed.toLowerCase().indexOf('assets/models/');
+  if (assetsIndex >= 0) {
+    const relativeAssetPath = trimmed.slice(assetsIndex).replace(/^\/+/, '');
+    return assetUrl(relativeAssetPath);
+  }
 
-    const trimmed = input.trim();
-    if (!trimmed) {
-      return null;
-    }
+  const normalized = trimmed.replace(/^\/+/, '');
+  if (normalized.toLowerCase().startsWith('models/')) {
+    return assetUrl(`assets/models/${normalized.slice('models/'.length)}`);
+  }
 
-    if (/^(https?:)?\/\//i.test(trimmed)) {
-      return trimmed;
-    }
+  return resolveAssetUrl(trimmed);
+}
 
-    if (/^\/assets\/models\//i.test(trimmed)) {
-      return assetUrl(trimmed);
-    }
-
-    if (/^assets\/models\//i.test(trimmed)) {
-      return assetUrl(trimmed);
-    }
-
-    const assetsIndex = trimmed.toLowerCase().indexOf('assets/models/');
-    if (assetsIndex >= 0) {
-      const relativeAssetPath = trimmed.slice(assetsIndex).replace(/^\/+/, '');
-      return assetUrl(relativeAssetPath);
-    }
-
-    const normalized = trimmed.replace(/^\/+/, '');
-    if (normalized.toLowerCase().startsWith('models/')) {
-      return assetUrl(`assets/models/${normalized.slice('models/'.length)}`);
-    }
-
-    return resolveAssetUrl(trimmed);
-  };
-
-  const loadModel = async () => {
-    if (!modelUrl) {
-      attachModel(buildPlaceholderModel());
-      return null;
-    }
-
-    try {
-      const resolvedUrl = normalizeModelUrl(modelUrl);
-      if (!resolvedUrl) {
-        attachModel(buildPlaceholderModel());
-        return null;
+function sanitizeWaypoints(waypoints, fallbackPosition) {
+  const result = [];
+  if (Array.isArray(waypoints)) {
+    for (const waypoint of waypoints) {
+      const vector = toVector3(waypoint);
+      if (vector) {
+        result.push(vector);
       }
-      const gltf = await loader.loadAsync(resolvedUrl);
-      const scene = gltf?.scene || gltf?.scenes?.[0];
+    }
+  } else if (waypoints) {
+    const vector = toVector3(waypoints);
+    if (vector) {
+      result.push(vector);
+    }
+  }
+
+  if (!result.length) {
+    const fallbackVector = fallbackPosition?.isVector3
+      ? fallbackPosition.clone()
+      : toVector3(fallbackPosition);
+    if (fallbackVector) {
+      result.push(fallbackVector);
+    } else {
+      result.push(new THREE.Vector3());
+    }
+  }
+
+  return result;
+}
+
+function attachModelToNpc(npc, model) {
+  if (!npc || !npc.object3d) {
+    return;
+  }
+  const { object3d } = npc;
+  if (npc.modelRoot && npc.modelRoot.parent === object3d) {
+    object3d.remove(npc.modelRoot);
+  }
+  if (npc.modelRoot && npc.modelRoot !== model) {
+    disposeObject3D(npc.modelRoot);
+  }
+  npc.modelRoot = model || null;
+  if (model) {
+    model.position.set(0, 0, 0);
+    model.rotation.set(0, model.rotation.y || 0, 0);
+    enableMeshShadows(model);
+    fixModelTilt(model);
+    object3d.add(model);
+  }
+}
+
+function loadNpcModel(npc, modelUrl) {
+  const resolvedUrl = normalizeModelUrl(modelUrl);
+  const { object3d } = npc;
+
+  if (!resolvedUrl) {
+    const placeholder = buildPlaceholderModel();
+    attachModelToNpc(npc, placeholder);
+    return Promise.resolve(placeholder);
+  }
+
+  return loader
+    .loadAsync(resolvedUrl)
+    .then((gltf) => {
+      const scene = gltf?.scene || gltf?.scenes?.[0] || null;
       if (scene) {
-        scene.traverse((child) => {
-          if (child.isMesh || child.isSkinnedMesh) {
-            child.castShadow = true;
-            child.receiveShadow = true;
-          }
-        });
-        attachModel(scene);
+        attachModelToNpc(npc, scene);
       } else {
-        attachModel(buildPlaceholderModel());
+        attachModelToNpc(npc, buildPlaceholderModel());
       }
+
+      npc.mixer?.stopAllAction?.();
+      npc.mixer?.uncacheRoot?.(npc.modelRoot || object3d);
+      npc.mixer = null;
 
       if (Array.isArray(gltf?.animations) && gltf.animations.length) {
-        npcState.mixer = new THREE.AnimationMixer(scene || object3d);
+        npc.mixer = new THREE.AnimationMixer(scene || object3d);
         const clip = gltf.animations[0];
-        const action = npcState.mixer.clipAction(clip);
-        action.play();
+        const action = npc.mixer.clipAction(clip);
+        action?.play();
       }
-    } catch (error) {
+
+      return npc.modelRoot;
+    })
+    .catch((error) => {
       console.warn('[npc] Failed to load NPC model, using placeholder instead.', error);
-      attachModel(buildPlaceholderModel());
-    }
-
-    return npcState.root;
-  };
-
-  npcState.ready = loadModel();
-
-  const update = (deltaSeconds, context = {}) => {
-    if (disposed) {
-      return;
-    }
-    const dt = Number.isFinite(deltaSeconds) ? deltaSeconds : 0;
-    npcState.mixer?.update(dt);
-
-    if (path.length < 2) {
-      return;
-    }
-
-    if (dwellTime > 0) {
-      dwellTime -= dt;
-      return;
-    }
-
-    const target = path[nextIndex];
-    if (!target) {
-      return;
-    }
-
-    tempDirection.subVectors(target, object3d.position);
-    tempDirection.y = 0;
-    const distance = tempDirection.length();
-    if (distance < 1e-4) {
-      object3d.position.x = target.x;
-      object3d.position.z = target.z;
-      nextIndex = (nextIndex + 1) % path.length;
-      dwellTime = normalizedIdle;
-      return;
-    }
-
-    tempDirection.normalize();
-    const step = normalizedSpeed * dt;
-    if (step >= distance) {
-      object3d.position.x = target.x;
-      object3d.position.z = target.z;
-      nextIndex = (nextIndex + 1) % path.length;
-      dwellTime = normalizedIdle;
-    } else {
-      object3d.position.addScaledVector(tempDirection, step);
-    }
-
-    if (tempDirection.lengthSq() > 1e-6) {
-      npcState.physics.yaw = Math.atan2(tempDirection.x, tempDirection.z);
-    }
-
-    const groundMeshes = context.groundMeshes;
-    snapToGround(object3d, groundMeshes, npcState.physics, dt);
-
-    keepUpright(object3d, npcState.physics.yaw, 0.18);
-  };
-
-  const dispose = () => {
-    if (disposed) {
-      return;
-    }
-    disposed = true;
-    npcState.mixer?.stopAllAction?.();
-    if (object3d.parent) {
-      object3d.parent.remove(object3d);
-    }
-    if (npcState.root) {
-      disposeObject3D(npcState.root);
-    }
-    disposeObject3D(object3d);
-  };
-
-  return {
-    object3d,
-    update,
-    dispose,
-    ready: npcState.ready
-  };
+      const placeholder = buildPlaceholderModel();
+      attachModelToNpc(npc, placeholder);
+      return placeholder;
+    });
 }
 
-export function createNpcManager(scene) {
-  const group = new THREE.Group();
-  group.name = 'NPCs';
-  group.userData.isNpcContainer = true;
-  if (scene) {
-    scene.add(group);
+function disposeNpcEntity(npc) {
+  if (!npc || npc.disposed) {
+    return;
+  }
+  npc.disposed = true;
+  npc.mixer?.stopAllAction?.();
+  npc.mixer?.uncacheRoot?.(npc.modelRoot || npc.object3d);
+  npc.mixer = null;
+  if (npc.modelRoot) {
+    if (npc.modelRoot.parent === npc.object3d) {
+      npc.object3d.remove(npc.modelRoot);
+    }
+    disposeObject3D(npc.modelRoot);
+    npc.modelRoot = null;
+  }
+  if (npc.object3d?.parent) {
+    npc.object3d.parent.remove(npc.object3d);
+  }
+  disposeObject3D(npc.object3d);
+}
+
+function createNpcEntity(config = {}, { scene = null } = {}) {
+  const {
+    object3d: providedObject = null,
+    modelUrl = null,
+    initialPosition = null,
+    waypoints = [],
+    walkSpeed = DEFAULT_WALK_SPEED,
+    runSpeed = DEFAULT_RUN_SPEED,
+    accel = DEFAULT_ACCEL,
+    turn = DEFAULT_TURN
+  } = config;
+
+  const object3d = providedObject || new THREE.Group();
+  object3d.userData = { ...(object3d.userData || {}), isNpc: true };
+  object3d.rotation.x = 0;
+  object3d.rotation.z = 0;
+
+  const startPosition = toVector3(initialPosition) || object3d.position.clone();
+  object3d.position.copy(startPosition);
+
+  if (scene && !object3d.parent) {
+    scene.add(object3d);
   }
 
-  const npcs = new Set();
-  let disposed = false;
+  const sanitizedWaypoints = sanitizeWaypoints(waypoints, startPosition);
+
+  const npc = {
+    object3d,
+    waypoints: sanitizedWaypoints,
+    walkSpeed: Number.isFinite(walkSpeed) ? walkSpeed : DEFAULT_WALK_SPEED,
+    runSpeed: Number.isFinite(runSpeed) ? runSpeed : DEFAULT_RUN_SPEED,
+    accel: Number.isFinite(accel) ? accel : DEFAULT_ACCEL,
+    turn: THREE.MathUtils.clamp(Number.isFinite(turn) ? turn : DEFAULT_TURN, 0, 1),
+    speed: 0,
+    state: {
+      vy: 0,
+      lastGoodY: object3d.position.y || 0,
+      yaw: object3d.rotation.y || 0
+    },
+    targetIdx: 0,
+    modelRoot: null,
+    mixer: null,
+    disposed: false
+  };
+
+  if (sanitizedWaypoints.length > 1) {
+    INIT_DIRECTION.subVectors(sanitizedWaypoints[1], sanitizedWaypoints[0]);
+    INIT_DIRECTION.y = 0;
+    if (INIT_DIRECTION.lengthSq() > 1e-6) {
+      npc.state.yaw = Math.atan2(INIT_DIRECTION.x, INIT_DIRECTION.z);
+      object3d.rotation.y = npc.state.yaw;
+    }
+  }
+
+  npc.ready = loadNpcModel(npc, modelUrl);
+  npc.dispose = () => disposeNpcEntity(npc);
+
+  return npc;
+}
+
+function stepNpc(npc, deltaSeconds, groundMeshes) {
+  if (!npc || npc.disposed) {
+    return;
+  }
+
+  const dt = Number.isFinite(deltaSeconds) ? deltaSeconds : 0;
+  if (dt <= 0) {
+    return;
+  }
+
+  const surfaces = Array.isArray(groundMeshes) ? groundMeshes : [];
+
+  npc.mixer?.update(dt);
+
+  if (!Array.isArray(npc.waypoints) || npc.waypoints.length === 0) {
+    snapToGround(npc.object3d, surfaces, npc.state, dt, SNAP_OPTIONS);
+    keepUpright(npc.object3d, npc.state.yaw, npc.turn);
+    return;
+  }
+
+  const target = npc.waypoints[npc.targetIdx];
+  if (!target) {
+    return;
+  }
+
+  STEP_DIRECTION.subVectors(target, npc.object3d.position);
+  STEP_DIRECTION.y = 0;
+  const distance = STEP_DIRECTION.length();
+
+  const desiredSpeed = npc.walkSpeed;
+  const accelFactor = Math.min(1, Math.max(0, npc.accel * dt));
+  npc.speed += (desiredSpeed - npc.speed) * accelFactor;
+
+  if (distance > STEP_EPSILON) {
+    STEP_DIRECTION.normalize();
+    const yaw = Math.atan2(STEP_DIRECTION.x, STEP_DIRECTION.z);
+    npc.state.yaw = yaw;
+    npc.object3d.position.x += STEP_DIRECTION.x * npc.speed * dt;
+    npc.object3d.position.z += STEP_DIRECTION.z * npc.speed * dt;
+  } else {
+    npc.targetIdx = (npc.targetIdx + 1) % npc.waypoints.length;
+  }
+
+  snapToGround(npc.object3d, surfaces, npc.state, dt, SNAP_OPTIONS);
+  keepUpright(npc.object3d, npc.state.yaw, npc.turn);
+}
+
+export function createNpc(options = {}) {
+  const npc = createNpcEntity(options);
 
   return {
-    group,
-    spawn(config = {}) {
-      if (disposed) {
-        return null;
-      }
-      const npc = createNpc(config);
-      group.add(npc.object3d);
-      npcs.add(npc);
-      const originalDispose = npc.dispose;
-      npc.dispose = () => {
-        npcs.delete(npc);
-        originalDispose();
-      };
-      return npc;
-    },
+    object3d: npc.object3d,
     update(deltaSeconds, context = {}) {
-      if (disposed) {
-        return;
-      }
-      for (const npc of npcs) {
-        npc.update?.(deltaSeconds, context);
-      }
+      stepNpc(npc, deltaSeconds, context.groundMeshes);
     },
     dispose() {
-      if (disposed) {
-        return;
-      }
-      disposed = true;
-      for (const npc of npcs) {
-        npc.dispose?.();
-      }
-      npcs.clear();
-      if (group.parent) {
-        group.parent.remove(group);
-      }
-    }
+      npc.dispose();
+    },
+    ready: npc.ready
   };
 }
 
-/**
- * Example NPC configuration:
- *
- * createNpcManager(scene).spawn({
- *   modelUrl: 'assets/models/npc_athenian.glb',
- *   initialPosition: { x: 12, y: 0, z: -6 },
- *   waypoints: [
- *     { x: 12, y: 0, z: -6 },
- *     { x: -4, y: 0, z: -8 },
- *     { x: -2, y: 0, z: 10 },
- *     { x: 14, y: 0, z: 8 }
- *   ]
- * });
- */
+export function createNpcManager(scene, groundMeshes) {
+  const npcs = [];
+  const surfaces = Array.isArray(groundMeshes) ? groundMeshes : [];
+  let warnedGround = false;
+
+  function spawn(config = {}) {
+    const npc = createNpcEntity(config, { scene });
+    npcs.push(npc);
+    const originalDispose = npc.dispose;
+    npc.dispose = () => {
+      if (npc.disposed) {
+        return;
+      }
+      originalDispose();
+      const index = npcs.indexOf(npc);
+      if (index !== -1) {
+        npcs.splice(index, 1);
+      }
+    };
+    return npc;
+  }
+
+  function update(deltaSeconds) {
+    const rawDt = Number.isFinite(deltaSeconds) ? deltaSeconds : 0;
+    if (rawDt <= 0 || rawDt > 0.2) {
+      console.warn('[npc] bad dt', rawDt);
+    }
+    const dt = Math.max(0, Math.min(rawDt, 0.2));
+    if (dt === 0) {
+      return;
+    }
+
+    if (!warnedGround && surfaces.length === 0) {
+      console.warn('[npc] no ground meshes');
+      warnedGround = true;
+    }
+
+    for (const npc of npcs) {
+      stepNpc(npc, dt, surfaces);
+    }
+  }
+
+  function dispose() {
+    while (npcs.length > 0) {
+      const npc = npcs.pop();
+      npc?.dispose?.();
+    }
+  }
+
+  return { spawn, update, dispose, _npcs: npcs };
+}

--- a/src/physics/groundSnap.js
+++ b/src/physics/groundSnap.js
@@ -74,7 +74,8 @@ export function snapToGround(object3d, groundMeshes, inputState, deltaSeconds = 
 
     if (hit) {
       const hitY = hit.point.y;
-      if (hitY >= predictedY && hitY - predictedY <= stepMax) {
+      const delta = hitY - predictedY;
+      if (Math.abs(delta) <= stepMax) {
         position.y = hitY + hover;
         state.vy = 0;
         state.lastGoodY = hitY;
@@ -90,6 +91,7 @@ export function snapToGround(object3d, groundMeshes, inputState, deltaSeconds = 
   if (lastGoodY - position.y > 2) {
     position.y = lastGoodY + hover;
     state.vy = 0;
+    state.lastGoodY = lastGoodY;
     return true;
   }
 


### PR DESCRIPTION
## Summary
- replace the NPC system with a reusable locomotion manager that snaps agents to the ground, keeps their yaw upright, and advances waypoint patrols
- wire the manager into the Athens entry point with ground mesh collection, guardrail warnings, and a walking test NPC
- relax ground snapping to tolerate small step height differences while preserving teleport recovery when falling through terrain

## Testing
- npm run build *(fails: missing @gltf-transform/core dependency during asset generation)*

------
https://chatgpt.com/codex/tasks/task_b_68d90553a8f48327995b2432ffe70578