### PR TITLE
Add manual Pages deploy and tag-triggered release backups

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,44 @@
+name: Deploy Pages
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Git ref to deploy (branch/tag/SHA)
+        required: false
+        default: main
+
+permissions:
+  pages: write
+  id-token: write
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout target ref
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+      - name: Install
+        run: npm ci
+      - name: Build
+        run: GH_PAGES=1 npm run build
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -1,0 +1,47 @@
+name: Release on Tag
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout tag
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+
+      - name: Install
+        run: npm ci
+
+      - name: Build
+        run: GH_PAGES=1 npm run build
+
+      - name: Zip source snapshot
+        run: |
+          git archive -o site-src-${GITHUB_REF_NAME}.zip HEAD
+
+      - name: Zip built site
+        run: |
+          cd dist
+          zip -r ../site-dist-${GITHUB_REF_NAME}.zip .
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
+          draft: false
+          prerelease: false
+          files: |
+            site-src-${{ github.ref_name }}.zip
+            site-dist-${{ github.ref_name }}.zip

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -1,0 +1,22 @@
+# Deploy & Rollback (Athens)
+
+## Checkpoint a known-good build
+```bash
+git tag -a vYYYY.MM.DD-a -m "Checkpoint before changes"
+git push origin vYYYY.MM.DD-a
+```
+
+This auto-creates a GitHub Release with source & built zips (see Releases tab).
+
+## Deploy any ref to Pages
+1. GitHub → Actions → Deploy Pages → Run workflow.
+2. Enter ref (e.g., `main`, `vYYYY.MM.DD-a`, or a commit SHA).
+3. Run → wait for green check → Pages updates.
+
+## Roll back instantly
+Run the Deploy Pages workflow again with the previous tag as the ref.
+No code changes needed.
+
+## Notes
+- Pages must be configured to GitHub Actions under Settings → Pages.
+- `npm run build` must emit to `dist/` (adjust if different).

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "preview": "vite preview",
     "test": "node --test",
     "html:no-ts": "./scripts/check-html-no-ts.sh",
-    "serve:dist": "http-server dist -p 4173 -s"
+    "serve:dist": "http-server dist -p 4173 -s",
+    "tag:checkpoint": "node -e \"const d=new Date();const p=n=>String(n).padStart(2,'0');const v=`v${d.getFullYear()}.${p(d.getMonth()+1)}.${p(d.getDate())}-a`;console.log(v)\" | xargs -I {} git tag -a {} -m \"Checkpoint\" && git push --tags"
   },
   "dependencies": {
     "cannon": "^0.6.2",


### PR DESCRIPTION
## Summary
- add a workflow to deploy GitHub Pages from a manually supplied ref
- create a release workflow that builds on version tags and uploads source/dist archives
- document deploy and rollback steps and add a helper script for checkpoint tagging

## Testing
- not run (workflow changes only)


------
https://chatgpt.com/codex/tasks/task_b_68da56f369c8832789b42dbe81da82cb