### PR TITLE
Guard remote integrations behind feature flag

### DIFF
--- a/src/config/flags.ts
+++ b/src/config/flags.ts
@@ -1,0 +1,1 @@
+export const USE_REMOTE = false;

--- a/src/entry/landing.js
+++ b/src/entry/landing.js
@@ -4,6 +4,7 @@ import boot, { whenBootReady } from '../core/bootstrap.js';
 import { startGameLoop, setLoopWatchdog } from '../engine/loop.js';
 import { createSafeScene } from '../engine/safeEntry.js';
 import { attachWatchdog } from '../ui/watchdog.js';
+import { maybeRemoteInit } from '../services/remote.js';
 
 /**
  * @typedef {ReturnType<typeof initializeAthens> extends Promise<infer T> ? T : never} AthensContext
@@ -171,6 +172,7 @@ async function runAthens(options = {}) {
     }
 
     teardownFallback();
+    maybeRemoteInit(context);
     initializedContext = context;
     return context;
   })();

--- a/src/services/remote.js
+++ b/src/services/remote.js
@@ -1,0 +1,17 @@
+import { USE_REMOTE } from '../config/flags.ts';
+
+/**
+ * Initialize optional remote integrations without blocking rendering.
+ * @param {unknown} context Optional context for remote hooks.
+ * @returns {Promise<void> | void}
+ */
+export async function maybeRemoteInit(context) {
+  if (!USE_REMOTE) return;
+
+  try {
+    void context;
+    // Remote integrations are currently disabled. Add guarded logic here when needed.
+  } catch (error) {
+    console.warn('[remote disabled]', error);
+  }
+}


### PR DESCRIPTION
## Summary
- add a central `USE_REMOTE` flag defaulting to false
- create a guarded `maybeRemoteInit` helper for any future remote integrations
- invoke remote initialization without blocking the main renderer startup

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68da33f7684483279a08f7b361ebb67a