### PR TITLE
Add arrow key camera look controls

### DIFF
--- a/src/camera/followCamera.js
+++ b/src/camera/followCamera.js
@@ -7,10 +7,12 @@ const desiredPosition = new THREE.Vector3();
 const lookOffset = new THREE.Vector3();
 const cameraForward = new THREE.Vector3();
 
-const MIN_PITCH = THREE.MathUtils.degToRad(-45);
-const MAX_PITCH = THREE.MathUtils.degToRad(70);
-const DEFAULT_YAW_SPEED = 1.6; // radians per second
-const DEFAULT_PITCH_SPEED = 1.2; // radians per second
+const MIN_PITCH = THREE.MathUtils.degToRad(-85);
+const MAX_PITCH = THREE.MathUtils.degToRad(85);
+const DEFAULT_YAW_SPEED = 1.8; // radians per second
+const DEFAULT_PITCH_SPEED = 1.4; // radians per second
+const MAX_DT = 0.25;
+const DEFAULT_DT = 1 / 60;
 
 function computeBaseParameters(offset) {
   const offsetVector = offset.clone();
@@ -102,14 +104,51 @@ export function createFollowCamera(
     return THREE.MathUtils.clamp(scaled, 0, 1);
   };
 
-  const update = (keyboard, deltaSeconds = 0) => {
+  const update = (keyboardState, deltaSeconds = 0) => {
     if (!camera || !currentTarget) {
       return;
     }
 
-    const dt = Number.isFinite(deltaSeconds) ? Math.max(0, deltaSeconds) : 0;
-    const lookX = keyboard?.look?.x ?? 0;
-    const lookY = keyboard?.look?.y ?? 0;
+    const dtRaw = Number.isFinite(deltaSeconds) ? Math.max(0, deltaSeconds) : NaN;
+    const dt = Number.isFinite(dtRaw) ? Math.min(dtRaw, MAX_DT) : DEFAULT_DT;
+
+    let lookX = 0;
+    let lookY = 0;
+
+    const axis = keyboardState?.axis && Object.prototype.hasOwnProperty.call(keyboardState.axis, 'lookX')
+      ? keyboardState.axis
+      : null;
+    const axisLookX = axis ? axis.lookX : undefined;
+    const axisLookY = axis ? axis.lookY : undefined;
+
+    if (Number.isFinite(axisLookX)) {
+      lookX += axisLookX;
+    }
+    if (Number.isFinite(axisLookY)) {
+      lookY += axisLookY;
+    }
+
+    if (keyboardState?.look) {
+      const fallbackLookX = keyboardState.look.x;
+      const fallbackLookY = keyboardState.look.y;
+      if (Number.isFinite(fallbackLookX)) {
+        if (!Number.isFinite(axisLookX) || Math.abs(fallbackLookX - axisLookX) > 1e-6) {
+          lookX += fallbackLookX;
+        }
+      }
+      if (Number.isFinite(fallbackLookY)) {
+        if (!Number.isFinite(axisLookY) || Math.abs(fallbackLookY - axisLookY) > 1e-6) {
+          lookY += fallbackLookY;
+        }
+      }
+    }
+
+    if (!Number.isFinite(yawOffset)) {
+      yawOffset = 0;
+    }
+    if (!Number.isFinite(pitchOffset)) {
+      pitchOffset = 0;
+    }
 
     yawOffset += lookX * options.yawSpeed * dt;
     pitchOffset += lookY * options.pitchSpeed * dt;

--- a/src/entry/initializeAthens.js
+++ b/src/entry/initializeAthens.js
@@ -760,7 +760,7 @@ export async function initializeAthens(options = {}) {
     });
   }
 
-  followCamera.update();
+  followCamera.update(keyboard, 0);
 
   // Resize
   const resizeHandler = () => {
@@ -832,7 +832,7 @@ export async function initializeAthens(options = {}) {
         skippedLargeDt: Boolean(skippedLargeDt)
       });
 
-      followCamera?.update?.();
+      followCamera?.update?.(keyboard, delta);
 
       const activePlayer = findPlayerObject() || playerObject;
       if (activePlayer?.position && !isFiniteVec3(activePlayer.position)) {

--- a/src/input/keyboard.js
+++ b/src/input/keyboard.js
@@ -161,6 +161,18 @@ export function createKeyboard(target = typeof window !== 'undefined' ? window :
       get() {
         return MODIFIER_KEYS.some((code) => isDown(code));
       }
+    },
+    lookX: {
+      enumerable: true,
+      get() {
+        return computeLook().x;
+      }
+    },
+    lookY: {
+      enumerable: true,
+      get() {
+        return computeLook().y;
+      }
     }
   });
 

--- a/tests/keyboard-controls.test.js
+++ b/tests/keyboard-controls.test.js
@@ -52,9 +52,11 @@ test('keyboard normalizes events without code to maintain controls', () => {
   keydown({ key: 'ArrowLeft', code: 'Unidentified' });
   assert.strictEqual(keyboard.isDown('ArrowLeft'), true);
   assert.strictEqual(keyboard.look.x, -1);
+  assert.strictEqual(keyboard.axis.lookX, -1);
 
   keydown({ key: 'ArrowUp', code: undefined });
   assert.strictEqual(keyboard.look.y, 1);
+  assert.strictEqual(keyboard.axis.lookY, 1);
 
   keyup({ key: 'ArrowLeft', code: '' });
   keyup({ key: 'ArrowUp', code: '' });
@@ -66,6 +68,8 @@ test('keyboard normalizes events without code to maintain controls', () => {
   assert.strictEqual(keyboard.axis.running, false);
   assert.strictEqual(keyboard.look.x, 0);
   assert.strictEqual(keyboard.look.y, 0);
+  assert.strictEqual(keyboard.axis.lookX, 0);
+  assert.strictEqual(keyboard.axis.lookY, 0);
 
   keyboard.dispose();
 });


### PR DESCRIPTION
## Summary
- expose keyboard.axis.lookX/lookY mapped to the arrow keys alongside running/strafe axes
- apply the new look axes in the follow camera with dt clamping, ±85° pitch limits, and additive fallbacks
- ensure the Athens init loop passes delta time to the camera and extend keyboard tests for the new axes

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68da54e838c48327b375e982418da532