### PR TITLE
Add ambient audio systems and integrate footsteps

### DIFF
--- a/src/audio/AudioManager.js
+++ b/src/audio/AudioManager.js
@@ -1,0 +1,171 @@
+import * as THREE from 'three';
+
+export function assetUrl(rel) {
+  const base = (typeof import.meta !== 'undefined' && import.meta.env && typeof import.meta.env.BASE_URL === 'string')
+    ? import.meta.env.BASE_URL
+    : '/';
+  const normalizedBase = base.endsWith('/') ? base : `${base}/`;
+  const normalizedRel = String(rel || '').replace(/^\/+/, '');
+  return `${normalizedBase}${normalizedRel}`;
+}
+
+export class AudioManager {
+  constructor(camera, { masterVolume = 0.9 } = {}) {
+    this._camera = camera || null;
+    this._listener = new THREE.AudioListener();
+    if (this._camera?.add) {
+      this._camera.add(this._listener);
+    }
+
+    this._audioLoader = new THREE.AudioLoader();
+    this._masterVolume = typeof masterVolume === 'number' ? THREE.MathUtils.clamp(masterVolume, 0, 1) : 0.9;
+    this._audios = new Map();
+    this._sources = new Map();
+    this._loading = new Map();
+    this._missing = new Set();
+  }
+
+  getListener() {
+    return this._listener;
+  }
+
+  getMasterVolume() {
+    return this._masterVolume;
+  }
+
+  isContextSuspended() {
+    return this._isContextSuspended();
+  }
+
+  _isContextSuspended() {
+    const ctx = this._listener?.context || this._listener?.getContext?.();
+    return ctx ? ctx.state === 'suspended' : false;
+  }
+
+  async load(name, relUrl) {
+    const key = String(name);
+    if (this._audios.has(key)) {
+      return this._audios.get(key);
+    }
+    if (this._loading.has(key)) {
+      return this._loading.get(key);
+    }
+
+    const relativePath = typeof relUrl === 'string' ? relUrl : '';
+    const url = assetUrl(`assets/audio/${relativePath}`);
+    this._sources.set(key, relativePath);
+
+    const audio = new THREE.Audio(this._listener);
+    audio.userData = audio.userData || {};
+    audio.userData.baseVolume = typeof audio.userData.baseVolume === 'number' ? audio.userData.baseVolume : 1;
+
+    const loadPromise = new Promise((resolve) => {
+      this._audioLoader.load(
+        url,
+        (buffer) => {
+          audio.setBuffer(buffer);
+          this._audios.set(key, audio);
+          this._loading.delete(key);
+          resolve(audio);
+        },
+        undefined,
+        () => {
+          this._loading.delete(key);
+          if (!this._missing.has(relativePath)) {
+            console.warn(`[audio] missing ${relativePath}, skipping`);
+            this._missing.add(relativePath);
+          }
+          resolve(null);
+        }
+      );
+    });
+
+    this._loading.set(key, loadPromise);
+    return loadPromise;
+  }
+
+  createPositional({ distance = 25 } = {}) {
+    const positional = new THREE.PositionalAudio(this._listener);
+    const safeDistance = Number.isFinite(distance) && distance > 0 ? distance : 25;
+    positional.setRefDistance(safeDistance);
+    positional.setRolloffFactor(0.8);
+    positional.setDistanceModel('linear');
+    positional.userData = positional.userData || {};
+    positional.userData.baseVolume = typeof positional.userData.baseVolume === 'number' ? positional.userData.baseVolume : 1;
+    return positional;
+  }
+
+  setMasterVolume(value) {
+    const volume = Number.isFinite(value) ? THREE.MathUtils.clamp(value, 0, 1) : this._masterVolume;
+    this._masterVolume = volume;
+    for (const audio of this._audios.values()) {
+      if (!audio) continue;
+      const baseVolume = typeof audio.userData?.baseVolume === 'number' ? audio.userData.baseVolume : 1;
+      audio.setVolume(baseVolume * this._masterVolume);
+    }
+  }
+
+  async playLoop(name, options = {}) {
+    const key = String(name);
+    const baseVolume = Number.isFinite(options.volume) ? THREE.MathUtils.clamp(options.volume, 0, 1) : 1;
+    const startVolume = Number.isFinite(options.startVolume) ? THREE.MathUtils.clamp(options.startVolume, 0, 1) : baseVolume;
+
+    let audio = this._audios.get(key);
+    const sourceRel = this._sources.get(key);
+    if (!audio && sourceRel) {
+      audio = await this.load(key, sourceRel);
+    }
+    if (!audio) {
+      return null;
+    }
+
+    audio.userData = audio.userData || {};
+    audio.userData.baseVolume = baseVolume;
+    audio.setLoop(true);
+
+    const effectiveStart = this._masterVolume * startVolume;
+    const effectiveTarget = this._masterVolume * baseVolume;
+
+    if (Number.isFinite(effectiveStart)) {
+      audio.setVolume(effectiveStart);
+    }
+
+    if (!audio.isPlaying) {
+      try {
+        audio.play();
+      } catch (_) {
+        // ignored
+      }
+    }
+
+    if (Number.isFinite(effectiveTarget) && Math.abs(effectiveTarget - effectiveStart) < 1e-4) {
+      audio.setVolume(effectiveTarget);
+    }
+
+    return audio;
+  }
+
+  stop(name) {
+    const audio = this._audios.get(String(name));
+    if (audio?.isPlaying) {
+      try {
+        audio.stop();
+      } catch (_) {
+        // noop
+      }
+    }
+  }
+
+  stopAll() {
+    for (const audio of this._audios.values()) {
+      if (!audio) continue;
+      if (audio.isPlaying) {
+        try {
+          audio.stop();
+        } catch (_) {
+          // noop
+        }
+      }
+    }
+  }
+}

