### PR TITLE
Normalize keyboard events without code

### DIFF
--- a/src/input/keyboard.js
+++ b/src/input/keyboard.js
@@ -20,6 +20,46 @@ const EXTRA_KEYS = ['Space', 'KeyX', 'KeyC', 'KeyE', 'KeyQ', 'KeyZ', 'ControlLef
 
 const RELEVANT_KEYS = new Set([...MOVEMENT_KEYS, ...LOOK_KEYS, ...MODIFIER_KEYS, ...EXTRA_KEYS]);
 
+const KEY_FALLBACK_MAP = new Map([
+  ['w', 'KeyW'],
+  ['a', 'KeyA'],
+  ['s', 'KeyS'],
+  ['d', 'KeyD'],
+  ['arrowup', 'ArrowUp'],
+  ['arrowdown', 'ArrowDown'],
+  ['arrowleft', 'ArrowLeft'],
+  ['arrowright', 'ArrowRight'],
+  [' ', 'Space'],
+  ['space', 'Space'],
+  ['spacebar', 'Space'],
+  ['x', 'KeyX'],
+  ['c', 'KeyC'],
+  ['e', 'KeyE'],
+  ['q', 'KeyQ'],
+  ['z', 'KeyZ'],
+  ['shift', 'ShiftLeft'],
+  ['control', 'ControlLeft']
+]);
+
+const normalizeCode = (event) => {
+  if (!event) {
+    return undefined;
+  }
+
+  const { code, key } = event;
+
+  if (code && code !== '' && code !== 'Unidentified') {
+    return code;
+  }
+
+  if (!key && key !== 0) {
+    return undefined;
+  }
+
+  const fallbackKey = String(key).toLowerCase();
+  return KEY_FALLBACK_MAP.get(fallbackKey);
+};
+
 export function createKeyboard(target = typeof window !== 'undefined' ? window : null) {
   const pressed = new Set();
   const listeners = new Map();
@@ -27,17 +67,21 @@ export function createKeyboard(target = typeof window !== 'undefined' ? window :
   const lookVector = { x: 0, y: 0 };
 
   const handleKeyDown = (event) => {
-    if (!RELEVANT_KEYS.has(event.code)) {
+    const code = normalizeCode(event);
+
+    if (!RELEVANT_KEYS.has(code)) {
       return;
     }
-    pressed.add(event.code);
+    pressed.add(code);
   };
 
   const handleKeyUp = (event) => {
-    if (!RELEVANT_KEYS.has(event.code)) {
+    const code = normalizeCode(event);
+
+    if (!RELEVANT_KEYS.has(code)) {
       return;
     }
-    pressed.delete(event.code);
+    pressed.delete(code);
   };
 
   if (target && target.addEventListener) {

--- a/tests/keyboard-controls.test.js
+++ b/tests/keyboard-controls.test.js
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import createKeyboard from '../src/input/keyboard.js';
+
+const createMockTarget = () => {
+  const listeners = new Map();
+
+  return {
+    listeners,
+    addEventListener(type, handler) {
+      listeners.set(type, handler);
+    },
+    removeEventListener(type, handler) {
+      if (listeners.get(type) === handler) {
+        listeners.delete(type);
+      }
+    }
+  };
+};
+
+test('keyboard respects event.code when provided', () => {
+  const target = createMockTarget();
+  const keyboard = createKeyboard(target);
+  const keydown = target.listeners.get('keydown');
+  const keyup = target.listeners.get('keyup');
+
+  keydown({ code: 'KeyW', key: 'w' });
+  assert.strictEqual(keyboard.isDown('KeyW'), true);
+  assert.strictEqual(keyboard.axis.z, -1);
+
+  keyup({ code: 'KeyW', key: 'w' });
+  assert.strictEqual(keyboard.isDown('KeyW'), false);
+  assert.strictEqual(keyboard.axis.z, 0);
+
+  keyboard.dispose();
+});
+
+test('keyboard normalizes events without code to maintain controls', () => {
+  const target = createMockTarget();
+  const keyboard = createKeyboard(target);
+  const keydown = target.listeners.get('keydown');
+  const keyup = target.listeners.get('keyup');
+
+  keydown({ key: 'w', code: '' });
+  assert.strictEqual(keyboard.isDown('KeyW'), true);
+  assert.strictEqual(keyboard.axis.z, -1);
+
+  keydown({ key: 'Shift', code: 'Unidentified' });
+  assert.strictEqual(keyboard.axis.running, true);
+
+  keydown({ key: 'ArrowLeft', code: 'Unidentified' });
+  assert.strictEqual(keyboard.isDown('ArrowLeft'), true);
+  assert.strictEqual(keyboard.look.x, -1);
+
+  keydown({ key: 'ArrowUp', code: undefined });
+  assert.strictEqual(keyboard.look.y, 1);
+
+  keyup({ key: 'ArrowLeft', code: '' });
+  keyup({ key: 'ArrowUp', code: '' });
+  keyup({ key: 'Shift', code: '' });
+  keyup({ key: 'w', code: '' });
+
+  assert.strictEqual(keyboard.isDown('KeyW'), false);
+  assert.strictEqual(keyboard.axis.z, 0);
+  assert.strictEqual(keyboard.axis.running, false);
+  assert.strictEqual(keyboard.look.x, 0);
+  assert.strictEqual(keyboard.look.y, 0);
+
+  keyboard.dispose();
+});


### PR DESCRIPTION
## Summary
- normalize keyboard event codes when browsers emit empty or Unidentified code values
- ensure movement, running, and camera controls still respond through regression tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d9ad07650c832781028daab3a2530c