### PR TITLE
Add sky visibility toggle and HUD control

### DIFF
--- a/src/entry/boot.ts
+++ b/src/entry/boot.ts
@@ -2,7 +2,7 @@ import * as THREE from 'three';
 import { createStats } from '../debug/statsShim.js';
 import { setupGround, updateTrees } from '../main.js';
 import { setEnvironment } from '../scene/sky.js';
-import { createTimeSky, setTimeOfDay } from '../sky/timeSky.js';
+import { createTimeSky, setTimeOfDay, setSkyEnabled } from '../sky/timeSky.js';
 import boot from '../core/bootstrap.js';
 import createKeyboard from '../input/keyboard.js';
 import { createPlayerController } from '../player/playerController.js';
@@ -353,12 +353,17 @@ export async function runAthens(options: RunOptions = {}) {
     audio.setMasterVolume(value);
   };
 
+  const handleSkyEnabled = (enabled: boolean) => {
+    setSkyEnabled(Boolean(enabled));
+  };
+
   applyQualityPreset('high');
 
   createHUD({
     setTimeOfDay: (mode) => handleTimeOfDay(mode),
     setVolume: (value) => handleVolume(Number(value)),
-    setQuality: (preset) => applyQualityPreset(String(preset))
+    setQuality: (preset) => applyQualityPreset(String(preset)),
+    setSkyEnabled: (value) => handleSkyEnabled(Boolean(value))
   });
 
   markGround(scene);

--- a/src/sky/timeSky.js
+++ b/src/sky/timeSky.js
@@ -39,6 +39,8 @@ let pmremGenerator = null;
 let activeRenderer = null;
 let activeScene = null;
 let currentMode = null;
