### PR TITLE
Implement keyboard locomotion and camera orbit controls

### DIFF
--- a/src/camera/followCamera.js
+++ b/src/camera/followCamera.js
@@ -2,9 +2,31 @@ import * as THREE from 'three';
 
 const tempPosition = new THREE.Vector3();
 const tempQuaternion = new THREE.Quaternion();
+const targetWorldPosition = new THREE.Vector3();
 const desiredPosition = new THREE.Vector3();
 const lookOffset = new THREE.Vector3();
-const targetWorldPosition = new THREE.Vector3();
+const cameraForward = new THREE.Vector3();
+
+const MIN_PITCH = THREE.MathUtils.degToRad(-45);
+const MAX_PITCH = THREE.MathUtils.degToRad(70);
+const DEFAULT_YAW_SPEED = 1.6; // radians per second
+const DEFAULT_PITCH_SPEED = 1.2; // radians per second
+
+function computeBaseParameters(offset) {
+  const offsetVector = offset.clone();
+  const radius = offsetVector.length();
+  const horizontal = Math.sqrt(offsetVector.x * offsetVector.x + offsetVector.z * offsetVector.z);
+  const basePitch = horizontal > 1e-5 ? Math.atan2(offsetVector.y, horizontal) : 0;
+  const baseYaw = Math.atan2(offsetVector.x, offsetVector.z);
+  return { radius, basePitch, baseYaw };
+}
+
+function wrapAngle(angle) {
+  if (!Number.isFinite(angle)) {
+    return 0;
+  }
+  return THREE.MathUtils.euclideanModulo(angle + Math.PI, Math.PI * 2) - Math.PI;
+}
 
 export function createFollowCamera(
   camera,
@@ -12,40 +34,135 @@ export function createFollowCamera(
   {
     offset = new THREE.Vector3(0, 2.2, -6),
     lerp = 0.12,
-    lookAtOffset = new THREE.Vector3(0, 1.5, 0)
+    lookAtOffset = new THREE.Vector3(0, 1.5, 0),
+    yawSpeed = DEFAULT_YAW_SPEED,
+    pitchSpeed = DEFAULT_PITCH_SPEED
   } = {}
 ) {
   const options = {
     offset: offset.clone(),
     lerp: Number.isFinite(lerp) ? lerp : 0.12,
-    lookAtOffset: lookAtOffset.clone()
+    lookAtOffset: lookAtOffset.clone(),
+    yawSpeed: Number.isFinite(yawSpeed) ? yawSpeed : DEFAULT_YAW_SPEED,
+    pitchSpeed: Number.isFinite(pitchSpeed) ? pitchSpeed : DEFAULT_PITCH_SPEED
   };
 
   let currentTarget = target || null;
+  const base = computeBaseParameters(options.offset);
+  const pitchMin = MIN_PITCH - base.basePitch;
+  const pitchMax = MAX_PITCH - base.basePitch;
 
-  const update = () => {
+  let yawOffset = 0;
+  let pitchOffset = 0;
+  let cachedTargetYaw = 0;
+
+  const getTargetYaw = () => {
+    if (!currentTarget) {
+      return cachedTargetYaw;
+    }
+    currentTarget.getWorldDirection(cameraForward);
+    cameraForward.y = 0;
+    if (cameraForward.lengthSq() > 1e-6) {
+      cameraForward.normalize();
+      cachedTargetYaw = Math.atan2(cameraForward.x, cameraForward.z);
+    }
+    return cachedTargetYaw;
+  };
+
+  const computeDesired = (out = desiredPosition) => {
+    if (!camera || !currentTarget) {
+      return out.set(0, 0, 0);
+    }
+
+    const targetYaw = getTargetYaw();
+    const finalYaw = targetYaw + yawOffset + base.baseYaw;
+    const finalPitch = THREE.MathUtils.clamp(base.basePitch + pitchOffset, MIN_PITCH, MAX_PITCH);
+    const radius = base.radius;
+    const horizontal = Math.cos(finalPitch) * radius;
+
+    out.set(
+      Math.sin(finalYaw) * horizontal,
+      Math.sin(finalPitch) * radius,
+      Math.cos(finalYaw) * horizontal
+    );
+
+    currentTarget.getWorldPosition(targetWorldPosition);
+    out.add(targetWorldPosition);
+    return out;
+  };
+
+  const computeLerpAlpha = (dt) => {
+    if (!Number.isFinite(options.lerp) || options.lerp <= 0) {
+      return 1;
+    }
+    if (!Number.isFinite(dt) || dt <= 0) {
+      return THREE.MathUtils.clamp(options.lerp, 0, 1);
+    }
+    const scaled = 1 - Math.exp(-options.lerp * dt * 60);
+    return THREE.MathUtils.clamp(scaled, 0, 1);
+  };
+
+  const update = (keyboard, deltaSeconds = 0) => {
     if (!camera || !currentTarget) {
       return;
     }
 
-    currentTarget.getWorldPosition(targetWorldPosition);
+    const dt = Number.isFinite(deltaSeconds) ? Math.max(0, deltaSeconds) : 0;
+    const lookX = keyboard?.look?.x ?? 0;
+    const lookY = keyboard?.look?.y ?? 0;
+
+    yawOffset += lookX * options.yawSpeed * dt;
+    pitchOffset += lookY * options.pitchSpeed * dt;
+    pitchOffset = THREE.MathUtils.clamp(pitchOffset, pitchMin, pitchMax);
+
+    const lerpAlpha = computeLerpAlpha(dt);
+    computeDesired(desiredPosition);
+    camera.position.lerp(desiredPosition, lerpAlpha);
+
+    lookOffset.copy(options.lookAtOffset);
     currentTarget.getWorldQuaternion(tempQuaternion);
+    lookOffset.applyQuaternion(tempQuaternion);
+    tempPosition.copy(targetWorldPosition).add(lookOffset);
+    camera.lookAt(tempPosition);
+  };
 
-    desiredPosition.copy(options.offset).applyQuaternion(tempQuaternion).add(targetWorldPosition);
-    camera.position.lerp(desiredPosition, THREE.MathUtils.clamp(options.lerp, 0, 1));
-
-    lookOffset.copy(options.lookAtOffset).applyQuaternion(tempQuaternion);
+  const syncImmediate = () => {
+    if (!camera || !currentTarget) {
+      return;
+    }
+    computeDesired(desiredPosition);
+    camera.position.copy(desiredPosition);
+    lookOffset.copy(options.lookAtOffset);
+    currentTarget.getWorldQuaternion(tempQuaternion);
+    lookOffset.applyQuaternion(tempQuaternion);
     tempPosition.copy(targetWorldPosition).add(lookOffset);
     camera.lookAt(tempPosition);
   };
 
   const setTarget = (nextTarget) => {
-    currentTarget = nextTarget || currentTarget;
+    if (!nextTarget) {
+      return;
+    }
+    currentTarget = nextTarget;
+    currentTarget.getWorldPosition(targetWorldPosition);
+    tempPosition.copy(camera.position).sub(targetWorldPosition);
+    const horizontal = Math.sqrt(tempPosition.x * tempPosition.x + tempPosition.z * tempPosition.z);
+    const worldPitch = horizontal > 1e-6 ? Math.atan2(tempPosition.y, horizontal) : 0;
+    const worldYaw = Math.atan2(tempPosition.x, tempPosition.z);
+    const targetYaw = getTargetYaw();
+    yawOffset = wrapAngle(worldYaw - targetYaw - base.baseYaw);
+    pitchOffset = THREE.MathUtils.clamp(worldPitch - base.basePitch, pitchMin, pitchMax);
+    syncImmediate();
   };
+
+  if (currentTarget) {
+    setTarget(currentTarget);
+  }
 
   return {
     update,
     setTarget,
+    syncImmediate,
     options
   };
 }

--- a/src/entry/boot.ts
+++ b/src/entry/boot.ts
@@ -2,6 +2,12 @@ import * as THREE from 'three';
 import { setupGround, updateTrees, initPerformanceStats } from '../main.js';
 import { setEnvironment } from '../scene/sky.js';
 import boot from '../core/bootstrap.js';
+import createKeyboard from '../input/keyboard.js';
+import { createPlayerController } from '../player/playerController.js';
+import { createFollowCamera } from '../camera/followCamera.js';
+import { markGround, collectGround } from '../physics/groundRegistry.js';
+import { snapToGround } from '../physics/groundSnap.js';
+import { createNpcManager } from '../npc/simpleNpcManager.js';
 
 type RunOptions = {
   containerId?: string;
@@ -47,6 +53,34 @@ function computeSize(element: HTMLElement) {
     width: Math.max(1, Math.floor(width || fallbackWidth || 1)),
     height: Math.max(1, Math.floor(height || fallbackHeight || 1))
   };
+}
+
+function createPlaceholderPlayer() {
+  const group = new THREE.Group();
+  group.name = 'Player';
+
+  const bodyMaterial = new THREE.MeshStandardMaterial({ color: 0x2563eb, roughness: 0.65, metalness: 0.15 });
+  const accentMaterial = new THREE.MeshStandardMaterial({ color: 0xfacc15, roughness: 0.5, metalness: 0.1 });
+
+  if (typeof THREE.CapsuleGeometry === 'function') {
+    const capsule = new THREE.Mesh(new THREE.CapsuleGeometry(0.45, 1.6, 12, 24), bodyMaterial);
+    capsule.castShadow = true;
+    capsule.receiveShadow = true;
+    group.add(capsule);
+  } else {
+    const cylinder = new THREE.Mesh(new THREE.CylinderGeometry(0.5, 0.5, 1.6, 16), bodyMaterial);
+    cylinder.castShadow = true;
+    cylinder.receiveShadow = true;
+    group.add(cylinder);
+  }
+
+  const head = new THREE.Mesh(new THREE.SphereGeometry(0.42, 16, 16), accentMaterial);
+  head.position.y = 1.1;
+  head.castShadow = true;
+  head.receiveShadow = true;
+  group.add(head);
+
+  return group;
 }
 
 export async function runAthens(options: RunOptions = {}) {
@@ -114,6 +148,41 @@ export async function runAthens(options: RunOptions = {}) {
     }
   }
 
+  markGround(scene);
+  const groundMeshes = collectGround(scene);
+
+  const playerObject = createPlaceholderPlayer();
+  scene.add(playerObject);
+  if (groundMeshes.length) {
+    const initialState = { vy: 0, lastGoodY: playerObject.position.y };
+    snapToGround(playerObject, groundMeshes, initialState, 0);
+  }
+
+  const keyboard = createKeyboard();
+  const playerController = createPlayerController(playerObject, keyboard, {
+    walkSpeed: 4.0,
+    runMultiplier: 1.7,
+    acceleration: 10,
+    turnLerp: 0.18
+  });
+  playerController.setGroundMeshes(groundMeshes);
+
+  const followCamera = createFollowCamera(camera, playerObject, {
+    offset: new THREE.Vector3(0, 2.2, -6),
+    lerp: 0.12,
+    lookAtOffset: new THREE.Vector3(0, 1.5, 0)
+  });
+  followCamera.syncImmediate();
+
+  const npcManager = createNpcManager(scene, groundMeshes);
+  npcManager.setGroundMeshes(groundMeshes);
+  npcManager.spawn({
+    waypoints: [
+      new THREE.Vector3(6, 0, 6),
+      new THREE.Vector3(10, 0, 6)
+    ]
+  });
+
   const clock = new THREE.Clock();
   let frameId: number | null = null;
 
@@ -138,6 +207,20 @@ export async function runAthens(options: RunOptions = {}) {
       }
     }
 
+    try {
+      playerController.update(delta, camera);
+    } catch (error) {
+      console.warn('[Athens][Boot] player update failed', error);
+    }
+
+    try {
+      npcManager.update(delta);
+    } catch (error) {
+      console.warn('[Athens][Boot] npc update failed', error);
+    }
+
+    followCamera.update(keyboard, delta);
+
     renderer.render(scene, camera);
     frameId = requestAnimationFrame(animate);
   };
