### PR TITLE
Stabilize render loop and harden GLB loading

### DIFF
--- a/src/engine/loop.js
+++ b/src/engine/loop.js
@@ -1,0 +1,157 @@
+import { logOnce } from '../utils/logOnce.js';
+
+const MIN_DT = 1 / 300;
+const MAX_DT = 0.2;
+
+let activeLoop = null;
+
+export function createGameLoop(update, render) {
+  if (typeof update !== 'function') {
+    throw new Error('createGameLoop requires an update function');
+  }
+  if (typeof render !== 'function') {
+    throw new Error('createGameLoop requires a render function');
+  }
+
+  let frameId = null;
+  let started = false;
+  let paused = false;
+  let disposed = false;
+  let lastTimestamp = null;
+
+  const step = (timestamp) => {
+    if (disposed || paused) {
+      return;
+    }
+
+    if (lastTimestamp == null) {
+      lastTimestamp = timestamp;
+      frameId = requestAnimationFrame(step);
+      return;
+    }
+
+    let dt = (timestamp - lastTimestamp) / 1000;
+    lastTimestamp = timestamp;
+
+    if (!Number.isFinite(dt)) {
+      dt = MIN_DT;
+    }
+
+    let skippedLargeDt = false;
+    if (dt <= 0) {
+      logOnce('dt_zero', '[loop] clamped non-positive dt', dt);
+      dt = MIN_DT;
+    } else if (dt > MAX_DT) {
+      logOnce('dt_huge', `[loop] clamped large dt ${dt.toFixed(3)}s`);
+      dt = MAX_DT;
+      skippedLargeDt = true;
+    }
+
+    try {
+      update(dt, { skippedLargeDt });
+    } catch (error) {
+      if (typeof console !== 'undefined' && typeof console.error === 'function') {
+        console.error('[loop] update step failed', error);
+      }
+    }
+
+    try {
+      render();
+    } catch (error) {
+      if (typeof console !== 'undefined' && typeof console.error === 'function') {
+        console.error('[loop] render step failed', error);
+      }
+    }
+
+    frameId = requestAnimationFrame(step);
+  };
+
+  const pause = () => {
+    if (paused) return;
+    paused = true;
+    if (frameId !== null) {
+      cancelAnimationFrame(frameId);
+      frameId = null;
+    }
+    lastTimestamp = null;
+  };
+
+  const resume = () => {
+    if (!started || disposed || !paused) {
+      return;
+    }
+    paused = false;
+    frameId = requestAnimationFrame(step);
+  };
+
+  const handleVisibility = () => {
+    if (typeof document === 'undefined') return;
+    if (document.hidden) {
+      pause();
+    } else {
+      lastTimestamp = null;
+      resume();
+    }
+  };
+
+  const addVisibilityListener = () => {
+    if (typeof document === 'undefined') return;
+    document.addEventListener('visibilitychange', handleVisibility);
+  };
+
+  const removeVisibilityListener = () => {
+    if (typeof document === 'undefined') return;
+    document.removeEventListener('visibilitychange', handleVisibility);
+  };
+
+  const start = () => {
+    if (disposed || started) {
+      return;
+    }
+    if (activeLoop && activeLoop !== api && activeLoop.isRunning()) {
+      logOnce('loop_multiple', '[loop] A game loop is already running; ignoring start request.');
+      return;
+    }
+
+    activeLoop = api;
+    started = true;
+    paused = Boolean(typeof document !== 'undefined' && document.hidden);
+    lastTimestamp = null;
+    addVisibilityListener();
+
+    if (!paused) {
+      frameId = requestAnimationFrame(step);
+    }
+  };
+
+  const stop = () => {
+    if (!started) return;
+    pause();
+    removeVisibilityListener();
+    started = false;
+    if (activeLoop === api) {
+      activeLoop = null;
+    }
+  };
+
+  const dispose = () => {
+    if (disposed) return;
+    stop();
+    disposed = true;
+  };
+
+  const api = {
+    start,
+    stop,
+    dispose,
+    pause,
+    resume,
+    isRunning() {
+      return started && !paused && !disposed;
+    }
+  };
+
+  return api;
+}
+
+export default createGameLoop;

