### PR TITLE
feat: apply bundled sky panoramas with query param switcher

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -1,7 +1,7 @@
 // ---- service-worker.js ----
 
 // Bump this whenever you change the SW to force an update
-const CACHE_NAME = 'athens-static-v4';
+const CACHE_NAME = 'athens-static-v5';
 
 // Optional pre-cache list (can stay empty for GH Pages)
 const PRECACHE_URLS = [];

--- a/src/engine/safeEntry.js
+++ b/src/engine/safeEntry.js
@@ -1,4 +1,5 @@
 import * as THREE from 'three';
+import { applySky } from '../scene/sky.ts';
 
 export function createSafeScene(canvasSelector = 'canvas') {
   const canvas = typeof document !== 'undefined' ? document.querySelector(canvasSelector) : null;
@@ -6,6 +7,7 @@ export function createSafeScene(canvasSelector = 'canvas') {
   renderer.setPixelRatio(Math.min(typeof window !== 'undefined' ? window.devicePixelRatio : 1, 2));
   renderer.setSize(typeof window !== 'undefined' ? window.innerWidth : 1, typeof window !== 'undefined' ? window.innerHeight : 1, false);
   renderer.setClearColor(0x202834, 1);
+  renderer.setClearAlpha(1);
   renderer.domElement.style.width = '100%';
   renderer.domElement.style.height = '100%';
   renderer.domElement.style.display = 'block';
@@ -16,6 +18,15 @@ export function createSafeScene(canvasSelector = 'canvas') {
   const camera = new THREE.PerspectiveCamera(60, (typeof window !== 'undefined' ? window.innerWidth : 1) / (typeof window !== 'undefined' ? window.innerHeight || 1 : 1), 0.1, 2000);
   camera.position.set(0, 3.5, 7);
   scene.add(camera);
+
+  let skyReady = false;
+  applySky(scene, renderer)
+    .catch((error) => {
+      console.warn('[safeEntry] applySky failed.', error);
+    })
+    .finally(() => {
+      skyReady = true;
+    });
 
   const ambient = new THREE.AmbientLight(0xffffff, 0.35);
   scene.add(ambient);
@@ -53,6 +64,9 @@ export function createSafeScene(canvasSelector = 'canvas') {
   };
 
   const render = () => {
+    if (!skyReady) {
+      return;
+    }
     renderer.render(scene, camera);
   };
 

--- a/src/entry/boot.ts
+++ b/src/entry/boot.ts
@@ -2,6 +2,7 @@ import * as THREE from 'three';
 import { createStats } from '../debug/statsShim.js';
 import { setupGround, updateTrees } from '../main.js';
 import { setEnvironment } from '../scene/sky.js';
+import { applySky } from '../scene/sky.ts';
 import boot from '../core/bootstrap.js';
 import createKeyboard from '../input/keyboard.js';
 import { createPlayerController } from '../player/playerController.js';
@@ -220,6 +221,8 @@ export async function runAthens(options: RunOptions = {}) {
     }
   }
 
+  const skyTask = applySky(scene, renderer);
+
   const audio = new AudioManager(camera, { masterVolume: 0.9 });
 
   const resumeAudioContext = () => {
@@ -302,6 +305,10 @@ export async function runAthens(options: RunOptions = {}) {
       console.warn('[Athens][Boot] setEnvironment failed', error);
     }
   }
+
+  await skyTask.catch((error) => {
+    console.warn('[Athens][Boot] applySky failed', error);
+  });
 
   if (typeof setupGround === 'function') {
     try {

--- a/src/entry/initializeAthens.js
+++ b/src/entry/initializeAthens.js
@@ -14,6 +14,7 @@ import { createFollowCamera } from '../camera/followCamera.js';
 import { createPlayerController } from '../player/playerController.js';
 import { assetUrl } from '../utils/assetUrl.js';
 import { createGameLoop } from '../engine/loop.js';
+import { applySky } from '../scene/sky.ts';
 import { markGround, collectGround } from '../physics/groundRegistry.js';
 import { markColliders, collectColliders, buildAABBs } from '../physics/colliderRegistry.js';
 import { sampleGroundY, snapGroupToGround, snapObjectToGround, snapChildrenToGround } from '../physics/groundProject.js';
@@ -365,6 +366,8 @@ export async function initializeAthens(options = {}) {
     }
   }
 
+  const skyTask = applySky(scene, renderer);
+
   ensureLights(scene);
 
   statsReady
@@ -397,6 +400,10 @@ export async function initializeAthens(options = {}) {
       // placeholder for compatibility
     }
   };
+
+  await skyTask.catch((error) => {
+    console.warn('[Athens] applySky failed.', error);
+  });
 
   await setupGround(scene, renderer);
 

--- a/src/scene/sky.ts
+++ b/src/scene/sky.ts
@@ -1,0 +1,108 @@
+import * as THREE from 'three';
+
+export type SkyChoice = {
+  id: string;
+  type: 'cube' | 'equirect';
+  label: string;
+  dir?: string;
+  faces?: { px: string; nx: string; py: string; ny: string; pz: string; nz: string };
+  file?: string;
+};
+
+// Auto-discovered JPG panoramas available in this repo (scanned under public/assets/sky).
+// These provide ready-to-use photographic skies when served from GitHub Pages or local builds.
+export const SKY_CHOICES: SkyChoice[] = [
+  {
+    id: 'night-sky',
+    type: 'equirect',
+    label: 'Night Sky',
+    file: 'assets/sky/night_sky.jpg'
+  },
+  {
+    id: 'high-noon',
+    type: 'equirect',
+    label: 'High Noon',
+    file: 'assets/sky/high_noon.jpg'
+  },
+  {
+    id: 'golden-hour',
+    type: 'equirect',
+    label: 'Golden Hour',
+    file: 'assets/sky/golden_hour.jpg'
+  }
+];
+
+function setTextureColorSpace(texture: THREE.Texture | THREE.CubeTexture) {
+  if ('colorSpace' in texture) {
+    (texture as THREE.Texture).colorSpace = THREE.SRGBColorSpace;
+  } else {
+    (texture as THREE.Texture).encoding = THREE.sRGBEncoding;
+  }
+}
+
+function baseURL(rel: string) {
+  if (/^https?:\/\//.test(rel)) {
+    return rel;
+  }
+  if (typeof window === 'undefined') {
+    return rel;
+  }
+  const baseHref = typeof document !== 'undefined' ? document.querySelector('base')?.getAttribute('href') : null;
+  const root = baseHref || window.location.pathname.replace(/[^/]*$/, '');
+  return new URL(rel, window.location.origin + root).toString();
+}
+
+export async function applySky(scene: THREE.Scene, renderer: THREE.WebGLRenderer, choice?: string) {
+  const params = typeof window !== 'undefined' ? new URLSearchParams(window.location.search) : null;
+  const id = (params?.get('sky')) || choice;
+  const pick = SKY_CHOICES.find((s) => s.id === id) || SKY_CHOICES[0];
+  if (!pick) {
+    console.warn('[sky] No sky choices found.');
+    return;
+  }
+
+  if (pick.type === 'cube' && pick.dir && pick.faces) {
+    const loader = new THREE.CubeTextureLoader();
+    const order = [pick.faces.px, pick.faces.nx, pick.faces.py, pick.faces.ny, pick.faces.pz, pick.faces.nz]
+      .map((n) => baseURL(`${pick.dir}${n}`));
+    const tex = await new Promise<THREE.CubeTexture>((resolve, reject) =>
+      loader.load(order, resolve, undefined, reject)
+    );
+    setTextureColorSpace(tex);
+    scene.background = tex;
+    const pmrem = new THREE.PMREMGenerator(renderer);
+    const env = pmrem.fromCubemap(tex).texture;
+    scene.environment = env;
+    pmrem.dispose();
+    if (typeof window !== 'undefined') {
+      (window as typeof window & { __athensDebug?: any }).__athensDebug = {
+        ...(window as typeof window & { __athensDebug?: any }).__athensDebug,
+        sky: { type: 'cube', id: pick.id, files: order }
+      };
+    }
+    return;
+  }
+
+  if (pick.type === 'equirect' && pick.file) {
+    const loader = new THREE.TextureLoader();
+    const tex = await new Promise<THREE.Texture>((resolve, reject) =>
+      loader.load(baseURL(pick.file!), resolve, undefined, reject)
+    );
+    tex.mapping = THREE.EquirectangularReflectionMapping;
+    setTextureColorSpace(tex);
+    scene.background = tex;
+    const pmrem = new THREE.PMREMGenerator(renderer);
+    const env = pmrem.fromEquirectangular(tex).texture;
+    scene.environment = env;
+    pmrem.dispose();
+    if (typeof window !== 'undefined') {
+      (window as typeof window & { __athensDebug?: any }).__athensDebug = {
+        ...(window as typeof window & { __athensDebug?: any }).__athensDebug,
+        sky: { type: 'equirect', id: pick.id, file: baseURL(pick.file!) }
+      };
+    }
+    return;
+  }
+
+  console.warn('[sky] Invalid sky choice config:', pick);
+}


### PR DESCRIPTION
## Summary
- add a sky loader module that catalogs the checked-in JPG panoramas and loads them as cube/equirect textures
- wire the loader into the boot, initializeAthens, and safe entry paths so ?sky=<id> works and scene.environment is set
- bump the service worker cache version to invalidate cached assets

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68da57e1cb5c832794d1c4745761c6f4