@@ -150,6 +233,10 @@ export async function runAthens(options: RunOptions = {}) {
     scene,
     camera,
     renderer,
+    keyboard,
+    playerController,
+    followCamera,
+    npcManager,
     dispose() {
       if (frameId !== null && typeof cancelAnimationFrame === 'function') {
         cancelAnimationFrame(frameId);
@@ -158,6 +245,8 @@ export async function runAthens(options: RunOptions = {}) {
       if (typeof window !== 'undefined') {
         window.removeEventListener('resize', handleResize);
       }
+      npcManager.dispose();
+      keyboard.dispose();
       renderer.dispose();
     }
   };

--- a/src/input/keyboard.js
+++ b/src/input/keyboard.js
@@ -1,30 +1,30 @@
 const INV_SQRT2 = 1 / Math.sqrt(2);
 
-const RELEVANT_KEYS = new Set([
+const MOVEMENT_KEYS = [
   'KeyW',
   'KeyA',
   'KeyS',
-  'KeyD',
+  'KeyD'
+];
+
+const LOOK_KEYS = [
   'ArrowUp',
   'ArrowDown',
   'ArrowLeft',
-  'ArrowRight',
-  'ShiftLeft',
-  'ShiftRight',
-  'Space',
-  'KeyX',
-  'KeyC',
-  'KeyE',
-  'KeyQ',
-  'KeyZ',
-  'ControlLeft',
-  'ControlRight'
-]);
+  'ArrowRight'
+];
+
+const MODIFIER_KEYS = ['ShiftLeft', 'ShiftRight'];
+
+const EXTRA_KEYS = ['Space', 'KeyX', 'KeyC', 'KeyE', 'KeyQ', 'KeyZ', 'ControlLeft', 'ControlRight'];
+
+const RELEVANT_KEYS = new Set([...MOVEMENT_KEYS, ...LOOK_KEYS, ...MODIFIER_KEYS, ...EXTRA_KEYS]);
 
 export function createKeyboard(target = typeof window !== 'undefined' ? window : null) {
   const pressed = new Set();
   const listeners = new Map();
   const axisVector = { x: 0, z: 0 };
+  const lookVector = { x: 0, y: 0 };
 
   const handleKeyDown = (event) => {
     if (!RELEVANT_KEYS.has(event.code)) {
@@ -53,16 +53,16 @@ export function createKeyboard(target = typeof window !== 'undefined' ? window :
     let x = 0;
     let z = 0;
 
-    if (isDown('KeyA') || isDown('ArrowLeft')) {
+    if (isDown('KeyA')) {
       x -= 1;
     }
-    if (isDown('KeyD') || isDown('ArrowRight')) {
+    if (isDown('KeyD')) {
       x += 1;
     }
-    if (isDown('KeyW') || isDown('ArrowUp')) {
+    if (isDown('KeyW')) {
       z -= 1;
     }
-    if (isDown('KeyS') || isDown('ArrowDown')) {
+    if (isDown('KeyS')) {
       z += 1;
     }
 
@@ -74,6 +74,28 @@ export function createKeyboard(target = typeof window !== 'undefined' ? window :
     axisVector.x = x;
     axisVector.z = z;
     return axisVector;
+  };
+
+  const computeLook = () => {
+    let x = 0;
+    let y = 0;
+
+    if (isDown('ArrowLeft')) {
+      x -= 1;
+    }
+    if (isDown('ArrowRight')) {
+      x += 1;
+    }
+    if (isDown('ArrowUp')) {
+      y += 1;
+    }
+    if (isDown('ArrowDown')) {
+      y -= 1;
+    }
+
+    lookVector.x = x;
+    lookVector.y = y;
+    return lookVector;
   };
 
   const axis = {};
@@ -93,7 +115,23 @@ export function createKeyboard(target = typeof window !== 'undefined' ? window :
     running: {
       enumerable: true,
       get() {
-        return isDown('ShiftLeft') || isDown('ShiftRight');
+        return MODIFIER_KEYS.some((code) => isDown(code));
+      }
+    }
+  });
+
+  const look = {};
+  Object.defineProperties(look, {
+    x: {
+      enumerable: true,
+      get() {
+        return computeLook().x;
+      }
+    },
+    y: {
+      enumerable: true,
+      get() {
+        return computeLook().y;
       }
     }
   });
@@ -112,6 +150,7 @@ export function createKeyboard(target = typeof window !== 'undefined' ? window :
   return {
     isDown,
     axis,
+    look,
     dispose
   };
 }

--- a/src/npc/simpleNpcManager.js
+++ b/src/npc/simpleNpcManager.js
@@ -1,0 +1,174 @@
+import * as THREE from 'three';
+import { snapToGround } from '../physics/groundSnap.js';
+import { keepUpright } from '../physics/upright.js';
+
+const tempDirection = new THREE.Vector3();
+const flatDirection = new THREE.Vector3();
+const tempVelocity = new THREE.Vector3();
+const forwardVector = new THREE.Vector3(0, 0, 1);
+
+function toVector3(input) {
+  if (!input) {
+    return null;
+  }
+  if (input.isVector3) {
+    return input.clone();
+  }
+  if (Array.isArray(input) && input.length >= 3) {
+    return new THREE.Vector3(Number(input[0]) || 0, Number(input[1]) || 0, Number(input[2]) || 0);
+  }
+  const { x, y, z } = input;
+  if (typeof x === 'number' && typeof y === 'number' && typeof z === 'number') {
+    return new THREE.Vector3(x, y, z);
+  }
+  return null;
+}
+
+function buildPlaceholderNpc() {
+  const group = new THREE.Group();
+  group.name = 'NPC';
+  const bodyMaterial = new THREE.MeshStandardMaterial({ color: 0xf97316, roughness: 0.7, metalness: 0.1 });
+  const headMaterial = new THREE.MeshStandardMaterial({ color: 0xfef3c7, roughness: 0.4, metalness: 0.05 });
+
+  const body = new THREE.Mesh(new THREE.CapsuleGeometry(0.4, 1.4, 8, 16), bodyMaterial);
+  body.castShadow = true;
+  body.receiveShadow = true;
+  group.add(body);
+
+  const head = new THREE.Mesh(new THREE.SphereGeometry(0.4, 16, 16), headMaterial);
+  head.position.y = 1.2;
+  head.castShadow = true;
+  head.receiveShadow = true;
+  group.add(head);
+
+  return group;
+}
+
+function deriveYaw(object3d) {
+  if (!object3d) {
+    return 0;
+  }
+  tempVelocity.copy(forwardVector).applyQuaternion(object3d.quaternion);
+  tempVelocity.y = 0;
+  if (tempVelocity.lengthSq() < 1e-6) {
+    return 0;
+  }
+  tempVelocity.normalize();
+  return Math.atan2(tempVelocity.x, tempVelocity.z);
+}
+
+function normalizeWaypoints(waypoints) {
+  const list = Array.isArray(waypoints) ? waypoints : [];
+  const result = [];
+  for (let i = 0; i < list.length; i += 1) {
+    const point = toVector3(list[i]);
+    if (point) {
+      result.push(point);
+    }
+  }
+  return result;
+}
+
+export function createNpcManager(scene, initialGroundMeshes = []) {
+  const npcs = [];
+  let groundMeshes = Array.isArray(initialGroundMeshes) ? initialGroundMeshes : [];
+
+  const setGroundMeshes = (meshes) => {
+    groundMeshes = Array.isArray(meshes) ? meshes : [];
+  };
+
+  const spawn = ({ object3d, waypoints, walkSpeed = 1.6, accel = 5.0, turn = 0.18 } = {}) => {
+    const npcObject = object3d || buildPlaceholderNpc();
+    npcObject.userData.isNpc = true;
+
+    const path = normalizeWaypoints(waypoints);
+    if (path.length === 0) {
+      path.push(npcObject.position.clone());
+    }
+
+    const npcState = {
+      object3d: npcObject,
+      waypoints: path,
+      waypointIndex: 0,
+      walkSpeed: Number.isFinite(walkSpeed) && walkSpeed > 0 ? walkSpeed : 1.6,
+      accel: Number.isFinite(accel) && accel > 0 ? accel : 5.0,
+      turn: Number.isFinite(turn) ? THREE.MathUtils.clamp(turn, 0, 1) : 0.18,
+      velocity: new THREE.Vector3(),
+      physics: {
+        vy: 0,
+        lastGoodY: npcObject.position?.y ?? 0
+      },
+      yaw: deriveYaw(npcObject)
+    };
+
+    if (scene && npcObject && !npcObject.parent) {
+      scene.add(npcObject);
+    }
+
+    snapToGround(npcObject, groundMeshes, npcState.physics, 0);
+    npcState.yaw = deriveYaw(npcObject);
+
+    npcs.push(npcState);
+    return npcState;
+  };
+
+  const updateNpc = (npc, dt) => {
+    if (!npc?.object3d || !npc.waypoints.length) {
+      return;
+    }
+
+    const { object3d } = npc;
+
+    let target = npc.waypoints[npc.waypointIndex];
+    flatDirection.subVectors(target, object3d.position);
+    const flatDistance = Math.sqrt(flatDirection.x * flatDirection.x + flatDirection.z * flatDirection.z);
+
+    if (flatDistance < 0.2) {
+      npc.waypointIndex = (npc.waypointIndex + 1) % npc.waypoints.length;
+      target = npc.waypoints[npc.waypointIndex];
+      flatDirection.subVectors(target, object3d.position);
+    }
+
+    flatDirection.y = 0;
+    if (flatDirection.lengthSq() > 1e-6) {
+      flatDirection.normalize();
+      tempVelocity.copy(flatDirection).multiplyScalar(npc.walkSpeed);
+    } else {
+      tempVelocity.set(0, 0, 0);
+    }
+
+    const lerpAlpha = npc.accel > 0 && dt > 0 ? 1 - Math.exp(-npc.accel * dt) : 1;
+    npc.velocity.lerp(tempVelocity, THREE.MathUtils.clamp(lerpAlpha, 0, 1));
+
+    if (dt > 0) {
+      object3d.position.addScaledVector(npc.velocity, dt);
+    }
+
+    if (npc.velocity.lengthSq() > 1e-6) {
+      npc.yaw = Math.atan2(npc.velocity.x, npc.velocity.z);
+    }
+
+    snapToGround(object3d, groundMeshes, npc.physics, dt);
+    keepUpright(object3d, npc.yaw, npc.turn);
+  };
+
+  const update = (deltaSeconds = 0) => {
+    const dt = Number.isFinite(deltaSeconds) ? Math.max(0, deltaSeconds) : 0;
+    for (let i = 0; i < npcs.length; i += 1) {
+      updateNpc(npcs[i], dt);
+    }
+  };
+
+  const dispose = () => {
+    npcs.length = 0;
+  };
+
+  return {
+    spawn,
+    update,
+    dispose,
+    setGroundMeshes
+  };
+}
+
+export default createNpcManager;

--- a/src/player/playerController.js
+++ b/src/player/playerController.js
@@ -1,48 +1,74 @@
 import * as THREE from 'three';
+import { snapToGround } from '../physics/groundSnap.js';
+import { keepUpright } from '../physics/upright.js';
 
 const WORLD_UP = new THREE.Vector3(0, 1, 0);
 const cameraForward = new THREE.Vector3();
 const cameraRight = new THREE.Vector3();
 const moveDirection = new THREE.Vector3();
-const horizontalDirection = new THREE.Vector3();
-const targetQuaternion = new THREE.Quaternion();
-const referenceForward = new THREE.Vector3(0, 0, 1);
+const targetVelocity = new THREE.Vector3();
+const velocity = new THREE.Vector3();
+const horizontalVector = new THREE.Vector3();
+const FORWARD = new THREE.Vector3(0, 0, 1);
+
+function deriveYaw(object3d) {
+  if (!object3d) {
+    return 0;
+  }
+  horizontalVector.copy(FORWARD).applyQuaternion(object3d.quaternion);
+  horizontalVector.y = 0;
+  if (horizontalVector.lengthSq() < 1e-6) {
+    return 0;
+  }
+  horizontalVector.normalize();
+  return Math.atan2(horizontalVector.x, horizontalVector.z);
+}
 
 export function createPlayerController(
   object3d,
   keyboard,
   {
-    walkSpeed = 5.5,
-    runMultiplier = 2.0,
-    flyMultiplier = 1.6,
-    turnLerp = 0.18,
-    flightToggleKey = 'KeyX'
+    walkSpeed = 4.0,
+    runMultiplier = 1.7,
+    acceleration = 10,
+    turnLerp = 0.18
   } = {}
 ) {
   let controlledObject = object3d || null;
-  let flightEnabled = false;
-  let previousToggleDown = false;
+  let currentKeyboard = keyboard || null;
+  let groundMeshes = [];
+  const physicsState = {
+    vy: 0,
+    lastGoodY: controlledObject?.position?.y ?? 0
+  };
+
+  let desiredYaw = deriveYaw(controlledObject);
   let runningState = false;
 
-  const isKeyDown = (code) => (typeof keyboard?.isDown === 'function' ? keyboard.isDown(code) : false);
+  const setGroundMeshes = (meshes) => {
+    groundMeshes = Array.isArray(meshes) ? meshes : [];
+  };
 
-  const getSpeed = () => {
-    const base = Number.isFinite(walkSpeed) ? walkSpeed : 4.0;
-    const runningMultiplier = runningState && Number.isFinite(runMultiplier) && runMultiplier > 0 ? runMultiplier : 1;
-    const activeFlyMultiplier = flightEnabled && Number.isFinite(flyMultiplier) && flyMultiplier > 0 ? flyMultiplier : 1;
-    return base * runningMultiplier * activeFlyMultiplier;
+  const setObject = (nextObject) => {
+    if (!nextObject) {
+      return;
+    }
+    controlledObject = nextObject;
+    physicsState.vy = 0;
+    physicsState.lastGoodY = controlledObject.position?.y ?? 0;
+    desiredYaw = deriveYaw(controlledObject);
+  };
+
+  const setKeyboard = (nextKeyboard) => {
+    currentKeyboard = nextKeyboard || currentKeyboard;
   };
 
   const update = (deltaSeconds, camera) => {
-    if (!controlledObject || !keyboard || !camera) {
+    if (!controlledObject || !currentKeyboard || !camera) {
       return;
     }
 
-    const toggleDown = flightToggleKey ? isKeyDown(flightToggleKey) : false;
-    if (toggleDown && !previousToggleDown) {
-      flightEnabled = !flightEnabled;
-    }
-    previousToggleDown = toggleDown;
+    const dt = Number.isFinite(deltaSeconds) ? Math.max(0, deltaSeconds) : 0;
 
     camera.getWorldDirection(cameraForward);
     cameraForward.y = 0;
@@ -54,10 +80,11 @@ export function createPlayerController(
 
     cameraRight.copy(cameraForward).cross(WORLD_UP).normalize();
 
-    moveDirection.set(0, 0, 0);
-    const axisX = keyboard.axis?.x || 0;
-    const axisZ = keyboard.axis?.z || 0;
+    const axisX = currentKeyboard.axis?.x || 0;
+    const axisZ = currentKeyboard.axis?.z || 0;
+    const hasInput = axisX !== 0 || axisZ !== 0;
 
+    moveDirection.set(0, 0, 0);
     if (axisZ !== 0) {
       moveDirection.addScaledVector(cameraForward, -axisZ);
     }
@@ -65,58 +92,48 @@ export function createPlayerController(
       moveDirection.addScaledVector(cameraRight, axisX);
     }
 
-    const shiftDown = isKeyDown('ShiftLeft') || isKeyDown('ShiftRight');
-    runningState = !flightEnabled && shiftDown;
-
-    if (flightEnabled) {
-      let verticalInput = 0;
-      if (isKeyDown('Space')) {
-        verticalInput += 1;
-      }
-      if (
-        shiftDown ||
-        isKeyDown('ControlLeft') ||
-        isKeyDown('ControlRight') ||
-        isKeyDown('KeyC') ||
-        isKeyDown('KeyZ')
-      ) {
-        verticalInput -= 1;
-      }
-      if (verticalInput !== 0) {
-        moveDirection.y = verticalInput;
-      }
-    }
-
-    const lengthSq = moveDirection.lengthSq();
-    if (lengthSq > 1e-6) {
+    if (moveDirection.lengthSq() > 1e-6) {
       moveDirection.normalize();
-      const speed = getSpeed();
-      const distance = speed * (Number.isFinite(deltaSeconds) ? deltaSeconds : 0);
-      controlledObject.position.addScaledVector(moveDirection, distance);
-
-      horizontalDirection.copy(moveDirection);
-      horizontalDirection.y = 0;
-      if (horizontalDirection.lengthSq() > 1e-6) {
-        horizontalDirection.normalize();
-        targetQuaternion.setFromUnitVectors(referenceForward, horizontalDirection);
-        controlledObject.quaternion.slerp(targetQuaternion, THREE.MathUtils.clamp(turnLerp, 0, 1));
-      }
+    } else {
+      moveDirection.set(0, 0, 0);
     }
-  };
 
-  const setObject = (nextObject) => {
-    if (!nextObject) {
-      return;
+    const shiftDown = Boolean(currentKeyboard.axis?.running);
+    const effectiveRunMultiplier = shiftDown ? Math.max(runMultiplier, 1) : 1;
+    const baseSpeed = Number.isFinite(walkSpeed) ? walkSpeed : 4.0;
+    const targetSpeed = hasInput ? baseSpeed * effectiveRunMultiplier : 0;
+    runningState = hasInput && shiftDown && targetSpeed > baseSpeed;
+
+    if (hasInput) {
+      targetVelocity.copy(moveDirection).multiplyScalar(targetSpeed);
+    } else {
+      targetVelocity.set(0, 0, 0);
     }
-    controlledObject = nextObject;
+
+    const accel = Number.isFinite(acceleration) ? Math.max(acceleration, 0) : 10;
+    const lerpAlpha = accel > 0 && dt > 0 ? 1 - Math.exp(-accel * dt) : 1;
+    velocity.lerp(targetVelocity, THREE.MathUtils.clamp(lerpAlpha, 0, 1));
+
+    if (dt > 0) {
+      controlledObject.position.addScaledVector(velocity, dt);
+    }
+
+    horizontalVector.copy(velocity);
+    horizontalVector.y = 0;
+    if (horizontalVector.lengthSq() > 1e-6) {
+      horizontalVector.normalize();
+      desiredYaw = Math.atan2(horizontalVector.x, horizontalVector.z);
+    }
+
+    snapToGround(controlledObject, groundMeshes, physicsState, dt);
+    keepUpright(controlledObject, desiredYaw, Number.isFinite(turnLerp) ? turnLerp : 0.18);
   };
 
   return {
     update,
     setObject,
-    isFlying() {
-      return flightEnabled;
-    },
+    setKeyboard,
+    setGroundMeshes,
     isRunning() {
       return runningState;
     }


### PR DESCRIPTION
## Summary
- add keyboard handling for WASD movement, arrow-key looking, and running
- implement a follow camera that orbits the player with yaw/pitch state and smooth lerping
- rework the player controller for grounded, camera-relative motion and keep-upright yaw alignment
- add a simple NPC manager and wire the boot entry point to spawn a waypoint-walking NPC

## Testing
- `npm run build` *(fails: missing @gltf-transform/core dependency)*

------
https://chatgpt.com/codex/tasks/task_b_68d908db580083278500b05c9c941ebf