+let currentEntry = null;
+let skyEnabled = true;
 let hotkeyAttached = false;
 
 function ensureColorSpace(texture) {
@@ -147,6 +149,13 @@ function applySky(entry) {
   if (!activeScene || !entry) {
     return;
   }
+  currentEntry = entry;
+  currentMode = entry.mode;
+  if (!skyEnabled) {
+    activeScene.background = null;
+    activeScene.environment = null;
+    return;
+  }
   if (entry.background?.isTexture) {
     activeScene.background = entry.background;
   } else if (entry.background instanceof THREE.Color) {
@@ -155,7 +164,17 @@ function applySky(entry) {
     activeScene.background = null;
   }
   activeScene.environment = entry.envMap || null;
-  currentMode = entry.mode;
+}
+
+function notifySkyEnabledChange() {
+  if (typeof window === 'undefined' || typeof window.dispatchEvent !== 'function') {
+    return;
+  }
+  try {
+    window.dispatchEvent(new CustomEvent('athens:sky-enabled-changed', { detail: { enabled: skyEnabled } }));
+  } catch (_) {
+    // ignored
+  }
 }
 
 export async function createTimeSky(renderer, scene, initial = 'day') {
@@ -187,6 +206,45 @@ export function getTimeOfDay() {
   return currentMode;
 }
 
+export function isSkyEnabled() {
+  return skyEnabled;
+}
+
+export function setSkyEnabled(enabled) {
+  const normalized = Boolean(enabled);
+  if (normalized === skyEnabled) {
+    return skyEnabled;
+  }
+  skyEnabled = normalized;
+  if (!activeScene) {
+    notifySkyEnabledChange();
+    return skyEnabled;
+  }
+  if (!skyEnabled) {
+    activeScene.background = null;
+    activeScene.environment = null;
+  } else if (currentEntry) {
+    applySky(currentEntry);
+  } else if (currentMode) {
+    loadSky(currentMode)
+      .then((entry) => {
+        if (skyEnabled) {
+          applySky(entry);
+        }
+      })
+      .catch(() => {});
+  }
+  notifySkyEnabledChange();
+  return skyEnabled;
+}
+
+export function toggleSkyEnabled(force) {
+  if (typeof force === 'boolean') {
+    return setSkyEnabled(force);
+  }
+  return setSkyEnabled(!skyEnabled);
+}
+
 export function attachTimeHotkeys(win = typeof window !== 'undefined' ? window : null) {
   if (!win || hotkeyAttached) {
     return undefined;
@@ -195,7 +253,8 @@ export function attachTimeHotkeys(win = typeof window !== 'undefined' ? window :
     if (event.defaultPrevented || event.altKey || event.metaKey || event.ctrlKey) {
       return;
     }
-    switch (event.key) {
+    const key = typeof event.key === 'string' ? event.key.toLowerCase() : '';
+    switch (key) {
       case '1':
         setTimeOfDay('dawn');
         break;
@@ -207,6 +266,9 @@ export function attachTimeHotkeys(win = typeof window !== 'undefined' ? window :
         break;
       case '4':
         setTimeOfDay('night');
+        break;
+      case 'k':
+        toggleSkyEnabled();
         break;
       default:
         return;

--- a/src/ui/hud.js
+++ b/src/ui/hud.js
@@ -2,7 +2,8 @@ const STORAGE_KEY = 'athens.hud.state';
 const DEFAULT_STATE = {
   timeMode: 'day',
   volume: 1,
-  quality: 'high'
+  quality: 'high',
+  skyEnabled: true
 };
 
 const TIME_OPTIONS = ['dawn', 'day', 'dusk', 'night'];
@@ -34,7 +35,8 @@ function readStoredState() {
     const normalized = {
       timeMode: TIME_OPTIONS.includes(parsed?.timeMode) ? parsed.timeMode : DEFAULT_STATE.timeMode,
       volume: VOLUME_OPTIONS.includes(parsed?.volume) ? parsed.volume : DEFAULT_STATE.volume,
-      quality: QUALITY_OPTIONS.includes(parsed?.quality) ? parsed.quality : DEFAULT_STATE.quality
+      quality: QUALITY_OPTIONS.includes(parsed?.quality) ? parsed.quality : DEFAULT_STATE.quality,
+      skyEnabled: typeof parsed?.skyEnabled === 'boolean' ? parsed.skyEnabled : DEFAULT_STATE.skyEnabled
     };
     return normalized;
   } catch (_) {
@@ -145,7 +147,8 @@ export function createHUD(callbacks = {}) {
   const buttonMaps = {
     time: new Map(),
     volume: new Map(),
-    quality: new Map()
+    quality: new Map(),
+    sky: new Map()
   };
 
   const state = readStoredState();
@@ -164,6 +167,10 @@ export function createHUD(callbacks = {}) {
       delete updates.quality;
     }
 
+    if ('skyEnabled' in updates) {
+      updates.skyEnabled = Boolean(updates.skyEnabled);
+    }
+
     Object.assign(state, updates);
 
     if (persist) {
@@ -179,6 +186,9 @@ export function createHUD(callbacks = {}) {
       }
       if ('quality' in updates) {
         callMaybeAsync(callbacks.setQuality, state.quality);
+      }
+      if ('skyEnabled' in updates) {
+        callMaybeAsync(callbacks.setSkyEnabled, state.skyEnabled);
       }
     }
   };
@@ -204,6 +214,44 @@ export function createHUD(callbacks = {}) {
     timeSection.appendChild(button);
     buttonMaps.time.set(value, button);
   });
+
+  const skySection = createSection(root, 'Sky');
+  [
+    ['On', true],
+    ['Off', false]
+  ].forEach(([label, value]) => {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.textContent = label;
+    button.addEventListener('click', (event) => {
+      event.preventDefault();
+      if (state.skyEnabled === value) {
+        return;
+      }
+      applyState({ skyEnabled: value });
+      updateActiveButtons(buttonMaps.sky, value);
+    });
+    skySection.appendChild(button);
+    buttonMaps.sky.set(value, button);
+  });
+
+  const handleExternalSkyChange = (event) => {
+    const next = Boolean(event?.detail?.enabled);
+    if (state.skyEnabled === next) {
+      return;
+    }
+    applyState({ skyEnabled: next }, { persist: true, callHandlers: false });
+    updateActiveButtons(buttonMaps.sky, state.skyEnabled);
+  };
+  if (typeof window !== 'undefined' && window.addEventListener) {
+    const globalWindow = window;
+    const previousListener = globalWindow.__athensHudSkyListener;
+    if (previousListener) {
+      globalWindow.removeEventListener('athens:sky-enabled-changed', previousListener);
+    }
+    globalWindow.__athensHudSkyListener = handleExternalSkyChange;
+    globalWindow.addEventListener('athens:sky-enabled-changed', handleExternalSkyChange);
+  }
 
   const audioSection = createSection(root, 'Audio');
   [
@@ -252,11 +300,13 @@ export function createHUD(callbacks = {}) {
   updateActiveButtons(buttonMaps.time, state.timeMode);
   updateActiveButtons(buttonMaps.volume, state.volume);
   updateActiveButtons(buttonMaps.quality, state.quality);
+  updateActiveButtons(buttonMaps.sky, state.skyEnabled);
 
   // Ensure handlers run once on initialization with stored values.
   callMaybeAsync(callbacks.setTimeOfDay, state.timeMode);
   callMaybeAsync(callbacks.setVolume, state.volume);
   callMaybeAsync(callbacks.setQuality, state.quality);
+  callMaybeAsync(callbacks.setSkyEnabled, state.skyEnabled);
   persistState(state);
 
   return {
@@ -274,6 +324,9 @@ export function createHUD(callbacks = {}) {
       }
       if (partial?.quality) {
         updateActiveButtons(buttonMaps.quality, state.quality);
+      }
+      if (partial?.skyEnabled != null) {
+        updateActiveButtons(buttonMaps.sky, state.skyEnabled);
       }
     }
   };


### PR DESCRIPTION
## Summary
- add sky enable/disable state management to the time sky system including hotkey support
- add HUD controls that persist and broadcast sky visibility changes
- wire the boot flow so HUD toggles update the active scene sky

## Testing
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_b_68d93946114c832794064fb3fda5c6cb