### PR TITLE
Remove stats.js dependency from debug shim

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
   },
   "dependencies": {
     "cannon": "^0.6.2",
-    "stats.js": "^0.17.0",
     "three": "^0.180.0",
     "tone": "^14.7.77"
   },

--- a/src/debug/statsShim.js
+++ b/src/debug/statsShim.js
@@ -1,20 +1,8 @@
 // Returns a Stats-like object with begin/end + optional DOM, or a no-op if stats.js isn’t available.
 export async function createStats() {
-  try {
-    const mod = await import('stats.js');
-    const Stats = mod.default || mod.Stats || window?.Stats;
-    if (!Stats) throw new Error('no Stats ctor');
-    const s = new Stats();
-    return {
-      dom: s.dom || s.domElement || null,
-      begin: () => s.begin?.(),
-      end: () => s.end?.()
-    };
-  } catch {
-    return {
-      dom: null,
-      begin: () => {},
-      end: () => {}
-    };
-  }
+  return {
+    dom: null,
+    begin: () => {},
+    end: () => {}
+  };
 }


### PR DESCRIPTION
## Summary
- remove the stats.js dependency from the project manifest
- replace the stats shim with a lightweight no-op implementation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d92a6c0a088327a6f86a880e968ddb