### PR TITLE
Remove missing NPC model references

### DIFF
--- a/src/entry/initializeAthens.js
+++ b/src/entry/initializeAthens.js
@@ -87,10 +87,8 @@ const DEFAULT_OVERLAY_ID = 'landmark-overlay';
 const DEFAULT_GEOJSON_URL = 'data/athens_places.geojson';
 
 const DEFAULT_NPC_MODEL_URLS = [
-  'models/Adventurer.glb',
   'models/Adventurer1.glb',
   'models/brokenCHar.glb',
-  'models/character2.glb',
   'models/character3.glb',
   assetUrl('assets/models/hoplite_npc.glb'),
   assetUrl('assets/models/npc_athenian.glb')


### PR DESCRIPTION
## Summary
- remove the default NPC model entries that reference Adventurer and character2 assets

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d9384651988327b2aa268b8fa80372