### PR TITLE
Adjust default spawn location to open area

### DIFF
--- a/src/entry/initializeAthens.js
+++ b/src/entry/initializeAthens.js
@@ -320,7 +320,7 @@ export async function initializeAthens(options = {}) {
   const mainCharacter = options.enableMainCharacter === false
     ? null
     : createMainCharacter(scene, {
-        initialPosition: { x: 4, y: 0, z: 4 },
+        initialPosition: { x: 72, y: 0, z: -48 },
         ...(mainCharacterOptions || {})
       });
 
@@ -662,7 +662,7 @@ export async function initializeAthens(options = {}) {
   const mainCharacter = options.enableMainCharacter === false
     ? null
     : createMainCharacter(scene, {
-        initialPosition: { x: 4, y: 0, z: 4 },
+        initialPosition: { x: 72, y: 0, z: -48 },
         ...(mainCharacterOptions || {})
       });
 


### PR DESCRIPTION
## Summary
- update the main character's default spawn position so the experience begins in an open plaza instead of inside a structure

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d90f6cfdf883279866b5074c46084a