### PR TITLE
Fix fly controls and load sky JPG backgrounds

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -1,7 +1,7 @@
 // ---- service-worker.js ----
 
 // Bump this whenever you change the SW to force an update
-const CACHE_NAME = 'athens-static-v5';
+const CACHE_NAME = 'athens-static-v6';
 
 // Optional pre-cache list (can stay empty for GH Pages)
 const PRECACHE_URLS = [];

--- a/src/player/playerController.js
+++ b/src/player/playerController.js
@@ -110,6 +110,9 @@ export function createPlayerController(
       if (isFlying) {
         physicsState.vy = 0;
       }
+      if (typeof console !== 'undefined' && typeof console.info === 'function') {
+        console.info(`[playerController] KeyX pressed. Fly mode ${isFlying ? 'enabled' : 'disabled'}.`);
+      }
     }
     prevFlyKeyDown = flyKeyDown;
     if (
@@ -181,6 +184,7 @@ export function createPlayerController(
       if (ascend) vy += verticalSpeed;
       if (descend) vy -= verticalSpeed;
       targetVelocity.y = vy;
+      physicsState.vy = 0;
     } else {
       targetVelocity.y = 0;
     }
@@ -189,6 +193,9 @@ export function createPlayerController(
     const accel = Number.isFinite(acceleration) ? Math.max(acceleration, 0) : 10;
     const lerpAlpha = accel > 0 && dt > 0 ? 1 - Math.exp(-accel * dt) : 1;
     velocity.lerp(targetVelocity, THREE.MathUtils.clamp(lerpAlpha, 0, 1));
+    if (isFlying) {
+      velocity.y = targetVelocity.y;
+    }
 
     // Integrate horizontal motion
     capsule.setPosition(

--- a/src/scene/sky.ts
+++ b/src/scene/sky.ts
@@ -9,26 +9,44 @@ export type SkyChoice = {
   file?: string;
 };
 
-// Auto-discovered JPG panoramas available in this repo (scanned under public/assets/sky).
+// Auto-discovered JPG panoramas available in this repo (scanned under assets/sky).
 // These provide ready-to-use photographic skies when served from GitHub Pages or local builds.
 export const SKY_CHOICES: SkyChoice[] = [
   {
-    id: 'night-sky',
+    id: 'day',
     type: 'equirect',
-    label: 'Night Sky',
-    file: 'assets/sky/night_sky.jpg'
+    label: 'Daytime',
+    file: 'assets/sky/day.jpg'
   },
   {
-    id: 'high-noon',
+    id: 'dawn',
     type: 'equirect',
-    label: 'High Noon',
-    file: 'assets/sky/high_noon.jpg'
+    label: 'Dawn',
+    file: 'assets/sky/dawn.jpg'
   },
   {
-    id: 'golden-hour',
+    id: 'dusk',
     type: 'equirect',
-    label: 'Golden Hour',
-    file: 'assets/sky/golden_hour.jpg'
+    label: 'Dusk',
+    file: 'assets/sky/dusk.jpg'
+  },
+  {
+    id: 'blue-hour',
+    type: 'equirect',
+    label: 'Blue Hour',
+    file: 'assets/sky/blue_hour.jpg'
+  },
+  {
+    id: 'night',
+    type: 'equirect',
+    label: 'Night',
+    file: 'assets/sky/night.jpg'
+  },
+  {
+    id: 'night-4k',
+    type: 'equirect',
+    label: 'Night (4K)',
+    file: 'assets/sky/night_sky_4k.jpg'
   }
 ];
 


### PR DESCRIPTION
## Audit
- Keyboard input is handled in `src/input/keyboard.js`; it tracks a `Set` of pressed codes and exposes derived `axis` getters for `KeyWASD`, arrow keys, modifiers (`ShiftLeft/Right`), and extras (`Space`, `KeyX`, `KeyC`, `KeyE`, `KeyQ`, `KeyZ`, `ControlLeft/Right`).
- `createPlayerController` in `src/player/playerController.js` already owns an `isFlying` flag and is updated every frame via `playerController.update(delta, camera)` inside the render loop in `src/entry/boot.ts` before the scene is rendered.
- Before the fix, the fly toggle path lacked any logging and vertical motion was filtered through the ground-movement acceleration lerp, which made the vertical controls unresponsive while gravity state lingered in `physicsState.vy`.
- Sky backgrounds are loaded through `src/scene/sky.ts`; the repo actually contains equirectangular JPGs in `assets/sky/{day,dawn,dusk,blue_hour,night,night_sky_4k}.jpg` that need to be referenced with subpath-safe URLs.
- A service worker (`service-worker.js`) is registered with cache name `athens-static-v5`, so the cache needs bumping after asset/script changes.

## Summary
- Hardened the fly toggle to log `KeyX` activations, keep gravity cleared while airborne, and apply immediate vertical velocity for Space/E and Ctrl/C/Q inputs without ground snapping.
- Replaced placeholder sky configuration with the repo’s actual JPG panoramas and continued to apply them as the scene background/environment using base-aware URLs.
- Bumped the service-worker cache version so the updated controls and sky assets deploy cleanly.

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68da5e72de8c832789430caa1fe446f5