### PR TITLE
Add capsule collision handling for characters

### DIFF
--- a/src/entry/boot.ts
+++ b/src/entry/boot.ts
@@ -8,6 +8,7 @@ import { createFollowCamera } from '../camera/followCamera.js';
 import { markGround, collectGround } from '../physics/groundRegistry.js';
 import { snapToGround } from '../physics/groundSnap.js';
 import { createNpcManager } from '../npc/simpleNpcManager.js';
+import { markColliders, collectColliders, buildAABBs } from '../physics/colliderRegistry.js';
 
 type RunOptions = {
   containerId?: string;
@@ -150,6 +151,9 @@ export async function runAthens(options: RunOptions = {}) {
 
   markGround(scene);
   const groundMeshes = collectGround(scene);
+  markColliders(scene);
+  const colliderMeshes = collectColliders(scene);
+  const colliders = buildAABBs(colliderMeshes);
 
   const playerObject = createPlaceholderPlayer();
   scene.add(playerObject);
@@ -163,9 +167,11 @@ export async function runAthens(options: RunOptions = {}) {
     walkSpeed: 4.0,
     runMultiplier: 1.7,
     acceleration: 10,
-    turnLerp: 0.18
+    turnLerp: 0.18,
+    colliders
   });
   playerController.setGroundMeshes(groundMeshes);
+  playerController.setColliders(colliders);
 
   const followCamera = createFollowCamera(camera, playerObject, {
     offset: new THREE.Vector3(0, 2.2, -6),
@@ -174,8 +180,9 @@ export async function runAthens(options: RunOptions = {}) {
   });
   followCamera.syncImmediate();
 
-  const npcManager = createNpcManager(scene, groundMeshes);
+  const npcManager = createNpcManager(scene, groundMeshes, { colliders });
   npcManager.setGroundMeshes(groundMeshes);
+  npcManager.setColliders(colliders);
   npcManager.spawn({
     waypoints: [
       new THREE.Vector3(6, 0, 6),

--- a/src/npc/simpleNpcManager.js
+++ b/src/npc/simpleNpcManager.js
@@ -1,11 +1,15 @@
 import * as THREE from 'three';
 import { snapToGround } from '../physics/groundSnap.js';
 import { keepUpright } from '../physics/upright.js';
+import { Capsule, resolveCapsuleVsAABBs } from '../physics/collision.js';
 
 const tempDirection = new THREE.Vector3();
 const flatDirection = new THREE.Vector3();
 const tempVelocity = new THREE.Vector3();
 const forwardVector = new THREE.Vector3(0, 0, 1);
+const moveDelta = new THREE.Vector3();
+const separationOffset = new THREE.Vector3();
+const orientVector = new THREE.Vector3();
 
 function toVector3(input) {
   if (!input) {
@@ -69,12 +73,17 @@ function normalizeWaypoints(waypoints) {
   return result;
 }
 
-export function createNpcManager(scene, initialGroundMeshes = []) {
+export function createNpcManager(scene, initialGroundMeshes = [], { colliders: initialColliders = [] } = {}) {
   const npcs = [];
   let groundMeshes = Array.isArray(initialGroundMeshes) ? initialGroundMeshes : [];
+  let colliderAabbs = Array.isArray(initialColliders) ? initialColliders : [];
 
   const setGroundMeshes = (meshes) => {
     groundMeshes = Array.isArray(meshes) ? meshes : [];
+  };
+
+  const setColliders = (nextColliders) => {
+    colliderAabbs = Array.isArray(nextColliders) ? nextColliders : [];
   };
 
   const spawn = ({ object3d, waypoints, walkSpeed = 1.6, accel = 5.0, turn = 0.18 } = {}) => {
@@ -98,7 +107,10 @@ export function createNpcManager(scene, initialGroundMeshes = []) {
         vy: 0,
         lastGoodY: npcObject.position?.y ?? 0
       },
-      yaw: deriveYaw(npcObject)
+      yaw: deriveYaw(npcObject),
+      capsule: new Capsule(0.4, 1.5),
+      prevPosition: npcObject.position.clone(),
+      lastMove: new THREE.Vector3()
     };
 
     if (scene && npcObject && !npcObject.parent) {
@@ -107,6 +119,12 @@ export function createNpcManager(scene, initialGroundMeshes = []) {
 
     snapToGround(npcObject, groundMeshes, npcState.physics, 0);
     npcState.yaw = deriveYaw(npcObject);
+    npcState.capsule.setPosition(
+      npcObject.position.x,
+      npcObject.position.y,
+      npcObject.position.z
+    );
+    npcState.prevPosition.copy(npcObject.position);
 
     npcs.push(npcState);
     return npcState;
@@ -118,6 +136,8 @@ export function createNpcManager(scene, initialGroundMeshes = []) {
     }
 
     const { object3d } = npc;
+
+    npc.capsule.setPosition(object3d.position.x, object3d.position.y, object3d.position.z);
 
     let target = npc.waypoints[npc.waypointIndex];
     flatDirection.subVectors(target, object3d.position);
@@ -141,21 +161,82 @@ export function createNpcManager(scene, initialGroundMeshes = []) {
     npc.velocity.lerp(tempVelocity, THREE.MathUtils.clamp(lerpAlpha, 0, 1));
 
     if (dt > 0) {
-      object3d.position.addScaledVector(npc.velocity, dt);
+      moveDelta.set(npc.velocity.x * dt, 0, npc.velocity.z * dt);
+      const moveLenSq = moveDelta.lengthSq();
+      if (moveLenSq > 1e-10) {
+        const result = resolveCapsuleVsAABBs(npc.capsule, moveDelta, colliderAabbs, {
+          maxIters: 3,
+          skin: 0.01
+        });
+        object3d.position.copy(npc.capsule.position);
+      } else if (moveLenSq > 0) {
+        object3d.position.add(moveDelta);
+        npc.capsule.setPosition(object3d.position.x, object3d.position.y, object3d.position.z);
+      }
     }
+  };
 
-    if (npc.velocity.lengthSq() > 1e-6) {
-      npc.yaw = Math.atan2(npc.velocity.x, npc.velocity.z);
+  const separationRadius = 0.8;
+  const separationRadiusSq = separationRadius * separationRadius;
+
+  const applySeparation = () => {
+    const limit = Math.min(npcs.length, 20);
+    for (let i = 0; i < limit; i += 1) {
+      const npcA = npcs[i];
+      if (!npcA?.object3d) continue;
+      const posA = npcA.object3d.position;
+      for (let j = i + 1; j < limit; j += 1) {
+        const npcB = npcs[j];
+        if (!npcB?.object3d) continue;
+        const posB = npcB.object3d.position;
+        separationOffset.subVectors(posA, posB);
+        separationOffset.y = 0;
+        const distSq = separationOffset.lengthSq();
+        if (distSq <= 1e-6 || distSq >= separationRadiusSq) continue;
+        const dist = Math.sqrt(distSq);
+        if (dist <= 1e-6) continue;
+        const push = (separationRadius - dist) * 0.5;
+        if (push <= 0) continue;
+        separationOffset.multiplyScalar(push / dist);
+        posA.add(separationOffset);
+        posB.addScaledVector(separationOffset, -1);
+        npcA.capsule?.setPosition(posA.x, posA.y, posA.z);
+        npcB.capsule?.setPosition(posB.x, posB.y, posB.z);
+      }
     }
-
-    snapToGround(object3d, groundMeshes, npc.physics, dt);
-    keepUpright(object3d, npc.yaw, npc.turn);
   };
 
   const update = (deltaSeconds = 0) => {
     const dt = Number.isFinite(deltaSeconds) ? Math.max(0, deltaSeconds) : 0;
+
     for (let i = 0; i < npcs.length; i += 1) {
-      updateNpc(npcs[i], dt);
+      const npc = npcs[i];
+      if (!npc?.object3d) continue;
+      npc.prevPosition.copy(npc.object3d.position);
+      updateNpc(npc, dt);
+    }
+
+    applySeparation();
+
+    for (let i = 0; i < npcs.length; i += 1) {
+      const npc = npcs[i];
+      if (!npc?.object3d) continue;
+      snapToGround(npc.object3d, groundMeshes, npc.physics, dt);
+      npc.capsule?.setPosition(
+        npc.object3d.position.x,
+        npc.object3d.position.y,
+        npc.object3d.position.z
+      );
+      npc.lastMove.subVectors(npc.object3d.position, npc.prevPosition);
+      orientVector.copy(npc.lastMove);
+      orientVector.y = 0;
+      if (orientVector.lengthSq() > 1e-6) {
+        orientVector.normalize();
+        npc.yaw = Math.atan2(orientVector.x, orientVector.z);
+      } else if (npc.velocity.lengthSq() > 1e-6) {
+        npc.yaw = Math.atan2(npc.velocity.x, npc.velocity.z);
+      }
+      keepUpright(npc.object3d, npc.yaw, npc.turn);
     }
   };
 
@@ -167,7 +248,8 @@ export function createNpcManager(scene, initialGroundMeshes = []) {
     spawn,
     update,
     dispose,
-    setGroundMeshes
+    setGroundMeshes,
+    setColliders
   };
 }
 

--- a/src/physics/colliderRegistry.js
+++ b/src/physics/colliderRegistry.js
@@ -16,99 +16,106 @@ const COLLIDER_KEYWORDS = [
   'gate'
 ];
 
-const keywordMatch = (name) => {
-  if (typeof name !== 'string' || name.length === 0) {
+const keywordCache = COLLIDER_KEYWORDS.map((word) => word.toLowerCase());
+
+function shouldMarkCollider(object) {
+  if (!object || typeof object !== 'object') {
     return false;
   }
-  const normalized = name.toLowerCase();
-  for (let i = 0; i < COLLIDER_KEYWORDS.length; i += 1) {
-    if (normalized.includes(COLLIDER_KEYWORDS[i])) {
+  if (object.userData && object.userData.collider === true) {
+    return true;
+  }
+  if (!object.name || typeof object.name !== 'string') {
+    return false;
+  }
+  const name = object.name.toLowerCase();
+  for (let i = 0; i < keywordCache.length; i += 1) {
+    if (name.includes(keywordCache[i])) {
       return true;
     }
   }
   return false;
-};
+}
 
 export function markColliders(root) {
-  if (!root || typeof root.traverse !== 'function') {
-    return;
+  if (!root) return;
+  const stack = [root];
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (!current) continue;
+    if (current.children && current.children.length) {
+      for (let i = 0; i < current.children.length; i += 1) {
+        stack.push(current.children[i]);
+      }
+    }
+    if (current.isMesh && shouldMarkCollider(current)) {
+      current.userData = current.userData || {};
+      current.userData.isCollider = true;
+    }
   }
-  root.traverse((child) => {
-    if (!child || !child.isMesh) {
-      return;
-    }
-    const userData = child.userData || (child.userData = {});
-    if (userData.collider === true) {
-      userData.isCollider = true;
-      return;
-    }
-    if (userData.collider === false) {
-      userData.isCollider = false;
-      return;
-    }
-    if (keywordMatch(child.name)) {
-      userData.isCollider = true;
-    }
-  });
 }
 
 export function collectColliders(root) {
   const colliders = [];
-  if (!root || typeof root.traverse !== 'function') {
-    return colliders;
-  }
-  root.traverse((child) => {
-    if (child && child.isMesh && child.userData?.isCollider === true) {
-      colliders.push(child);
+  if (!root) return colliders;
+  const stack = [root];
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (!current) continue;
+    if (current.children && current.children.length) {
+      for (let i = 0; i < current.children.length; i += 1) {
+        stack.push(current.children[i]);
+      }
     }
-  });
+    if (current.isMesh && current.userData && current.userData.isCollider === true) {
+      colliders.push(current);
+    }
+  }
   return colliders;
 }
 
 function computeWorldAABB(mesh, target) {
-  if (!mesh || !mesh.isMesh || !mesh.geometry) {
-    return null;
-  }
+  if (!mesh || !mesh.geometry || !target) return target;
   mesh.updateWorldMatrix(true, false);
   const geometry = mesh.geometry;
   if (!geometry.boundingBox) {
     geometry.computeBoundingBox();
   }
-  if (!geometry.boundingBox) {
-    return null;
+  if (geometry.boundingBox) {
+    target.copy(geometry.boundingBox);
+    target.applyMatrix4(mesh.matrixWorld);
+  } else {
+    target.makeEmpty();
   }
-  target.copy(geometry.boundingBox);
-  target.applyMatrix4(mesh.matrixWorld);
   return target;
 }
 
 export function buildAABBs(meshes) {
-  const result = [];
   const list = Array.isArray(meshes) ? meshes : [];
+  const results = [];
   for (let i = 0; i < list.length; i += 1) {
     const mesh = list[i];
-    const box = computeWorldAABB(mesh, new THREE.Box3());
-    if (box) {
-      result.push({ mesh, box });
-    }
+    if (!mesh || !mesh.isMesh) continue;
+    const box = new THREE.Box3();
+    computeWorldAABB(mesh, box);
+    results.push({ mesh, box });
   }
-  return result;
+  return results;
 }
 
-export function updateAABBs(entries) {
-  if (!Array.isArray(entries)) {
-    return entries;
+export function updateAABBs(aabbs) {
+  if (!Array.isArray(aabbs)) return aabbs;
+  for (let i = 0; i < aabbs.length; i += 1) {
+    const entry = aabbs[i];
+    if (!entry || !entry.mesh || !entry.box) continue;
+    computeWorldAABB(entry.mesh, entry.box);
   }
-  for (let i = 0; i < entries.length; i += 1) {
-    const entry = entries[i];
-    if (!entry || !entry.mesh || !entry.box) {
-      continue;
-    }
-    const box = computeWorldAABB(entry.mesh, entry.box);
-    if (!box) {
-      entry.box.makeEmpty();
-    }
-  }
-  return entries;
+  return aabbs;
 }
 
+export default {
+  markColliders,
+  collectColliders,
+  buildAABBs,
+  updateAABBs
+};

--- a/src/physics/collision.js
+++ b/src/physics/collision.js
@@ -1,227 +1,192 @@
 import * as THREE from 'three';
 
-const EPSILON = 1e-6;
+const tempBottom = new THREE.Vector3();
+const tempTop = new THREE.Vector3();
+const tempAttempt = new THREE.Vector3();
+const tempPrevPos = new THREE.Vector3();
+const tempActualMove = new THREE.Vector3();
+const tempRemaining = new THREE.Vector3();
+const tempBox = new THREE.Box3();
+const tempMtv = new THREE.Vector3();
+const tempNormal = new THREE.Vector3();
+
+const BLOCKED_NORMALS = [];
 
 export class Capsule {
   constructor(radius = 0.5, height = 1.6) {
-    this.radius = Number.isFinite(radius) && radius > 0 ? radius : 0.5;
-    this.height = Number.isFinite(height) && height >= 0 ? height : 0;
-    this.center = new THREE.Vector3();
+    this.radius = Number.isFinite(radius) ? Math.max(0, radius) : 0.5;
+    this.height = Number.isFinite(height) ? Math.max(0, height) : 0;
+    this.position = new THREE.Vector3();
   }
 
-  setPosition(x, y, z) {
-    this.center.set(x, y, z);
+  setPosition(x = 0, y = 0, z = 0) {
+    this.position.set(x, y, z);
     return this;
   }
 
-  getPosition(target = new THREE.Vector3()) {
-    target.copy(this.center);
-    return target;
+  getPosition(target) {
+    if (target && target.isVector3) {
+      target.copy(this.position);
+      return target;
+    }
+    return this.position.clone();
   }
 
   clone() {
-    const copy = new Capsule(this.radius, this.height);
-    copy.center.copy(this.center);
-    return copy;
+    const capsule = new Capsule(this.radius, this.height);
+    capsule.position.copy(this.position);
+    return capsule;
   }
 }
 
-const EXPANDED_BOX = new THREE.Box3();
-const CAPSULE_BOTTOM = new THREE.Vector3();
-const CAPSULE_TOP = new THREE.Vector3();
-const CAPSULE_MID = new THREE.Vector3();
-const MTV_MID = new THREE.Vector3();
-const MTV_TOP = new THREE.Vector3();
-const MTV_BOTTOM = new THREE.Vector3();
-const PUSH_VECTOR = new THREE.Vector3();
-const NORMAL = new THREE.Vector3();
-const DELTA_VEC = new THREE.Vector3();
-const START_POS = new THREE.Vector3();
-
-function isPointInsideBox(point, box) {
-  return (
-    point.x >= box.min.x &&
-    point.x <= box.max.x &&
-    point.y >= box.min.y &&
-    point.y <= box.max.y &&
-    point.z >= box.min.z &&
-    point.z <= box.max.z
-  );
-}
-
-function computeMTVForPoint(point, box, target) {
-  if (!isPointInsideBox(point, box)) {
-    return null;
-  }
-
-  let best = Infinity;
-
-  const left = point.x - box.min.x;
-  if (left < best) {
-    best = left;
-    target.set(-left, 0, 0);
-  }
-
-  const right = box.max.x - point.x;
-  if (right < best) {
-    best = right;
-    target.set(right, 0, 0);
-  }
-
-  const down = point.y - box.min.y;
-  if (down < best) {
-    best = down;
-    target.set(0, -down, 0);
-  }
-
-  const up = box.max.y - point.y;
-  if (up < best) {
-    best = up;
-    target.set(0, up, 0);
-  }
-
-  const back = point.z - box.min.z;
-  if (back < best) {
-    best = back;
-    target.set(0, 0, -back);
-  }
-
-  const forward = box.max.z - point.z;
-  if (forward < best) {
-    best = forward;
-    target.set(0, 0, forward);
-  }
-
-  if (best === Infinity) {
-    return null;
-  }
-
+export function expandAABB(box, radius, target = new THREE.Box3()) {
+  target.copy(box);
+  target.min.x -= radius;
+  target.min.y -= radius;
+  target.min.z -= radius;
+  target.max.x += radius;
+  target.max.y += radius;
+  target.max.z += radius;
   return target;
 }
 
-export function expandAABB(box, radius) {
-  EXPANDED_BOX.copy(box);
-  const r = Number.isFinite(radius) ? radius : 0;
-  EXPANDED_BOX.min.x -= r;
-  EXPANDED_BOX.min.y -= r;
-  EXPANDED_BOX.min.z -= r;
-  EXPANDED_BOX.max.x += r;
-  EXPANDED_BOX.max.y += r;
-  EXPANDED_BOX.max.z += r;
-  return EXPANDED_BOX;
+function getSegmentPoints(capsule, bottomTarget, topTarget) {
+  const halfHeight = capsule.height * 0.5;
+  const { x, y, z } = capsule.position;
+  bottomTarget.set(x, y - halfHeight, z);
+  topTarget.set(x, y + halfHeight, z);
+}
+
+function chooseMtv(xDepthMin, xDepthMax, zDepthMin, zDepthMax, yDepthMin, yDepthMax) {
+  let bestDepth = Infinity;
+  tempMtv.set(0, 0, 0);
+
+  if (xDepthMin >= 0 && xDepthMin < bestDepth) {
+    bestDepth = xDepthMin;
+    tempMtv.set(-xDepthMin, 0, 0);
+  }
+  if (xDepthMax >= 0 && xDepthMax < bestDepth) {
+    bestDepth = xDepthMax;
+    tempMtv.set(xDepthMax, 0, 0);
+  }
+  if (zDepthMin >= 0 && zDepthMin < bestDepth) {
+    bestDepth = zDepthMin;
+    tempMtv.set(0, 0, -zDepthMin);
+  }
+  if (zDepthMax >= 0 && zDepthMax < bestDepth) {
+    bestDepth = zDepthMax;
+    tempMtv.set(0, 0, zDepthMax);
+  }
+  if (yDepthMin >= 0 && yDepthMin < bestDepth) {
+    bestDepth = yDepthMin;
+    tempMtv.set(0, -yDepthMin, 0);
+  }
+  if (yDepthMax >= 0 && yDepthMax < bestDepth) {
+    bestDepth = yDepthMax;
+    tempMtv.set(0, yDepthMax, 0);
+  }
+
+  if (!Number.isFinite(bestDepth) || bestDepth === Infinity) {
+    return null;
+  }
+
+  return tempMtv.lengthSq() > 0 ? tempMtv : null;
 }
 
 export function segmentAABBOverlap(p0, p1, box) {
   const x = p0.x;
   const z = p0.z;
-  if (x < box.min.x || x > box.max.x || z < box.min.z || z > box.max.z) {
-    return false;
-  }
+
+  if (x < box.min.x || x > box.max.x) return null;
+  if (z < box.min.z || z > box.max.z) return null;
+
   const segMinY = Math.min(p0.y, p1.y);
   const segMaxY = Math.max(p0.y, p1.y);
-  if (segMaxY < box.min.y || segMinY > box.max.y) {
-    return false;
-  }
-  return true;
-}
 
-function computeCapsuleMTV(capsule, expandedBox, skin) {
-  const halfHeight = Math.max(0, capsule.height) * 0.5;
-  CAPSULE_BOTTOM.set(capsule.center.x, capsule.center.y - halfHeight, capsule.center.z);
-  CAPSULE_TOP.set(capsule.center.x, capsule.center.y + halfHeight, capsule.center.z);
+  if (segMaxY < box.min.y || segMinY > box.max.y) return null;
 
-  if (!segmentAABBOverlap(CAPSULE_BOTTOM, CAPSULE_TOP, expandedBox)) {
-    return null;
-  }
+  const xDepthMin = x - box.min.x;
+  const xDepthMax = box.max.x - x;
+  const zDepthMin = z - box.min.z;
+  const zDepthMax = box.max.z - z;
+  const yDepthMin = segMaxY - box.min.y;
+  const yDepthMax = box.max.y - segMinY;
 
-  const segMinY = Math.min(CAPSULE_BOTTOM.y, CAPSULE_TOP.y);
-  const segMaxY = Math.max(CAPSULE_BOTTOM.y, CAPSULE_TOP.y);
-  const overlapMin = Math.max(segMinY, expandedBox.min.y);
-  const overlapMax = Math.min(segMaxY, expandedBox.max.y);
-  const clampedY = THREE.MathUtils.clamp((overlapMin + overlapMax) * 0.5, segMinY, segMaxY);
-
-  CAPSULE_MID.set(capsule.center.x, clampedY, capsule.center.z);
-
-  let bestVector = null;
-  let bestMagnitude = -Infinity;
-
-  const candidates = [
-    computeMTVForPoint(CAPSULE_MID, expandedBox, MTV_MID),
-    computeMTVForPoint(CAPSULE_TOP, expandedBox, MTV_TOP),
-    computeMTVForPoint(CAPSULE_BOTTOM, expandedBox, MTV_BOTTOM)
-  ];
-
-  for (let i = 0; i < candidates.length; i += 1) {
-    const candidate = candidates[i];
-    if (!candidate) {
-      continue;
-    }
-    const lengthSq = candidate.lengthSq();
-    if (lengthSq > bestMagnitude && lengthSq > EPSILON) {
-      bestMagnitude = lengthSq;
-      bestVector = candidate;
-    }
-  }
-
-  if (!bestVector) {
-    return null;
-  }
-
-  const depth = Math.sqrt(bestMagnitude);
-  if (depth <= EPSILON) {
-    return null;
-  }
-
-  NORMAL.copy(bestVector).multiplyScalar(1 / depth);
-  const correction = Math.max(depth - skin, 0);
-  if (correction <= EPSILON) {
-    return null;
-  }
-
-  PUSH_VECTOR.copy(NORMAL).multiplyScalar(correction);
-  return PUSH_VECTOR;
+  return chooseMtv(xDepthMin, xDepthMax, zDepthMin, zDepthMax, yDepthMin, yDepthMax);
 }
 
 export function resolveCapsuleVsAABBs(capsule, delta, aabbs, { maxIters = 3, skin = 0.01 } = {}) {
-  const moved = new THREE.Vector3();
-  if (!capsule || !delta) {
-    return { moved };
+  const results = { moved: new THREE.Vector3() };
+  if (!capsule || !delta || !aabbs || aabbs.length === 0) {
+    if (capsule && delta) {
+      capsule.position.add(delta);
+      results.moved.copy(delta);
+    }
+    return results;
   }
 
-  const colliders = Array.isArray(aabbs) ? aabbs : [];
+  const iterationCount = Math.max(1, Math.floor(maxIters));
+  const skinWidth = Number.isFinite(skin) ? Math.max(0, skin) : 0.01;
 
-  DELTA_VEC.copy(delta);
-  if (DELTA_VEC.lengthSq() <= EPSILON) {
-    return { moved };
-  }
+  tempRemaining.copy(delta);
+  results.moved.set(0, 0, 0);
 
-  START_POS.copy(capsule.center);
-  capsule.center.add(DELTA_VEC);
+  for (let iter = 0; iter < iterationCount; iter += 1) {
+    if (tempRemaining.lengthSq() <= 1e-10) {
+      break;
+    }
 
-  if (colliders.length > 0) {
-    const iterations = Math.max(1, Math.floor(maxIters));
-    for (let iter = 0; iter < iterations; iter += 1) {
-      let collided = false;
-      for (let i = 0; i < colliders.length; i += 1) {
-        const entry = colliders[i];
-        if (!entry || !entry.box) {
-          continue;
+    tempAttempt.copy(tempRemaining);
+    tempPrevPos.copy(capsule.position);
+    capsule.position.add(tempAttempt);
+
+    let collided = false;
+    BLOCKED_NORMALS.length = 0;
+
+    getSegmentPoints(capsule, tempBottom, tempTop);
+
+    for (let i = 0; i < aabbs.length; i += 1) {
+      const entry = aabbs[i];
+      if (!entry || !entry.box) continue;
+      const expanded = expandAABB(entry.box, capsule.radius + skinWidth, tempBox);
+      const mtv = segmentAABBOverlap(tempBottom, tempTop, expanded);
+      if (!mtv) continue;
+
+      collided = true;
+      capsule.position.add(mtv);
+      const lengthSq = mtv.lengthSq();
+      if (lengthSq > 1e-12) {
+        tempNormal.copy(mtv).multiplyScalar(-1 / Math.sqrt(lengthSq));
+        const slot = BLOCKED_NORMALS.length;
+        if (!BLOCKED_NORMALS[slot]) {
+          BLOCKED_NORMALS[slot] = new THREE.Vector3();
         }
-        const expanded = expandAABB(entry.box, capsule.radius);
-        const correction = computeCapsuleMTV(capsule, expanded, skin);
-        if (!correction) {
-          continue;
+        BLOCKED_NORMALS[slot].copy(tempNormal);
+      }
+
+      // Update segment points for successive tests
+      getSegmentPoints(capsule, tempBottom, tempTop);
+    }
+
+    tempActualMove.subVectors(capsule.position, tempPrevPos);
+    results.moved.add(tempActualMove);
+
+    tempRemaining.sub(tempActualMove);
+
+    if (BLOCKED_NORMALS.length > 0) {
+      for (let n = 0; n < BLOCKED_NORMALS.length; n += 1) {
+        const normal = BLOCKED_NORMALS[n];
+        const push = tempRemaining.dot(normal);
+        if (push > 0) {
+          tempRemaining.addScaledVector(normal, -push);
         }
-        capsule.center.add(correction);
-        collided = true;
       }
-      if (!collided) {
-        break;
-      }
+    }
+
+    if (!collided) {
+      break;
     }
   }
 
-  moved.copy(capsule.center).sub(START_POS);
-  return { moved };
+  return results;
 }
-

--- a/src/player/playerController.js
+++ b/src/player/playerController.js
@@ -1,6 +1,7 @@
 import * as THREE from 'three';
 import { snapToGround } from '../physics/groundSnap.js';
 import { keepUpright } from '../physics/upright.js';
+import { Capsule, resolveCapsuleVsAABBs } from '../physics/collision.js';
 
 const WORLD_UP = new THREE.Vector3(0, 1, 0);
 const cameraForward = new THREE.Vector3();
@@ -11,6 +12,8 @@ const targetVelocity = new THREE.Vector3();
 const velocity = new THREE.Vector3();
 const horizontalVector = new THREE.Vector3();
 const FORWARD = new THREE.Vector3(0, 0, 1);
+const moveDelta = new THREE.Vector3();
+const actualMove = new THREE.Vector3();
 
 function deriveYaw(object3d) {
   if (!object3d) return 0;
@@ -28,12 +31,16 @@ export function createPlayerController(
     walkSpeed = 4.0,
     runMultiplier = 1.7,
     acceleration = 10,
-    turnLerp = 0.18
+    turnLerp = 0.18,
+    colliders: initialColliders = []
   } = {}
 ) {
   let controlledObject = object3d || null;
   let currentKeyboard = keyboard || null;
   let groundMeshes = [];
+  let colliderAabbs = Array.isArray(initialColliders) ? initialColliders : [];
+
+  const capsule = new Capsule(0.45, 1.6);
 
   const physicsState = {
     vy: 0,
@@ -43,8 +50,20 @@ export function createPlayerController(
   let desiredYaw = deriveYaw(controlledObject);
   let runningState = false;
 
+  if (controlledObject) {
+    capsule.setPosition(
+      controlledObject.position.x,
+      controlledObject.position.y,
+      controlledObject.position.z
+    );
+  }
+
   const setGroundMeshes = (meshes) => {
     groundMeshes = Array.isArray(meshes) ? meshes : [];
+  };
+
+  const setColliders = (nextColliders) => {
+    colliderAabbs = Array.isArray(nextColliders) ? nextColliders : [];
   };
 
   const setObject = (nextObject) => {
@@ -53,6 +72,11 @@ export function createPlayerController(
     physicsState.vy = 0;
     physicsState.lastGoodY = controlledObject.position?.y ?? 0;
     desiredYaw = deriveYaw(controlledObject);
+    capsule.setPosition(
+      controlledObject.position.x,
+      controlledObject.position.y,
+      controlledObject.position.z
+    );
   };
 
   const setKeyboard = (nextKeyboard) => {
@@ -103,12 +127,28 @@ export function createPlayerController(
     velocity.lerp(targetVelocity, THREE.MathUtils.clamp(lerpAlpha, 0, 1));
 
     // Integrate horizontal motion
+    capsule.setPosition(
+      controlledObject.position.x,
+      controlledObject.position.y,
+      controlledObject.position.z
+    );
+
+    actualMove.set(0, 0, 0);
     if (dt > 0) {
-      controlledObject.position.addScaledVector(velocity, dt);
+      moveDelta.copy(velocity).multiplyScalar(dt);
+      moveDelta.y = 0;
+      if (moveDelta.lengthSq() > 1e-10) {
+        const result = resolveCapsuleVsAABBs(capsule, moveDelta, colliderAabbs, {
+          maxIters: 3,
+          skin: 0.01
+        });
+        controlledObject.position.copy(capsule.position);
+        actualMove.copy(result.moved);
+      }
     }
 
     // Face move direction smoothly
-    horizontalVector.copy(velocity);
+    horizontalVector.copy(actualMove.lengthSq() > 0 ? actualMove : velocity);
     horizontalVector.y = 0;
     if (horizontalVector.lengthSq() > 1e-6) {
       horizontalVector.normalize();
@@ -117,6 +157,11 @@ export function createPlayerController(
 
     // Ground & upright stabilization
     snapToGround(controlledObject, groundMeshes, physicsState, dt);
+    capsule.setPosition(
+      controlledObject.position.x,
+      controlledObject.position.y,
+      controlledObject.position.z
+    );
     keepUpright(controlledObject, desiredYaw, Number.isFinite(turnLerp) ? turnLerp : 0.18);
   };
 
@@ -125,6 +170,7 @@ export function createPlayerController(
     setObject,
     setKeyboard,
     setGroundMeshes,
+    setColliders,
     isRunning() {
       return runningState;
     }


### PR DESCRIPTION
## Summary
- mark static meshes as movement colliders and cache their world-space AABBs
- implement capsule vs AABB collision resolution utilities
- update the player and NPC controllers to use capsule collisions, including NPC separation, and wire the system in boot

## Testing
- npm run build *(fails: existing import-analysis error in src/entry/initializeAthens.js)*

------
https://chatgpt.com/codex/tasks/task_b_68d90f278bc88327a5897553fc20b424