--- a/src/audio/ambience.js
+++ b/src/audio/ambience.js
@@ -1,0 +1,145 @@
+const MODE_TO_CLIP = {
+  dawn: 'ambience_dawn.mp3',
+  day: 'ambience_day.mp3',
+  dusk: 'ambience_dusk.mp3',
+  night: 'ambience_night.mp3'
+};
+
+const VALID_MODES = new Set(Object.keys(MODE_TO_CLIP));
+const DEFAULT_VOLUME = 0.6;
+const FADE_SECONDS = 0.6;
+
+const stateMap = new WeakMap();
+
+function getState(audio) {
+  if (!audio) {
+    return null;
+  }
+  let state = stateMap.get(audio);
+  if (!state) {
+    state = {
+      currentMode: null,
+      currentAudio: null,
+      loops: new Map()
+    };
+    stateMap.set(audio, state);
+  }
+  return state;
+}
+
+function scheduleStop(audioNode, delaySeconds) {
+  if (!audioNode) return;
+  const delayMs = Math.max(0, delaySeconds * 1000 + 20);
+  const stopFn = () => {
+    if (audioNode.isPlaying) {
+      try {
+        audioNode.stop();
+      } catch (_) {
+        // noop
+      }
+    }
+  };
+  if (typeof window !== 'undefined' && typeof window.setTimeout === 'function') {
+    window.setTimeout(stopFn, delayMs);
+  } else if (typeof setTimeout === 'function') {
+    setTimeout(stopFn, delayMs);
+  } else {
+    stopFn();
+  }
+}
+
+function fadeVolume(audioNode, targetVolume, durationSeconds) {
+  if (!audioNode) {
+    return;
+  }
+  const gainNode = audioNode.gain;
+  const context = gainNode?.context || audioNode.context || audioNode.listener?.context;
+  const param = gainNode?.gain;
+  const now = context?.currentTime ?? 0;
+  const currentVolume = typeof audioNode.getVolume === 'function' ? audioNode.getVolume() : targetVolume;
+
+  if (param && typeof param.cancelScheduledValues === 'function' && typeof param.setValueAtTime === 'function') {
+    try {
+      param.cancelScheduledValues(now);
+      param.setValueAtTime(currentVolume, now);
+      param.linearRampToValueAtTime(targetVolume, now + durationSeconds);
+      return;
+    } catch (_) {
+      // fall through
+    }
+  }
+
+  audioNode.setVolume(targetVolume);
+}
+
+async function ensureLoop(audio, mode) {
+  const state = getState(audio);
+  if (!state || !VALID_MODES.has(mode)) {
+    return null;
+  }
+  if (state.loops.has(mode)) {
+    return state.loops.get(mode);
+  }
+  const clip = MODE_TO_CLIP[mode];
+  const name = `ambience:${mode}`;
+  const loop = await audio.load(name, clip);
+  if (loop) {
+    loop.userData = loop.userData || {};
+    loop.userData.baseVolume = DEFAULT_VOLUME;
+    state.loops.set(mode, loop);
+  }
+  return loop;
+}
+
+export async function initAmbience(audio, initial = 'day') {
+  const state = getState(audio);
+  if (!state) {
+    return;
+  }
+  const promises = [];
+  for (const mode of VALID_MODES) {
+    promises.push(audio.load(`ambience:${mode}`, MODE_TO_CLIP[mode]));
+  }
+  await Promise.all(promises);
+  await setAmbience(audio, VALID_MODES.has(initial) ? initial : 'day');
+}
+
+export async function setAmbience(audio, mode) {
+  const state = getState(audio);
+  if (!state) {
+    return;
+  }
+  if (!VALID_MODES.has(mode)) {
+    mode = 'day';
+  }
+  if (state.currentMode === mode) {
+    return;
+  }
+
+  const nextLoop = await ensureLoop(audio, mode);
+  if (!nextLoop) {
+    state.currentMode = mode;
+    state.currentAudio = null;
+    return;
+  }
+
+  const previous = state.currentAudio && state.currentAudio !== nextLoop ? state.currentAudio : null;
+  const masterVolume = typeof audio.getMasterVolume === 'function' ? audio.getMasterVolume() : 1;
+  const targetVolume = masterVolume * DEFAULT_VOLUME;
+
+  if (previous) {
+    fadeVolume(previous, 0, FADE_SECONDS);
+    scheduleStop(previous, FADE_SECONDS);
+  }
+
+  const playing = await audio.playLoop(`ambience:${mode}`, { volume: DEFAULT_VOLUME, startVolume: 0 });
+  const suspended = typeof audio.isContextSuspended === 'function' ? audio.isContextSuspended() : false;
+  if (playing && !suspended) {
+    fadeVolume(playing, targetVolume, FADE_SECONDS);
+  } else if (playing) {
+    playing.setVolume(targetVolume);
+  }
+
+  state.currentMode = mode;
+  state.currentAudio = nextLoop;
+}

