### PR TITLE
Add safe fallback renderer and watchdog overlay

### DIFF
--- a/src/engine/loop.js
+++ b/src/engine/loop.js
@@ -1,9 +1,100 @@
-import { logOnce } from '../utils/logOnce.js';
+import * as THREE from 'three';
 
 const MIN_DT = 1 / 300;
-const MAX_DT = 0.2;
+const MAX_DT = 0.25;
 
-let activeLoop = null;
+let loopWatchdog = null;
+
+export function setLoopWatchdog(handler) {
+  loopWatchdog = handler || null;
+}
+
+export function startGameLoop({ update, render, onResume } = {}) {
+  const clock = new THREE.Clock();
+  let running = true;
+  let frameId = null;
+
+  const visibilityHandler = () => {
+    if (typeof document === 'undefined' || document.hidden) {
+      return;
+    }
+    clock.getDelta();
+    if (typeof onResume === 'function') {
+      try {
+        onResume();
+      } catch (error) {
+        console.error('[loop] onResume error:', error);
+      }
+    }
+  };
+
+  const step = () => {
+    if (!running) {
+      return;
+    }
+
+    frameId = requestAnimationFrame(step);
+
+    let dt = clock.getDelta();
+    if (!Number.isFinite(dt) || dt <= 0) {
+      dt = MIN_DT;
+    }
+
+    let skippedLargeDt = false;
+    if (dt > MAX_DT) {
+      dt = MAX_DT;
+      skippedLargeDt = true;
+    }
+
+    if (typeof update === 'function') {
+      try {
+        update(dt, { skippedLargeDt });
+      } catch (error) {
+        console.error('[loop] update error:', error);
+        loopWatchdog?.error?.('update failure');
+      }
+    }
+
+    if (typeof render === 'function') {
+      try {
+        render();
+      } catch (error) {
+        console.error('[loop] render error:', error);
+        loopWatchdog?.error?.('render failure');
+      }
+    }
+
+    loopWatchdog?.tick?.();
+  };
+
+  if (typeof document !== 'undefined') {
+    document.addEventListener('visibilitychange', visibilityHandler, { passive: true });
+  }
+
+  frameId = requestAnimationFrame(step);
+
+  return {
+    stop() {
+      if (!running) {
+        return;
+      }
+      running = false;
+      if (frameId !== null) {
+        cancelAnimationFrame(frameId);
+        frameId = null;
+      }
+      if (typeof document !== 'undefined') {
+        document.removeEventListener('visibilitychange', visibilityHandler);
+      }
+    },
+    resetClock() {
+      clock.getDelta();
+    },
+    isRunning() {
+      return running;
+    }
+  };
+}
 
 export function createGameLoop(update, render) {
   if (typeof update !== 'function') {
@@ -13,141 +104,85 @@ export function createGameLoop(update, render) {
     throw new Error('createGameLoop requires a render function');
   }
 
-  let frameId = null;
-  let started = false;
+  let runner = null;
   let paused = false;
   let disposed = false;
-  let lastTimestamp = null;
 
-  const step = (timestamp) => {
-    if (disposed || paused) {
+  const handleUpdate = (dt, meta) => {
+    if (paused || disposed) {
       return;
     }
-
-    if (lastTimestamp == null) {
-      lastTimestamp = timestamp;
-      frameId = requestAnimationFrame(step);
-      return;
-    }
-
-    let dt = (timestamp - lastTimestamp) / 1000;
-    lastTimestamp = timestamp;
-
-    if (!Number.isFinite(dt)) {
-      dt = MIN_DT;
-    }
-
-    let skippedLargeDt = false;
-    if (dt <= 0) {
-      logOnce('dt_zero', '[loop] clamped non-positive dt', dt);
-      dt = MIN_DT;
-    } else if (dt > MAX_DT) {
-      logOnce('dt_huge', `[loop] clamped large dt ${dt.toFixed(3)}s`);
-      dt = MAX_DT;
-      skippedLargeDt = true;
-    }
-
     try {
-      update(dt, { skippedLargeDt });
+      update(dt, meta || {});
     } catch (error) {
-      if (typeof console !== 'undefined' && typeof console.error === 'function') {
-        console.error('[loop] update step failed', error);
-      }
+      console.error('[loop] update error:', error);
+      loopWatchdog?.error?.('update failure');
     }
+  };
 
+  const handleRender = () => {
+    if (paused || disposed) {
+      return;
+    }
     try {
       render();
     } catch (error) {
-      if (typeof console !== 'undefined' && typeof console.error === 'function') {
-        console.error('[loop] render step failed', error);
-      }
+      console.error('[loop] render error:', error);
+      loopWatchdog?.error?.('render failure');
     }
-
-    frameId = requestAnimationFrame(step);
   };
 
-  const pause = () => {
-    if (paused) return;
-    paused = true;
-    if (frameId !== null) {
-      cancelAnimationFrame(frameId);
-      frameId = null;
-    }
-    lastTimestamp = null;
-  };
-
-  const resume = () => {
-    if (!started || disposed || !paused) {
+  const handleResume = () => {
+    if (disposed) {
       return;
     }
-    paused = false;
-    frameId = requestAnimationFrame(step);
+    runner?.resetClock?.();
   };
 
-  const handleVisibility = () => {
-    if (typeof document === 'undefined') return;
-    if (document.hidden) {
-      pause();
-    } else {
-      lastTimestamp = null;
-      resume();
-    }
-  };
-
-  const addVisibilityListener = () => {
-    if (typeof document === 'undefined') return;
-    document.addEventListener('visibilitychange', handleVisibility);
-  };
-
-  const removeVisibilityListener = () => {
-    if (typeof document === 'undefined') return;
-    document.removeEventListener('visibilitychange', handleVisibility);
-  };
-
-  const start = () => {
-    if (disposed || started) {
+  const ensureRunner = () => {
+    if (runner || disposed) {
       return;
     }
-    if (activeLoop && activeLoop !== api && activeLoop.isRunning()) {
-      logOnce('loop_multiple', '[loop] A game loop is already running; ignoring start request.');
-      return;
-    }
-
-    activeLoop = api;
-    started = true;
-    paused = Boolean(typeof document !== 'undefined' && document.hidden);
-    lastTimestamp = null;
-    addVisibilityListener();
-
-    if (!paused) {
-      frameId = requestAnimationFrame(step);
-    }
-  };
-
-  const stop = () => {
-    if (!started) return;
-    pause();
-    removeVisibilityListener();
-    started = false;
-    if (activeLoop === api) {
-      activeLoop = null;
-    }
-  };
-
-  const dispose = () => {
-    if (disposed) return;
-    stop();
-    disposed = true;
+    runner = startGameLoop({ update: handleUpdate, render: handleRender, onResume: handleResume });
   };
 
   const api = {
-    start,
-    stop,
-    dispose,
-    pause,
-    resume,
+    start() {
+      if (disposed) {
+        return;
+      }
+      paused = false;
+      ensureRunner();
+    },
+    stop() {
+      if (runner) {
+        runner.stop();
+        runner = null;
+      }
+    },
+    pause() {
+      paused = true;
+    },
+    resume() {
+      if (disposed) {
+        return;
+      }
+      paused = false;
+      if (runner) {
+        runner.resetClock?.();
+      } else {
+        ensureRunner();
+      }
+    },
+    dispose() {
+      if (disposed) {
+        return;
+      }
+      disposed = true;
+      api.stop();
+    },
     isRunning() {
-      return started && !paused && !disposed;
+      return !disposed && !paused && Boolean(runner?.isRunning?.());
     }
   };
 

--- a/src/engine/safeEntry.js
+++ b/src/engine/safeEntry.js
@@ -1,0 +1,69 @@
+import * as THREE from 'three';
+
+export function createSafeScene(canvasSelector = 'canvas') {
+  const canvas = typeof document !== 'undefined' ? document.querySelector(canvasSelector) : null;
+  const renderer = new THREE.WebGLRenderer({ antialias: true, canvas: canvas || undefined });
+  renderer.setPixelRatio(Math.min(typeof window !== 'undefined' ? window.devicePixelRatio : 1, 2));
+  renderer.setSize(typeof window !== 'undefined' ? window.innerWidth : 1, typeof window !== 'undefined' ? window.innerHeight : 1, false);
+  renderer.setClearColor(0x202834, 1);
+  renderer.domElement.style.width = '100%';
+  renderer.domElement.style.height = '100%';
+  renderer.domElement.style.display = 'block';
+
+  const scene = new THREE.Scene();
+  scene.background = new THREE.Color(0x202834);
+
+  const camera = new THREE.PerspectiveCamera(60, (typeof window !== 'undefined' ? window.innerWidth : 1) / (typeof window !== 'undefined' ? window.innerHeight || 1 : 1), 0.1, 2000);
+  camera.position.set(0, 3.5, 7);
+  scene.add(camera);
+
+  const ambient = new THREE.AmbientLight(0xffffff, 0.35);
+  scene.add(ambient);
+  const directional = new THREE.DirectionalLight(0xffffff, 1.1);
+  directional.position.set(5, 10, 7);
+  scene.add(directional);
+
+  const cube = new THREE.Mesh(
+    new THREE.BoxGeometry(1, 1, 1),
+    new THREE.MeshStandardMaterial({ color: 0x4fa3ff, roughness: 0.6, metalness: 0 })
+  );
+  cube.position.y = 1;
+  scene.add(cube);
+
+  const grid = new THREE.GridHelper(40, 40, 0x6aa0ff, 0x2a3550);
+  scene.add(grid);
+
+  const onResize = () => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    const width = window.innerWidth;
+    const height = window.innerHeight || 1;
+    camera.aspect = width / (height || 1);
+    camera.updateProjectionMatrix();
+    renderer.setSize(width, height, false);
+  };
+
+  if (typeof window !== 'undefined') {
+    window.addEventListener('resize', onResize, { passive: true });
+  }
+
+  const update = (dt = 0) => {
+    cube.rotation.y += dt;
+  };
+
+  const render = () => {
+    renderer.render(scene, camera);
+  };
+
+  const dispose = () => {
+    if (typeof window !== 'undefined') {
+      window.removeEventListener('resize', onResize);
+    }
+    renderer.dispose();
+  };
+
+  return { renderer, scene, camera, update, render, dispose };
+}
+
+export default createSafeScene;

--- a/src/entry/landing.js
+++ b/src/entry/landing.js
@@ -1,17 +1,78 @@
+import * as THREE from 'three';
 import initializeAthens from './initializeAthens.js';
 import boot, { whenBootReady } from '../core/bootstrap.js';
+import { startGameLoop, setLoopWatchdog } from '../engine/loop.js';
+import { createSafeScene } from '../engine/safeEntry.js';
+import { attachWatchdog } from '../ui/watchdog.js';
 
 /**
  * @typedef {ReturnType<typeof initializeAthens> extends Promise<infer T> ? T : never} AthensContext
  */
 
-/** @type {Promise<AthensContext> | null} */
 let initializationTask = null;
-/** @type {AthensContext | null} */
 let initializedContext = null;
-/** @type {Promise<any> | null} */
 let bootPromise = null;
 let bootLogEmitted = false;
+
+const watchdog = attachWatchdog();
+setLoopWatchdog(watchdog);
+
+let fallbackActive = false;
+let fallbackLoop = null;
+let fallbackScene = null;
+let fallbackRoot = null;
+
+const ensureFallback = () => {
+  if (fallbackActive || typeof document === 'undefined') {
+    return;
+  }
+  if (!document.body) {
+    document.addEventListener('DOMContentLoaded', ensureFallback, { once: true });
+    return;
+  }
+
+  fallbackActive = true;
+  fallbackRoot = document.createElement('div');
+  fallbackRoot.id = 'athens-fallback-root';
+  fallbackRoot.style.cssText =
+    'position:fixed;inset:0;z-index:9998;pointer-events:none;display:flex;align-items:center;justify-content:center;background:#202834;';
+  document.body.appendChild(fallbackRoot);
+
+  fallbackScene = createSafeScene();
+  const canvas = fallbackScene.renderer?.domElement;
+  if (canvas) {
+    canvas.style.width = '100%';
+    canvas.style.height = '100%';
+    canvas.style.pointerEvents = 'none';
+    fallbackRoot.appendChild(canvas);
+  }
+
+  fallbackLoop = startGameLoop({
+    update: (dt) => {
+      fallbackScene?.update?.(dt);
+    },
+    render: () => {
+      fallbackScene?.render?.();
+    }
+  });
+};
+
+const teardownFallback = () => {
+  if (!fallbackActive) {
+    return;
+  }
+  fallbackActive = false;
+  fallbackLoop?.stop?.();
+  fallbackLoop = null;
+  fallbackScene?.dispose?.();
+  fallbackScene = null;
+  if (fallbackRoot?.parentNode) {
+    fallbackRoot.parentNode.removeChild(fallbackRoot);
+  }
+  fallbackRoot = null;
+};
+
+ensureFallback();
 
 async function waitForDomReady() {
   if (typeof document === 'undefined') {
@@ -53,7 +114,27 @@ function ensureBootStarted() {
   return { promise: bootPromise, started };
 }
 
-async function runAthens() {
+function resolveContainer(options = {}) {
+  if (typeof document === 'undefined') {
+    throw new Error('Missing document for Athens renderer.');
+  }
+  if (options.container instanceof HTMLElement) {
+    return options.container;
+  }
+  if (typeof options.containerId === 'string') {
+    const byId = document.getElementById(options.containerId);
+    if (byId) {
+      return byId;
+    }
+  }
+  const fallback = document.getElementById('app');
+  if (!fallback) {
+    throw new Error('Missing #app container for Athens renderer.');
+  }
+  return fallback;
+}
+
+async function runAthens(options = {}) {
   if (initializedContext) {
     return initializedContext;
   }
@@ -75,18 +156,30 @@ async function runAthens() {
 
     await waitForDomReady();
 
-    const container = document.getElementById('app');
-    if (!container) {
-      throw new Error('Missing #app container for Athens renderer.');
+    const container = resolveContainer(options);
+    container.style.position = container.style.position || 'relative';
+    container.style.backgroundColor = container.style.backgroundColor || '#202834';
+
+    const context = await initializeAthens({ ...options, container });
+    context.renderer?.setClearColor?.(0x202834, 1);
+    if (context.scene) {
+      try {
+        context.scene.background = new THREE.Color(0x202834);
+      } catch (error) {
+        console.warn('[Athens] Unable to set scene background color.', error);
+      }
     }
 
-    const context = await initializeAthens({ container });
+    teardownFallback();
     initializedContext = context;
     return context;
   })();
 
   try {
     return await initializationTask;
+  } catch (error) {
+    watchdog?.error?.(error?.message || 'boot failed');
+    throw error;
   } finally {
     initializationTask = null;
   }
@@ -111,7 +204,7 @@ globalWindow.getAthensContext = async () => {
 
 window.dispatchEvent(
   new CustomEvent('athens:initializer-ready', {
-    detail: { initializer: runAthens, source: 'index.html' }
+    detail: { initializer: runAthens, source: 'landing.js' }
   })
 );
 console.log('[Athens] initializer ready');

--- a/src/ui/watchdog.js
+++ b/src/ui/watchdog.js
@@ -1,0 +1,31 @@
+export function attachWatchdog() {
+  const el = document.createElement('div');
+  el.id = 'watchdog';
+  el.style.cssText = 'position:fixed;left:8px;top:8px;background:rgba(0,0,0,0.6);color:#0f0;font:12px/14px monospace;padding:6px 8px;border-radius:6px;white-space:pre;z-index:99999;pointer-events:none;';
+  el.textContent = 'loop: init';
+  document.body.appendChild(el);
+
+  let lastTimestamp = performance.now();
+  let framesThisSecond = 0;
+  let fps = 0;
+
+  return {
+    tick() {
+      const now = performance.now();
+      framesThisSecond += 1;
+      if (now - lastTimestamp >= 1000) {
+        fps = framesThisSecond;
+        framesThisSecond = 0;
+        lastTimestamp = now;
+      }
+      el.style.color = '#0f0';
+      el.textContent = `loop: running\nfps: ${fps.toString().padStart(2, ' ')} `;
+    },
+    error(message) {
+      el.style.color = '#f66';
+      el.textContent = `loop ERROR: ${message}`;
+    }
+  };
+}
+
+export default attachWatchdog;


### PR DESCRIPTION
## Summary
- replace the engine loop with a restartable runner that reports to a watchdog overlay
- add a reusable safe fallback scene that renders a spinning cube on a dark background
- update the landing entry point to start the fallback immediately, attach the watchdog, and hand off to the full Athens bootstrap when ready

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d92cedf3608327ac0329b1d7912fdb