### PR TITLE
Disable default photo sky to preserve environment

### DIFF
--- a/src/entry/boot.ts
+++ b/src/entry/boot.ts
@@ -287,13 +287,11 @@ export async function runAthens(options: RunOptions = {}) {
   const environmentMode = options.skyMode ?? options.preset ?? 'day';
   if (typeof setEnvironment === 'function') {
     try {
+      // Default to environment map + preserved background; photo-sky can be re-enabled per-call.
       await setEnvironment(renderer, scene, environmentMode, {
-        preserveBackground: Boolean(options.preserveBackground)
+        enablePhotoSky: false,
+        preserveBackground: true
       });
-      
-      await setEnvironment(renderer, scene, environmentMode, {
-  enablePhotoSky: false,        // disables JPG dome
-  preserveBackground: true
     } catch (error) {
       console.warn('[Athens][Boot] setEnvironment failed', error);
     }

--- a/src/entry/initializeAthens.js
+++ b/src/entry/initializeAthens.js
@@ -300,7 +300,7 @@ export async function initializeAthens(options = {}) {
 
   const { width: initialWidth, height: initialHeight } = computeContainerSize(container);
 
-  const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
+  const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: false });
   renderer.shadowMap.enabled = true;
   renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
   renderer.setSize(initialWidth, initialHeight, false);


### PR DESCRIPTION
## Summary
- default environment setup preserves the renderer background and skips the photo sky to avoid white flashes
- create the WebGL renderer with an opaque canvas so page white does not show through background clears

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d941d6e4c483278a40618e3b77d0ed