--- a/src/audio/footsteps.js
+++ b/src/audio/footsteps.js
@@ -1,0 +1,142 @@
+import * as THREE from 'three';
+
+const DEFAULT_INTERVAL = 0.5;
+const MIN_SPEED = 0.2;
+
+function nowSeconds() {
+  if (typeof performance !== 'undefined' && typeof performance.now === 'function') {
+    return performance.now() * 0.001;
+  }
+  return Date.now() * 0.001;
+}
+
+export function createFootsteps(audio, clips = {}) {
+  if (!audio) {
+    return {
+      onStep() {},
+      setIntervalBySpeed() {
+        return Infinity;
+      },
+      dispose() {}
+    };
+  }
+
+  const clipMap = {
+    stone: clips.stone || 'footstep_stone.mp3',
+    dirt: clips.dirt || 'footstep_dirt.mp3'
+  };
+
+  const buffers = new Map();
+  const loading = new Map();
+  let disposed = false;
+  let currentInterval = DEFAULT_INTERVAL;
+  let lastStepTime = nowSeconds();
+
+  const listener = typeof audio.getListener === 'function' ? audio.getListener() : null;
+
+  const ensureClip = async (surface) => {
+    const key = surface === 'stone' ? 'stone' : 'dirt';
+    if (buffers.has(key)) {
+      return buffers.get(key);
+    }
+    if (loading.has(key)) {
+      return loading.get(key);
+    }
+
+    const rel = clipMap[key];
+    const promise = (async () => {
+      const audioName = `footstep:${key}`;
+      const base = await audio.load(audioName, rel);
+      if (base && base.buffer) {
+        buffers.set(key, base.buffer);
+        return base.buffer;
+      }
+      return null;
+    })();
+
+    loading.set(key, promise);
+    const buffer = await promise;
+    loading.delete(key);
+    return buffer;
+  };
+
+  const playBuffer = (buffer) => {
+    if (!buffer || !listener || disposed) {
+      return;
+    }
+
+    const oneShot = new THREE.Audio(listener);
+    oneShot.setBuffer(buffer);
+
+    const baseVolume = 0.75;
+    const randomVolume = baseVolume * (0.85 + Math.random() * 0.3);
+    const master = typeof audio.getMasterVolume === 'function' ? audio.getMasterVolume() : 1;
+    oneShot.setVolume(master * randomVolume);
+
+    const playbackRate = 0.92 + Math.random() * 0.18;
+    if (typeof oneShot.setPlaybackRate === 'function') {
+      try {
+        oneShot.setPlaybackRate(playbackRate);
+      } catch (_) {
+        // noop
+      }
+    }
+
+    if (audio.isContextSuspended && audio.isContextSuspended()) {
+      return;
+    }
+
+    try {
+      oneShot.play();
+    } catch (_) {
+      return;
+    }
+
+    const source = oneShot.source;
+    if (source && typeof source.addEventListener === 'function') {
+      source.addEventListener('ended', () => {
+        oneShot.disconnect();
+      });
+    }
+  };
+
+  const onStep = async (surface = 'dirt') => {
+    if (disposed || currentInterval === Infinity) {
+      return;
+    }
+    const now = nowSeconds();
+    if (now - lastStepTime < currentInterval - 1e-3) {
+      return;
+    }
+    lastStepTime = now;
+
+    const buffer = await ensureClip(surface === 'stone' ? 'stone' : 'dirt');
+    playBuffer(buffer);
+  };
+
+  const setIntervalBySpeed = (speedMps) => {
+    const speed = Number.isFinite(speedMps) ? Math.max(0, speedMps) : 0;
+    if (speed < MIN_SPEED) {
+      currentInterval = Infinity;
+      return currentInterval;
+    }
+    if (speed < 1.5) {
+      currentInterval = 0.6;
+    } else if (speed < 4) {
+      currentInterval = DEFAULT_INTERVAL;
+    } else {
+      currentInterval = 0.33;
+    }
+    return currentInterval;
+  };
+
+  const dispose = () => {
+    disposed = true;
+    buffers.clear();
+    loading.clear();
+  };
+
+  return { onStep, setIntervalBySpeed, dispose };
+}
+
+export default createFootsteps;

