### PR TITLE
Fix fly controls and load bundled sky textures

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -1,7 +1,7 @@
 // ---- service-worker.js ----
 
 // Bump this whenever you change the SW to force an update
-const CACHE_NAME = 'athens-static-v5';
+const CACHE_NAME = 'athens-static-v6';
 
 // Optional pre-cache list (can stay empty for GH Pages)
 const PRECACHE_URLS = [];

--- a/src/player/playerController.js
+++ b/src/player/playerController.js
@@ -110,6 +110,9 @@ export function createPlayerController(
       if (isFlying) {
         physicsState.vy = 0;
       }
+      if (typeof window !== 'undefined') {
+        console.debug('[controls] Fly toggle', isFlying ? 'ENABLED' : 'DISABLED');
+      }
     }
     prevFlyKeyDown = flyKeyDown;
     if (
@@ -189,6 +192,11 @@ export function createPlayerController(
     const accel = Number.isFinite(acceleration) ? Math.max(acceleration, 0) : 10;
     const lerpAlpha = accel > 0 && dt > 0 ? 1 - Math.exp(-accel * dt) : 1;
     velocity.lerp(targetVelocity, THREE.MathUtils.clamp(lerpAlpha, 0, 1));
+    if (isFlying) {
+      velocity.y = targetVelocity.y;
+    } else {
+      velocity.y = 0;
+    }
 
     // Integrate horizontal motion
     capsule.setPosition(

--- a/src/scene/sky.ts
+++ b/src/scene/sky.ts
@@ -7,28 +7,66 @@ export type SkyChoice = {
   dir?: string;
   faces?: { px: string; nx: string; py: string; ny: string; pz: string; nz: string };
   file?: string;
+  aliases?: string[];
 };
 
 // Auto-discovered JPG panoramas available in this repo (scanned under public/assets/sky).
 // These provide ready-to-use photographic skies when served from GitHub Pages or local builds.
 export const SKY_CHOICES: SkyChoice[] = [
   {
-    id: 'night-sky',
+    id: 'day',
     type: 'equirect',
-    label: 'Night Sky',
-    file: 'assets/sky/night_sky.jpg'
+    label: 'Sunny Day',
+    file: 'assets/sky/day.jpg',
+    aliases: ['sunny-day', 'daytime', 'high-noon']
   },
   {
     id: 'high-noon',
     type: 'equirect',
     label: 'High Noon',
-    file: 'assets/sky/high_noon.jpg'
+    file: 'assets/sky/high_noon.jpg',
+    aliases: ['noon', 'midday']
   },
   {
     id: 'golden-hour',
     type: 'equirect',
     label: 'Golden Hour',
-    file: 'assets/sky/golden_hour.jpg'
+    file: 'assets/sky/golden_hour.jpg',
+    aliases: ['sunset', 'dusk', 'golden-hour']
+  },
+  {
+    id: 'blue-hour',
+    type: 'equirect',
+    label: 'Blue Hour',
+    file: 'assets/sky/blue_hour.jpg'
+  },
+  {
+    id: 'dawn',
+    type: 'equirect',
+    label: 'Dawn',
+    file: 'assets/sky/dawn.jpg',
+    aliases: ['sunrise']
+  },
+  {
+    id: 'dusk',
+    type: 'equirect',
+    label: 'Dusk',
+    file: 'assets/sky/dusk.jpg',
+    aliases: ['evening']
+  },
+  {
+    id: 'night',
+    type: 'equirect',
+    label: 'Night Sky',
+    file: 'assets/sky/night_sky.jpg',
+    aliases: ['night-sky', 'starlit-night']
+  },
+  {
+    id: 'night-4k',
+    type: 'equirect',
+    label: 'Night Sky (4K)',
+    file: 'assets/sky/night_sky_4k.jpg',
+    aliases: ['night-hires', 'night_sky_4k']
   }
 ];
 
@@ -44,18 +82,47 @@ function baseURL(rel: string) {
   if (/^https?:\/\//.test(rel)) {
     return rel;
   }
-  if (typeof window === 'undefined') {
-    return rel;
+
+  const sanitized = rel.replace(/^\/+/, '');
+
+  if (typeof document !== 'undefined' && typeof document.baseURI === 'string') {
+    return new URL(sanitized, document.baseURI).toString();
   }
-  const baseHref = typeof document !== 'undefined' ? document.querySelector('base')?.getAttribute('href') : null;
-  const root = baseHref || window.location.pathname.replace(/[^/]*$/, '');
-  return new URL(rel, window.location.origin + root).toString();
+
+  const baseFromImport = (import.meta as any)?.env?.BASE_URL;
+  if (typeof baseFromImport === 'string' && baseFromImport.length > 0) {
+    if (/^https?:\/\//.test(baseFromImport)) {
+      return new URL(sanitized, baseFromImport).toString();
+    }
+    const normalized = baseFromImport.endsWith('/') ? baseFromImport : `${baseFromImport}/`;
+    return `${normalized}${sanitized}`.replace(/^\/+/, '/');
+  }
+
+  if (typeof window !== 'undefined') {
+    const root = window.location.pathname.replace(/[^/]*$/, '');
+    return new URL(sanitized, window.location.origin + root).toString();
+  }
+
+  return sanitized;
 }
 
 export async function applySky(scene: THREE.Scene, renderer: THREE.WebGLRenderer, choice?: string) {
   const params = typeof window !== 'undefined' ? new URLSearchParams(window.location.search) : null;
-  const id = (params?.get('sky')) || choice;
-  const pick = SKY_CHOICES.find((s) => s.id === id) || SKY_CHOICES[0];
+  const normalize = (value?: string | null) =>
+    value && typeof value === 'string'
+      ? value.trim().toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '')
+      : null;
+  const requested = normalize(params?.get('sky') || choice || undefined);
+  const pick =
+    SKY_CHOICES.find((s) => {
+      const baseId = normalize(s.id);
+      if (requested && baseId === requested) {
+        return true;
+      }
+      return requested
+        ? s.aliases?.some((alias) => normalize(alias) === requested)
+        : false;
+    }) || SKY_CHOICES[0];
   if (!pick) {
     console.warn('[sky] No sky choices found.');
     return;


### PR DESCRIPTION
## Summary
- make the fly toggle emit a debug log and apply immediate vertical velocity so the capsule can climb/descend while X toggles flight state
- list the photographic JPG skies that live in `public/assets/sky/`, add alias matching, and harden the base URL helper so the loader works on GitHub Pages subpaths while wiring the textures into the background/environment
- bump the service-worker cache so browsers fetch the updated flight controller and sky assets

## Testing
- not run (not requested)

## Audit
- Keyboard input lives in `src/input/keyboard.js`; it tracks movement/extra keys including `KeyX`, `Space`, `KeyE`, `KeyQ`, `KeyC`, and both Control keys, exposing getters for `axis`/`isDown`
- `createPlayerController` in `src/player/playerController.js` already held an internal `isFlying` toggle (switched by `KeyX`), zeroed `moveDelta.y` when grounded, and only called `snapToGround` when not flying
- `controller.update(delta, camera)` runs each frame from `initializeAthens` (skipped only when `skippedLargeDt` is true), so flight state and motion are evaluated per frame
- Real sky panoramas ship under `public/assets/sky/` (day, dawn, dusk, blue_hour, golden_hour, night_sky, night_sky_4k, etc.), and `applySky(scene, renderer)` is invoked during boot before the main scene loads
- A service worker caches static assets using the `athens-static-v5` bucket before this change

------
https://chatgpt.com/codex/tasks/task_b_68da5f9030208327b260cc5ee08d91ab