### PR TITLE
fix: harden sanitize helpers and refresh service worker cache

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -1,7 +1,7 @@
 // ---- service-worker.js ----
 
 // Bump this whenever you change the SW to force an update
-const CACHE_NAME = 'athens-static-v2';
+const CACHE_NAME = 'athens-static-v3';
 
 // Optional pre-cache list (can stay empty for GH Pages)
 const PRECACHE_URLS = [];

--- a/src/utils/sanitize.ts
+++ b/src/utils/sanitize.ts
@@ -4,7 +4,8 @@ export const DEFAULT_PLAYER = new THREE.Vector3(0, 1, 0);
 export const DEFAULT_CAMERA = new THREE.Vector3(20, 12, 20);
 
 export function finiteNumber(n: any, def = 0): number {
-  return Number.isFinite(n) ? n : def;
+  const parsed = typeof n === 'number' ? n : Number(n);
+  return Number.isFinite(parsed) ? parsed : def;
 }
 
 export function isFiniteVec3(v: THREE.Vector3): boolean {
@@ -45,9 +46,9 @@ export function safeSetVec3(
   def: { x: number; y: number; z: number }
 ) {
   v.set(
-    finiteNumber(src?.x, def.x),
-    finiteNumber(src?.y, def.y),
-    finiteNumber(src?.z, def.z),
+    Number.isFinite(+src?.x) ? +src.x : def.x,
+    Number.isFinite(+src?.y) ? +src.y : def.y,
+    Number.isFinite(+src?.z) ? +src.z : def.z,
   );
   sanitizeVec3(v, def);
 }


### PR DESCRIPTION
## Summary
- coerce stored numeric values before finite checks so sanitize helpers recover from stringy saves
- guard safeSetVec3 with explicit numeric coercion to avoid propagating NaN into player and camera state
- bump the service worker cache name to v3 so clients fetch the refreshed bundle

## Testing
- npm run build *(fails: missing optional dependency @gltf-transform/core in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68da432a19c083279df61ebc9f0bac27