--- a/src/audio/npcAudio.js
+++ b/src/audio/npcAudio.js
@@ -1,0 +1,28 @@
+export async function attachNpcAudio(audio, npcObject3D, { clip = 'market_chatter.mp3', volume = 0.35, distance = 18 } = {}) {
+  if (!audio || !npcObject3D) {
+    return null;
+  }
+
+  const name = `npc:${clip}`;
+  const base = await audio.load(name, clip);
+  if (!base || !base.buffer) {
+    return null;
+  }
+
+  const positional = audio.createPositional({ distance });
+  positional.userData = positional.userData || {};
+  positional.userData.baseVolume = Number.isFinite(volume) ? Math.max(0, volume) : 0.35;
+  positional.setBuffer(base.buffer);
+  positional.setLoop(true);
+  positional.setVolume(audio.getMasterVolume() * positional.userData.baseVolume);
+
+  npcObject3D.add(positional);
+
+  try {
+    positional.play();
+  } catch (_) {
+    // Ignore autoplay restrictions; playback will resume after context resumes
+  }
+
+  return positional;
+}

--- a/src/entry/boot.ts
+++ b/src/entry/boot.ts
@@ -9,6 +9,10 @@ import { markGround, collectGround } from '../physics/groundRegistry.js';
 import { snapToGround } from '../physics/groundSnap.js';
 import { createNpcManager } from '../npc/simpleNpcManager.js';
 import { markColliders, collectColliders, buildAABBs } from '../physics/colliderRegistry.js';
