### PR TITLE
Remove gradient sky binaries and add generation guidance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,12 @@ public/assets/models/plane.glb
 public/assets/models/hoplite_npc.glb
 public/assets/models/npc_athenian.glb
 public/favicon.ico
+# Development gradient placeholders (not tracked)
+assets/sky/dawn.jpg
+assets/sky/day.jpg
+assets/sky/dusk.jpg
+assets/sky/night.jpg
+public/assets/sky/dawn.jpg
+public/assets/sky/day.jpg
+public/assets/sky/dusk.jpg
+public/assets/sky/night.jpg

--- a/assets/sky/README.md
+++ b/assets/sky/README.md
@@ -42,3 +42,29 @@ public/assets/sky/blue_hour.jpg
 
 This file is prefetched during initialization so the skydome can swap immediately when entering the "Blue Hour" preset. If
 it's absent the experience will fall back to the built-in dusk assets.
+
+## Time-of-day Gradient Backdrops
+
+For development builds the runtime can load lightweight gradient panoramas for the simplified `timeSky` system. Because this
+pull request workflow cannot include binary assets, the JPG placeholders are not checked into source control. To enable them
+locally, create four 2048×1024 JPGs named:
+
+```
+assets/sky/dawn.jpg
+assets/sky/day.jpg
+assets/sky/dusk.jpg
+assets/sky/night.jpg
+```
+
+and mirror the same files under `public/assets/sky/`. Any image editor can be used to author the gradients. If you have
+ImageMagick installed, the following commands generate quick stand-ins:
+
+```
+magick -size 2048x1024 gradient:"#3b2c57-#f8c36a" assets/sky/dawn.jpg
+magick -size 2048x1024 gradient:"#6ea8ff-#e4f2ff" assets/sky/day.jpg
+magick -size 2048x1024 gradient:"#733d6e-#f8a06c" assets/sky/dusk.jpg
+magick -size 2048x1024 gradient:"#0b1630-#2f3a5d" assets/sky/night.jpg
+```
+
+Copy the generated files into `public/assets/sky/` so the engine can resolve them in development builds. Replace the gradients
+with art-directed panoramas for production deployments.

--- a/public/assets/sky/README.md
+++ b/public/assets/sky/README.md
@@ -42,3 +42,29 @@ public/assets/sky/blue_hour.jpg
 
 This file is prefetched during initialization so the skydome can swap immediately when entering the "Blue Hour" preset. If
 it's absent the experience will fall back to the built-in dusk assets.
+
+## Time-of-day Gradient Backdrops
+
+For development builds the runtime can load lightweight gradient panoramas for the simplified `timeSky` system. Because this
+pull request workflow cannot include binary assets, the JPG placeholders are not checked into source control. To enable them
+locally, create four 2048×1024 JPGs named:
+
+```
+public/assets/sky/dawn.jpg
+public/assets/sky/day.jpg
+public/assets/sky/dusk.jpg
+public/assets/sky/night.jpg
+```
+
+The engine also searches for mirrored copies in `assets/sky/` for offline bundling workflows. Author the gradients in your
+preferred image editor. If you have ImageMagick available, you can generate quick placeholders with:
+
+```
+magick -size 2048x1024 gradient:"#3b2c57-#f8c36a" public/assets/sky/dawn.jpg
+magick -size 2048x1024 gradient:"#6ea8ff-#e4f2ff" public/assets/sky/day.jpg
+magick -size 2048x1024 gradient:"#733d6e-#f8a06c" public/assets/sky/dusk.jpg
+magick -size 2048x1024 gradient:"#0b1630-#2f3a5d" public/assets/sky/night.jpg
+```
+
+Copy or symlink the generated files into `assets/sky/` when packaging development builds so both asset trees stay in sync.
+Replace the gradients with art-directed panoramas for production deployments.

--- a/src/ui/originalUi.js
+++ b/src/ui/originalUi.js
@@ -1,9 +1,11 @@
 const ENVIRONMENT_LABELS = {
   high_noon: 'High Noon',
+  day: 'High Noon',
   golden_hour: 'Golden Hour',
   dawn: 'Golden Dawn',
   dusk: 'Dusk',
-  midnight: 'Midnight'
+  midnight: 'Midnight',
+  night: 'Midnight'
 };
 
 const STATUS_UPDATE_INTERVAL = 0.1; // seconds


### PR DESCRIPTION
## Summary
- remove the gradient JPG placeholders from both asset trees so the repo no longer ships binary panoramas
- document how to recreate the optional time-of-day gradients locally in both sky asset READMEs
- ignore the generated gradient files in version control to prevent accidental commits

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d917d724e88327bec6031abc19f218