### PR TITLE
Add console debug hooks for smoke tests

### DIFF
--- a/src/entry/initializeAthens.js
+++ b/src/entry/initializeAthens.js
@@ -1,5 +1,5 @@
 import * as THREE from 'three';
-if (typeof window !== 'undefined') window.THREE = THREE;
+if (typeof window !== 'undefined') window.THREE = THREE; // debug: use THREE from console
 import { createStats } from '../debug/statsShim.js';
 import { setupGround, updateTrees } from '../main.js';
 import { loadLandmarks } from '../landmarks-loader.js';
@@ -301,7 +301,7 @@ export async function initializeAthens(options = {}) {
 
   const { width: initialWidth, height: initialHeight } = computeContainerSize(container);
 
-  const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: false });
+  const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: false }); // avoid page-white if background=null
   renderer.shadowMap.enabled = true;
   renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
   renderer.setSize(initialWidth, initialHeight, false);
@@ -316,8 +316,12 @@ export async function initializeAthens(options = {}) {
 
   const scene = new THREE.Scene();
   const camera = new THREE.PerspectiveCamera(60, initialWidth / initialHeight, 0.1, 2000);
+  // Minimal debug hook for smoke tests / console
   if (typeof window !== 'undefined') {
-    window.__athensDebug = { scene, camera, renderer };
+    const params = new URLSearchParams(window.location.search);
+    if (params.get('headlessSmoke') === '1') {
+      window.__athensDebug = { scene, camera, renderer };
+    }
   }
   camera.position.set(90, 110, 180);
   camera.lookAt(new THREE.Vector3(0, 0, 0));


### PR DESCRIPTION
## Summary
- expose the THREE module on window for interactive debugging
- avoid transparent renderer to prevent white flashes when no background
- gate the debug scene/camera hook behind a headlessSmoke query parameter

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68d9c4a8ae4c8327879c3c29c8175384