+import { AudioManager } from '../audio/AudioManager.js';
+import { initAmbience, setAmbience } from '../audio/ambience.js';
+import { createFootsteps } from '../audio/footsteps.js';
+import { attachNpcAudio } from '../audio/npcAudio.js';
 
 type RunOptions = {
   containerId?: string;
@@ -118,6 +122,24 @@ export async function runAthens(options: RunOptions = {}) {
   camera.position.set(90, 110, 180);
   camera.lookAt(new THREE.Vector3(0, 0, 0));
 
+  const audio = new AudioManager(camera, { masterVolume: 0.9 });
+
+  const resumeAudioContext = () => {
+    const listener = audio.getListener?.();
+    const ctx = listener?.context || listener?.getContext?.();
+    if (ctx && ctx.state === 'suspended' && typeof ctx.resume === 'function') {
+      ctx.resume().catch(() => {});
+    }
+    if (typeof window !== 'undefined') {
+      window.removeEventListener('click', resumeAudioContext);
+      window.removeEventListener('keydown', resumeAudioContext);
+    }
+  };
+  if (typeof window !== 'undefined') {
+    window.addEventListener('click', resumeAudioContext);
+    window.addEventListener('keydown', resumeAudioContext);
+  }
+
   const ambientLight = new THREE.AmbientLight(0xffffff, 0.7);
   const directionalLight = new THREE.DirectionalLight(0xffffff, 1.0);
   directionalLight.position.set(120, 220, 150);
@@ -149,6 +171,13 @@ export async function runAthens(options: RunOptions = {}) {
     }
   }
 
+  const ambienceMode = ['dawn', 'day', 'dusk', 'night'].includes(environmentMode) ? environmentMode : 'day';
+  try {
+    await initAmbience(audio, ambienceMode);
+  } catch (error) {
+    console.warn('[Athens][Boot] initAmbience failed', error);
+  }
+
   markGround(scene);
   const groundMeshes = collectGround(scene);
   markColliders(scene);
@@ -173,6 +202,8 @@ export async function runAthens(options: RunOptions = {}) {
   playerController.setGroundMeshes(groundMeshes);
   playerController.setColliders(colliders);
 
+  const footsteps = createFootsteps(audio);
+
   const followCamera = createFollowCamera(camera, playerObject, {
     offset: new THREE.Vector3(0, 2.2, -6),
     lerp: 0.12,
@@ -183,15 +214,22 @@ export async function runAthens(options: RunOptions = {}) {
   const npcManager = createNpcManager(scene, groundMeshes, { colliders });
   npcManager.setGroundMeshes(groundMeshes);
   npcManager.setColliders(colliders);
-  npcManager.spawn({
+  const npcState = npcManager.spawn({
     waypoints: [
       new THREE.Vector3(6, 0, 6),
       new THREE.Vector3(10, 0, 6)
     ]
   });
+  if (npcState?.object3d) {
+    attachNpcAudio(audio, npcState.object3d, { clip: 'market_chatter.mp3', volume: 0.3, distance: 20 }).catch(() => {});
+  }
 
   const clock = new THREE.Clock();
   let frameId: number | null = null;
+  const previousPlayerPosition = playerObject.position.clone();
+  const playerDelta = new THREE.Vector3();
+  let footstepTimer = 0;
+  let footstepInterval = Infinity;
 
   const handleResize = () => {
     const { width, height } = computeSize(container);
@@ -214,10 +252,31 @@ export async function runAthens(options: RunOptions = {}) {
       }
     }
 
+    previousPlayerPosition.copy(playerObject.position);
     try {
       playerController.update(delta, camera);
     } catch (error) {
       console.warn('[Athens][Boot] player update failed', error);
+    }
+
+    playerDelta.subVectors(playerObject.position, previousPlayerPosition);
+    const moveDistance = playerDelta.length();
+    const currentSpeed = delta > 1e-6 ? moveDistance / Math.max(delta, 1e-6) : 0;
+    footstepInterval = footsteps.setIntervalBySpeed(currentSpeed);
+    if (Number.isFinite(footstepInterval)) {
+      if (currentSpeed < 0.3) {
+        footstepTimer = Math.min(footstepTimer, footstepInterval);
+      } else {
+        footstepTimer += delta;
+        if (footstepTimer >= footstepInterval) {
+          footstepTimer = 0;
+          const { x, z } = playerObject.position;
+          const surface = Math.abs(x) < 55 && Math.abs(z) < 55 ? 'stone' : 'dirt';
+          footsteps.onStep(surface);
+        }
+      }
+    } else {
+      footstepTimer = 0;
     }
 
     try {
@@ -244,6 +303,11 @@ export async function runAthens(options: RunOptions = {}) {
     playerController,
     followCamera,
     npcManager,
+    audio,
+    footsteps,
+    setAmbience(mode: string) {
+      return setAmbience(audio, mode);
+    },
     dispose() {
       if (frameId !== null && typeof cancelAnimationFrame === 'function') {
         cancelAnimationFrame(frameId);
@@ -251,9 +315,13 @@ export async function runAthens(options: RunOptions = {}) {
       }
       if (typeof window !== 'undefined') {
         window.removeEventListener('resize', handleResize);
+        window.removeEventListener('click', resumeAudioContext);
+        window.removeEventListener('keydown', resumeAudioContext);
       }
       npcManager.dispose();
       keyboard.dispose();
+      footsteps.dispose();
+      audio.stopAll();
       renderer.dispose();
     }
   };


### PR DESCRIPTION
## Summary
- add an AudioManager that safely loads audio assets with base-url aware paths
- implement ambience, footsteps, and NPC positional audio helpers with graceful fallbacks
- wire the entry bootstrap to initialize ambience, player footsteps, and NPC chatter with resume handling

## Testing
- npm run build *(fails: [vite]: Rollup failed to resolve import "three" from src/entry/initializeAthens.js)*

------
https://chatgpt.com/codex/tasks/task_b_68d9179688ec8327b77e600b8e7c9232