--- a/src/entry/initializeAthens.js
+++ b/src/entry/initializeAthens.js
@@ -11,6 +11,7 @@ import { createKeyboard } from '../input/keyboard.js';
 import { createFollowCamera } from '../camera/followCamera.js';
 import { createPlayerController } from '../player/playerController.js';
 import { assetUrl } from '../utils/assetUrl.js';
+import { createGameLoop } from '../engine/loop.js';
 import { markGround, collectGround } from '../physics/groundRegistry.js';
 import { markColliders, collectColliders, buildAABBs } from '../physics/colliderRegistry.js';
 import { sampleGroundY, snapGroupToGround, snapObjectToGround, snapChildrenToGround } from '../physics/groundProject.js';
@@ -600,39 +601,63 @@ export async function initializeAthens(options = {}) {
   window.addEventListener('resize', resizeHandler);
 
   // Main loop
-  const clock = new THREE.Clock();
   let disposed = false;
-  let frameId = 0;
+  let statsForFrame = null;
 
-  const frame = () => {
-    if (disposed) return;
-    const activeStats = stats;
-    activeStats?.begin?.();
+  const updateFrame = (delta, { skippedLargeDt }) => {
+    if (disposed) {
+      statsForFrame = stats;
+      statsForFrame?.begin?.();
+      statsForFrame?.end?.();
+      statsForFrame = null;
+      return;
+    }
+
+    statsForFrame = stats;
+    statsForFrame?.begin?.();
+
     try {
-      const delta = clock.getDelta();
       try {
         updateTrees?.(delta);
       } catch (error) {
         console.warn('[Athens] Tree animation update failed.', error);
       }
-      mainCharacter?.update(delta, { groundMeshes });
-      npcManager?.update(delta);
+
+      const npcContext = { groundMeshes, skippedLargeDt: Boolean(skippedLargeDt) };
+      mainCharacter?.update?.(delta, npcContext);
+      npcManager?.update?.(delta, { skippedLargeDt: Boolean(skippedLargeDt) });
       landmarks.update?.(camera);
-      controller?.update(delta, camera);
+
+      if (!skippedLargeDt) {
+        controller?.update?.(delta, camera);
+      }
+
       ui?.update?.(delta, {
         position: playerObject?.position,
         isFlying: false,
-        isRunning: controller?.isRunning?.()
+        isRunning: controller?.isRunning?.(),
+        skippedLargeDt: Boolean(skippedLargeDt)
       });
-      followCamera?.update();
-      renderer.render(scene, camera);
-    } finally {
-      activeStats?.end?.();
+
+      followCamera?.update?.();
+    } catch (error) {
+      console.warn('[Athens] Frame update failed.', error);
     }
-    frameId = requestAnimationFrame(frame);
   };
 
-  frameId = requestAnimationFrame(frame);
+  const renderFrame = () => {
+    try {
+      if (!disposed) {
+        renderer.render(scene, camera);
+      }
+    } finally {
+      statsForFrame?.end?.();
+      statsForFrame = null;
+    }
+  };
+
+  const gameLoop = createGameLoop(updateFrame, renderFrame);
+  gameLoop.start();
 
   // Context / teardown
   const context = {
@@ -662,7 +687,7 @@ export async function initializeAthens(options = {}) {
     dispose() {
       if (disposed) return;
       disposed = true;
-      if (frameId) cancelAnimationFrame(frameId);
+      gameLoop?.dispose?.();
       window.removeEventListener('resize', resizeHandler);
       overlay?.destroy?.();
       if (overlayCanvas.parentNode) {

--- a/src/loaders/safeGltf.js
+++ b/src/loaders/safeGltf.js
@@ -1,0 +1,70 @@
+import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
+
+const ACCEPTED_TYPES = ['application/octet-stream', 'model/gltf-binary'];
+
+function normalizeError(error) {
+  if (!error) return 'Unknown error';
+  if (error instanceof Error) return error.message || error.toString();
+  return String(error);
+}
+
+async function verifyUrl(url) {
+  if (typeof fetch !== 'function') {
+    return { verified: false, reason: null };
+  }
+
+  try {
+    const response = await fetch(url, { method: 'HEAD' });
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`);
+    }
+
+    const contentType = (response.headers.get('content-type') || '').toLowerCase();
+    const contentLengthHeader = response.headers.get('content-length');
+    const resolvedUrl = response.url || url;
+    const looksLikeGlb = resolvedUrl.toLowerCase().endsWith('.glb') || url.toLowerCase().endsWith('.glb');
+
+    const hasAcceptedType = ACCEPTED_TYPES.some((type) => contentType.includes(type));
+
+    if (!hasAcceptedType) {
+      const lengthValue = contentLengthHeader ? Number.parseInt(contentLengthHeader, 10) : NaN;
+      if (!(looksLikeGlb && Number.isFinite(lengthValue) && lengthValue > 1024)) {
+        throw new Error(`Unexpected response for ${resolvedUrl} (type: ${contentType || 'unknown'}, length: ${contentLengthHeader || 'unknown'})`);
+      }
+    }
+
+    return { verified: true, reason: null };
+  } catch (error) {
+    if (error instanceof Error && /HTTP\s+\d+/.test(error.message)) {
+      throw new Error(`GLB request failed (${error.message}) for ${url}`);
+    }
+
+    return { verified: false, reason: error };
+  }
+}
+
+export async function loadGLTF(url, { dracoLoader } = {}) {
+  if (!url) {
+    throw new Error('GLTF URL is required');
+  }
+
+  const { verified, reason } = await verifyUrl(url);
+
+  const loader = new GLTFLoader();
+  if (dracoLoader) {
+    loader.setDRACOLoader(dracoLoader);
+  }
+
+  try {
+    return await loader.loadAsync(url);
+  } catch (error) {
+    if (!verified && reason) {
+      const verifyMessage = normalizeError(reason);
+      throw new Error(`Failed to load GLB at ${url}: ${verifyMessage}`);
+    }
+    const message = normalizeError(error);
+    throw new Error(`Failed to load GLB at ${url}: ${message}`);
+  }
+}
+
+export default loadGLTF;

--- a/src/npc/npcSystem.js
+++ b/src/npc/npcSystem.js
@@ -1,11 +1,10 @@
 import * as THREE from 'three';
-import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 import { resolveAssetUrl } from '../utils/asset-paths.js';
 import { assetUrl } from '../utils/assetUrl.js';
 import { snapToGround } from '../physics/groundSnap.js';
 import { keepUpright } from '../physics/upright.js';
-
-const loader = new GLTFLoader();
+import { loadGLTF } from '../loaders/safeGltf.js';
+import { logOnce } from '../utils/logOnce.js';
 
 const SNAP_OPTIONS = { gravity: 12, stepMax: 0.6, hover: 0.03 };
 const DEFAULT_WALK_SPEED = 1.5;
@@ -360,8 +359,7 @@ function loadNpcModel(npc, modelUrl) {
     return Promise.resolve(placeholder);
   }
 
-  return loader
-    .loadAsync(resolvedUrl)
+  return loadGLTF(resolvedUrl)
     .then((gltf) => {
       const scene = gltf?.scene || gltf?.scenes?.[0] || null;
       if (scene) {
@@ -384,7 +382,12 @@ function loadNpcModel(npc, modelUrl) {
       return npc.modelRoot;
     })
     .catch((error) => {
-      console.warn('[npc] Failed to load NPC model, using placeholder instead.', error);
+      const reason = error instanceof Error ? error.message : String(error);
+      const label = modelUrl || 'unknown';
+      logOnce(
+        `npc_model_${resolvedUrl}`,
+        `[npc] Failed to load model ${label} at ${resolvedUrl}: ${reason} — using placeholder`
+      );
       const placeholder = buildPlaceholderModel();
       attachModelToNpc(npc, placeholder);
       return placeholder;
@@ -555,6 +558,9 @@ export function createNpc(options = {}) {
   return {
     object3d: npc.object3d,
     update(deltaSeconds, context = {}) {
+      if (context.skippedLargeDt) {
+        return;
+      }
       const nav = context.navContext || navContext || npc.navContext || null;
       stepNpc(npc, deltaSeconds, context.groundMeshes, nav);
     },
@@ -588,10 +594,15 @@ export function createNpcManager(scene, groundMeshes, options = {}) {
     return npc;
   }
 
-  function update(deltaSeconds) {
+  function update(deltaSeconds, context = {}) {
+    if (context?.skippedLargeDt) {
+      return;
+    }
     const rawDt = Number.isFinite(deltaSeconds) ? deltaSeconds : 0;
-    if (rawDt <= 0 || rawDt > 0.2) {
-      console.warn('[npc] bad dt', rawDt);
+    if (rawDt <= 0) {
+      logOnce('dt_zero', '[npc] bad dt', rawDt);
+    } else if (rawDt > 0.2) {
+      logOnce('dt_huge', '[npc] bad dt', rawDt);
     }
     const dt = Math.max(0, Math.min(rawDt, 0.2));
     if (dt === 0) return;

--- a/src/utils/logOnce.js
+++ b/src/utils/logOnce.js
@@ -1,0 +1,32 @@
+export function logOnce(key, ...args) {
+  if (typeof key !== 'string' || !key) {
+    if (typeof console !== 'undefined' && typeof console.warn === 'function') {
+      console.warn(...args);
+    }
+    return;
+  }
+
+  const globalObject = typeof window !== 'undefined' ? window : typeof globalThis !== 'undefined' ? globalThis : null;
+  if (!globalObject) {
+    if (typeof console !== 'undefined' && typeof console.warn === 'function') {
+      console.warn(...args);
+    }
+    return;
+  }
+
+  if (!globalObject.__LOG_ONCE || !(globalObject.__LOG_ONCE instanceof Set)) {
+    globalObject.__LOG_ONCE = new Set();
+  }
+
+  if (globalObject.__LOG_ONCE.has(key)) {
+    return;
+  }
+
+  globalObject.__LOG_ONCE.add(key);
+
+  if (typeof console !== 'undefined' && typeof console.warn === 'function') {
+    console.warn(...args);
+  }
+}
+
+export default logOnce;

--- a/src/vegetation/trees.js
+++ b/src/vegetation/trees.js
@@ -1,8 +1,9 @@
 import * as THREE from 'three';
-import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 import { createProceduralTree } from './procTree.js';
 import { assetUrl } from '../utils/assetUrl.js';
 import { applyCompressionToVector3 } from '../world/scale.js';
+import { loadGLTF } from '../loaders/safeGltf.js';
+import { logOnce } from '../utils/logOnce.js';
 
 const TREE_MODEL_FILES = {
   olive: 'olive.glb',
@@ -249,14 +250,15 @@ function buildInstancingData(group, height) {
   };
 }
 
-async function loadTreeDefinition(name, file, loader) {
+async function loadTreeDefinition(name, file) {
   let gltfScene = null;
+  const url = assetUrl(`assets/models/${file}`);
   try {
-    const url = assetUrl(`assets/models/${file}`);
-    const gltf = await loader.loadAsync(url);
+    const gltf = await loadGLTF(url);
     gltfScene = gltf.scene || (gltf.scenes && gltf.scenes[0]) || null;
   } catch (error) {
-    console.warn(`[trees] Missing ${file}, using procedural fallback`);
+    const reason = error instanceof Error ? error.message : String(error);
+    logOnce(`trees_model_${url}`, `[trees] Failed to load model ${name} at ${url}: ${reason} — using procedural fallback`);
   }
 
   const highSource = gltfScene ?? createProceduralTree(name, 'high');
@@ -328,10 +330,9 @@ export async function loadTreeLibrary(renderer) {
   }
 
   if (!libraryPromise) {
-    const loader = new GLTFLoader();
     const entries = Object.entries(TREE_MODEL_FILES);
 
-    libraryPromise = Promise.all(entries.map(([name, file]) => loadTreeDefinition(name, file, loader))).then(() => {
+    libraryPromise = Promise.all(entries.map(([name, file]) => loadTreeDefinition(name, file))).then(() => {
       libraryHandle = {
         getTree(treeName) {
           return treeLibrary.get(treeName) ?? null;


### PR DESCRIPTION
## Summary
- add a reusable requestAnimationFrame game loop that clamps dt, pauses on tab hide, and prevents duplicate loops
- wire initializeAthens into the new loop and propagate skippedLargeDt flags to gameplay systems
- introduce a guarded GLB loader with HEAD validation plus log-once support and apply it to NPC and tree assets

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d924c64e548327ac57b0da73e1bc37