### PR TITLE
Restore default background without sky textures

### DIFF
--- a/public/dev/index.html
+++ b/public/dev/index.html
@@ -253,6 +253,7 @@
         const renderer = new THREE.WebGLRenderer({ antialias: true });
         renderer.shadowMap.enabled = true;
         renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
+        renderer.setClearColor(0x202834, 1);
         const { width, height } = computeContainerSize();
         renderer.setSize(width, height, false);
         renderer.domElement.style.width = '100%';
@@ -268,7 +269,7 @@
         }
 
         const scene = new THREE.Scene();
-        scene.background = new THREE.Color('#8fbcd4');
+        scene.background = new THREE.Color(0x202834);
 
         const camera = new THREE.PerspectiveCamera(60, width / height, 0.1, 2000);
         camera.position.set(90, 110, 180);
@@ -295,7 +296,12 @@
         if (typeof setEnvironment === 'function') {
           try {
             const mode = options?.skyMode || 'day';
-            setEnvironment(renderer, scene, mode, { preserveBackground: Boolean(options?.preserveBackground) });
+            const preserveBackgroundOption = options?.preserveBackground;
+            const environmentOptions = {
+              preserveBackground:
+                preserveBackgroundOption === undefined ? true : Boolean(preserveBackgroundOption)
+            };
+            setEnvironment(renderer, scene, mode, environmentOptions);
           } catch (error) {
             console.warn('[Athens][Dev] setEnvironment failed', error);
           }

--- a/src/entry/boot.ts
+++ b/src/entry/boot.ts
@@ -159,6 +159,7 @@ export async function runAthens(options: RunOptions = {}) {
   const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: false });
   renderer.shadowMap.enabled = true;
   renderer.setPixelRatio(Math.min((typeof window !== 'undefined' ? window.devicePixelRatio : 1) || 1, 2));
+  renderer.setClearColor(0x202834, 1);
 
   const { width: initialWidth, height: initialHeight } = computeSize(container);
   renderer.setSize(initialWidth, initialHeight, false);
@@ -186,7 +187,7 @@ export async function runAthens(options: RunOptions = {}) {
     });
 
   const scene = new THREE.Scene();
-  scene.background = new THREE.Color('#8fbcd4');
+  scene.background = new THREE.Color(0x202834);
 
   const camera = new THREE.PerspectiveCamera(60, initialWidth / initialHeight, 0.1, 2000);
   camera.position.set(90, 110, 180);

--- a/src/sky/timeSky.js
+++ b/src/sky/timeSky.js
@@ -1,11 +1,13 @@
 import * as THREE from 'three';
 import { assetUrl } from '../utils/assetUrl.js';
 
+const DEFAULT_BACKGROUND_COLOR = 0x202834;
+
 const MODE_CONFIG = {
-  dawn: { path: 'assets/sky/dawn.jpg', fallbackColor: 0x335577 },
-  day: { path: 'assets/sky/day.jpg', fallbackColor: 0x87ceeb },
-  dusk: { path: 'assets/sky/dusk.jpg', fallbackColor: 0x553344 },
-  night: { path: 'assets/sky/night.jpg', fallbackColor: 0x0b0e19 }
+  dawn: { fallbackColor: DEFAULT_BACKGROUND_COLOR },
+  day: { fallbackColor: DEFAULT_BACKGROUND_COLOR },
+  dusk: { fallbackColor: DEFAULT_BACKGROUND_COLOR },
+  night: { fallbackColor: DEFAULT_BACKGROUND_COLOR }
 };
 
 const MODE_ALIASES = new Map(
@@ -43,6 +45,16 @@ let currentEntry = null;
 let skyEnabled = true;
 let hotkeyAttached = false;
 
+const DEFAULT_BACKGROUND = new THREE.Color(DEFAULT_BACKGROUND_COLOR);
+
+function applyDefaultBackground() {
+  if (!activeScene) {
+    return;
+  }
+  activeScene.background = DEFAULT_BACKGROUND.clone();
+  activeScene.environment = null;
+}
+
 function ensureColorSpace(texture) {
   if (!texture) {
     return;
@@ -79,7 +91,7 @@ function normalizeMode(mode) {
 
 function fallbackEntry(mode) {
   const config = MODE_CONFIG[mode] || {};
-  const color = new THREE.Color(config.fallbackColor ?? 0x000000);
+  const color = new THREE.Color(config.fallbackColor ?? DEFAULT_BACKGROUND_COLOR);
   return { background: color, envMap: null, mode };
 }
 
@@ -152,8 +164,7 @@ function applySky(entry) {
   currentEntry = entry;
   currentMode = entry.mode;
   if (!skyEnabled) {
-    activeScene.background = null;
-    activeScene.environment = null;
+    applyDefaultBackground();
     return;
   }
   if (entry.background?.isTexture) {
@@ -221,8 +232,7 @@ export function setSkyEnabled(enabled) {
     return skyEnabled;
   }
   if (!skyEnabled) {
-    activeScene.background = null;
-    activeScene.environment = null;
+    applyDefaultBackground();
   } else if (currentEntry) {
     applySky(currentEntry);
   } else if (currentMode) {


### PR DESCRIPTION
## Summary
- force the time-of-day sky loader to fall back to the default Athens background colour and keep the scene environment clear when the sky is toggled off
- set the renderer clear colour and scene background to the default dark backdrop during boot
- update the developer sandbox to use the same background and preserve it when configuring environments

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d9f992ce60832791c6c8c3957a0ddc