### PR TITLE
Implement WASD strafe controls with pointer-lock mouse look

### DIFF
--- a/src/camera/followCamera.js
+++ b/src/camera/followCamera.js
@@ -9,10 +9,11 @@ const cameraForward = new THREE.Vector3();
 
 const MIN_PITCH = THREE.MathUtils.degToRad(-85);
 const MAX_PITCH = THREE.MathUtils.degToRad(85);
-const DEFAULT_YAW_SPEED = 1.8; // radians per second
-const DEFAULT_PITCH_SPEED = 1.4; // radians per second
+const DEFAULT_YAW_SPEED = 2.0; // radians per second
+const DEFAULT_PITCH_SPEED = 1.6; // radians per second
 const MAX_DT = 0.25;
 const DEFAULT_DT = 1 / 60;
+const MOUSE_SENSITIVITY = 0.0018;
 
 function computeBaseParameters(offset) {
   const offsetVector = offset.clone();
@@ -57,6 +58,15 @@ export function createFollowCamera(
   let yawOffset = 0;
   let pitchOffset = 0;
   let cachedTargetYaw = 0;
+  let pointerElement = null;
+  let accumulatedMouseDX = 0;
+  let accumulatedMouseDY = 0;
+  let handlePointerMove = null;
+  let handlePointerLockChange = null;
+  let handleClick = null;
+
+  const browserWindow = typeof window !== 'undefined' ? window : null;
+  const browserDocument = typeof document !== 'undefined' ? document : null;
 
   const getTargetYaw = () => {
     if (!currentTarget) {
@@ -104,6 +114,66 @@ export function createFollowCamera(
     return THREE.MathUtils.clamp(scaled, 0, 1);
   };
 
+  const detachPointerLock = () => {
+    if (pointerElement && handleClick && pointerElement.removeEventListener) {
+      pointerElement.removeEventListener('click', handleClick);
+    }
+    if (browserWindow && handlePointerMove) {
+      browserWindow.removeEventListener('mousemove', handlePointerMove);
+    }
+    if (browserDocument && handlePointerLockChange) {
+      browserDocument.removeEventListener('pointerlockchange', handlePointerLockChange);
+    }
+    pointerElement = null;
+    handleClick = null;
+    handlePointerMove = null;
+    handlePointerLockChange = null;
+    accumulatedMouseDX = 0;
+    accumulatedMouseDY = 0;
+  };
+
+  const applyPointerLockElement = (element) => {
+    if (pointerElement === element) {
+      return;
+    }
+    detachPointerLock();
+    if (!element || typeof element.addEventListener !== 'function') {
+      return;
+    }
+    pointerElement = element;
+    handleClick = () => {
+      if (pointerElement && typeof pointerElement.requestPointerLock === 'function') {
+        pointerElement.requestPointerLock();
+      } else if (pointerElement && pointerElement.requestPointerLock) {
+        try {
+          pointerElement.requestPointerLock();
+        } catch {
+          // ignore errors from browsers without pointer lock
+        }
+      }
+    };
+    pointerElement.addEventListener('click', handleClick);
+
+    handlePointerMove = (event) => {
+      if (!browserDocument || browserDocument.pointerLockElement !== pointerElement) {
+        return;
+      }
+      const movementX = Number.isFinite(event?.movementX) ? event.movementX : 0;
+      const movementY = Number.isFinite(event?.movementY) ? event.movementY : 0;
+      if (movementX) accumulatedMouseDX += movementX;
+      if (movementY) accumulatedMouseDY += movementY;
+    };
+    browserWindow?.addEventListener?.('mousemove', handlePointerMove);
+
+    handlePointerLockChange = () => {
+      if (!browserDocument || browserDocument.pointerLockElement !== pointerElement) {
+        accumulatedMouseDX = 0;
+        accumulatedMouseDY = 0;
+      }
+    };
+    browserDocument?.addEventListener?.('pointerlockchange', handlePointerLockChange);
+  };
+
   const update = (keyboardState, deltaSeconds = 0) => {
     if (!camera || !currentTarget) {
       return;
@@ -111,6 +181,7 @@ export function createFollowCamera(
 
     const dtRaw = Number.isFinite(deltaSeconds) ? Math.max(0, deltaSeconds) : NaN;
     const dt = Number.isFinite(dtRaw) ? Math.min(dtRaw, MAX_DT) : DEFAULT_DT;
+    const dtSafe = Number.isFinite(dt) ? dt : DEFAULT_DT;
 
     let lookX = 0;
     let lookY = 0;
@@ -150,9 +221,17 @@ export function createFollowCamera(
       pitchOffset = 0;
     }
 
-    yawOffset += lookX * options.yawSpeed * dt;
-    pitchOffset += lookY * options.pitchSpeed * dt;
+    if (accumulatedMouseDX !== 0 || accumulatedMouseDY !== 0) {
+      yawOffset += accumulatedMouseDX * MOUSE_SENSITIVITY;
+      pitchOffset -= accumulatedMouseDY * MOUSE_SENSITIVITY;
+      accumulatedMouseDX = 0;
+      accumulatedMouseDY = 0;
+    }
+
+    yawOffset += lookX * options.yawSpeed * dtSafe;
+    pitchOffset += lookY * options.pitchSpeed * dtSafe;
     pitchOffset = THREE.MathUtils.clamp(pitchOffset, pitchMin, pitchMax);
+    yawOffset = wrapAngle(yawOffset);
 
     const lerpAlpha = computeLerpAlpha(dt);
     computeDesired(desiredPosition);
@@ -202,7 +281,13 @@ export function createFollowCamera(
     update,
     setTarget,
     syncImmediate,
-    options
+    options,
+    setPointerLockElement(element) {
+      applyPointerLockElement(element);
+    },
+    get target() {
+      return currentTarget;
+    }
   };
 }
 

--- a/src/entry/boot.ts
+++ b/src/entry/boot.ts
@@ -508,6 +508,7 @@ export async function runAthens(options: RunOptions = {}) {
     lerp: 0.12,
     lookAtOffset: new THREE.Vector3(0, 1.5, 0)
   });
+  followCamera.setPointerLockElement?.(renderer.domElement);
   followCamera.syncImmediate?.();
   if ((followCamera as any)?.target) {
     sanitizeVec3((followCamera as any).target, DEFAULT_PLAYER);
@@ -708,6 +709,7 @@ export async function runAthens(options: RunOptions = {}) {
       footsteps.dispose?.();
       audio.stopAll?.();
       renderer.dispose?.();
+      followCamera.setPointerLockElement?.(null);
     }
   };
 

--- a/src/entry/initializeAthens.js
+++ b/src/entry/initializeAthens.js
@@ -615,6 +615,7 @@ export async function initializeAthens(options = {}) {
     lerp: 0.12,
     lookAtOffset: new THREE.Vector3(0, 1.5, 0)
   });
+  followCamera.setPointerLockElement?.(renderer.domElement);
 
   followCamera.syncImmediate?.();
   const initialFollowTarget = followCamera && followCamera.target;
@@ -951,6 +952,7 @@ export async function initializeAthens(options = {}) {
       keyboard?.dispose?.();
       city?.dispose?.();
       extendedCity?.dispose?.();
+      followCamera.setPointerLockElement?.(null);
     }
   };
 

--- a/src/input/keyboard.js
+++ b/src/input/keyboard.js
@@ -97,19 +97,18 @@ export function createKeyboard(target = typeof window !== 'undefined' ? window :
     let x = 0;
     let z = 0;
 
-    if (isDown('KeyA')) {
-      x -= 1;
-    }
     if (isDown('KeyD')) {
       x += 1;
     }
-    const turn = x;
-
-    if (isDown('KeyW')) {
-      z -= 1;
+    if (isDown('KeyA')) {
+      x -= 1;
     }
+
     if (isDown('KeyS')) {
       z += 1;
+    }
+    if (isDown('KeyW')) {
+      z -= 1;
     }
 
     if (x !== 0 && z !== 0) {
@@ -119,7 +118,7 @@ export function createKeyboard(target = typeof window !== 'undefined' ? window :
 
     axisVector.x = x;
     axisVector.z = z;
-    axisVector.turn = turn;
+    axisVector.turn = 0;
     return axisVector;
   };
 

--- a/src/player/playerController.js
+++ b/src/player/playerController.js
@@ -11,10 +11,12 @@ const horizontalVector = new THREE.Vector3();
 const FORWARD = new THREE.Vector3(0, 0, 1);
 const moveDelta = new THREE.Vector3();
 const actualMove = new THREE.Vector3();
+const rightVector = new THREE.Vector3();
+const viewDirection = new THREE.Vector3();
+const desiredMove = new THREE.Vector3();
+const UP = new THREE.Vector3(0, 1, 0);
 
-const TURN_SPEED = 2.2;
 const TURN_ACCEL = 12;
-const TURN_DAMP = 10;
 
 function deriveYaw(object3d) {
   if (!object3d) return 0;
@@ -49,7 +51,6 @@ export function createPlayerController(
   };
 
   let yaw = deriveYaw(controlledObject);
-  let angularVelocity = 0;
   let runningState = false;
   let isFlying = false;
   let prevFlyKeyDown = false;
@@ -87,7 +88,6 @@ export function createPlayerController(
     physicsState.vy = 0;
     physicsState.lastGoodY = controlledObject.position?.y ?? 0;
     yaw = deriveYaw(controlledObject);
-    angularVelocity = 0;
     capsule.setPosition(
       controlledObject.position.x,
       controlledObject.position.y,
@@ -140,44 +140,75 @@ export function createPlayerController(
     const dt = Number.isFinite(dtRaw) ? Math.min(dtRaw, 0.25) : 0;
     const dtSafe = Number.isFinite(dtRaw) ? dt : 1 / 60;
 
-    // Turn control (yaw)
-    const turnInputRaw = currentKeyboard.axis?.turn;
-    const turnInput = Number.isFinite(turnInputRaw) ? turnInputRaw : 0;
-    const targetAngularVelocity = turnInput * TURN_SPEED;
-    const turnLerpAlpha = 1 - Math.exp(-TURN_ACCEL * dtSafe);
-    angularVelocity += (targetAngularVelocity - angularVelocity) * turnLerpAlpha;
-    angularVelocity *= Math.exp(-TURN_DAMP * dtSafe);
-    if (!Number.isFinite(angularVelocity)) angularVelocity = 0;
-
-    yaw += angularVelocity * dtSafe;
-    if (!Number.isFinite(yaw)) {
-      yaw = 0;
-    } else {
-      yaw = THREE.MathUtils.euclideanModulo(yaw + Math.PI, Math.PI * 2) - Math.PI;
-    }
-
-    // Input (forward/back)
-    const axisZ = currentKeyboard.axis?.z || 0;
-    const hasMoveInput = axisZ !== 0;
+    const axisXRaw = currentKeyboard.axis?.x;
+    const axisZRaw = currentKeyboard.axis?.z;
+    const axisX = Number.isFinite(axisXRaw) ? axisXRaw : 0;
+    const axisZ = Number.isFinite(axisZRaw) ? axisZRaw : 0;
+    const hasMoveInput = Math.abs(axisX) > 1e-3 || Math.abs(axisZ) > 1e-3;
 
     // Speed target
     const shiftDown = Boolean(currentKeyboard.axis?.running);
     const effectiveRunMultiplier = shiftDown ? Math.max(runMultiplier, 1) : 1;
     const baseSpeed = Number.isFinite(walkSpeed) ? walkSpeed : 4.0;
-    const targetSpeed = hasMoveInput ? baseSpeed * effectiveRunMultiplier : 0;
-    const verticalSpeed = baseSpeed * effectiveRunMultiplier;
-    runningState = hasMoveInput && shiftDown && targetSpeed > baseSpeed;
+    const speed = baseSpeed * effectiveRunMultiplier;
+    const targetSpeed = hasMoveInput ? speed : 0;
+    const verticalSpeed = speed;
+    runningState = hasMoveInput && shiftDown && speed > baseSpeed;
 
     targetVelocity.set(0, 0, 0);
+    let desiredYaw = yaw;
     if (hasMoveInput) {
-      moveDirection.set(Math.sin(yaw), 0, Math.cos(yaw));
+      if (typeof camera.getWorldDirection === 'function') {
+        camera.getWorldDirection(viewDirection);
+      } else {
+        viewDirection.set(0, 0, -1);
+      }
+      viewDirection.y = 0;
+      if (viewDirection.lengthSq() < 1e-6) {
+        viewDirection.set(0, 0, -1);
+      } else {
+        viewDirection.normalize();
+      }
+
+      moveDirection.copy(viewDirection).negate();
       if (moveDirection.lengthSq() < 1e-6) {
         moveDirection.set(0, 0, 1);
       } else {
         moveDirection.normalize();
       }
-      const forwardMagnitude = THREE.MathUtils.clamp(-axisZ, -1, 1);
-      targetVelocity.addScaledVector(moveDirection, forwardMagnitude * targetSpeed);
+
+      rightVector.crossVectors(UP, moveDirection);
+      if (rightVector.lengthSq() < 1e-6) {
+        rightVector.set(1, 0, 0);
+      } else {
+        rightVector.normalize();
+      }
+
+      desiredMove.set(0, 0, 0);
+      const forwardInput = THREE.MathUtils.clamp(-axisZ, -1, 1);
+      const strafeInput = THREE.MathUtils.clamp(axisX, -1, 1);
+      desiredMove
+        .addScaledVector(moveDirection, forwardInput)
+        .addScaledVector(rightVector, strafeInput);
+
+      const desiredLengthSq = desiredMove.lengthSq();
+      if (desiredLengthSq > 1e-6) {
+        desiredMove.normalize().multiplyScalar(targetSpeed);
+        targetVelocity.copy(desiredMove);
+        desiredYaw = Math.atan2(desiredMove.x, desiredMove.z);
+      }
+    }
+
+    if (Number.isFinite(desiredYaw)) {
+      const yawDelta = THREE.MathUtils.euclideanModulo(desiredYaw - yaw + Math.PI, Math.PI * 2) - Math.PI;
+      const yawLerp = 1 - Math.exp(-TURN_ACCEL * dtSafe);
+      yaw += yawDelta * yawLerp;
+    }
+
+    if (!Number.isFinite(yaw)) {
+      yaw = 0;
+    } else {
+      yaw = THREE.MathUtils.euclideanModulo(yaw + Math.PI, Math.PI * 2) - Math.PI;
     }
 
     let flyVerticalVelocity = 0;
@@ -237,10 +268,9 @@ export function createPlayerController(
       debugLogTime += dtSafe;
       if (debugLogTime <= 2) {
         console.log('[controls]', {
-          turn: turnInput,
+          x: axisX,
           z: axisZ,
-          yaw,
-          angVel: angularVelocity
+          yaw
         });
       }
     }


### PR DESCRIPTION
## Summary
- Audit: keyboard axis.x previously drove turning while axis.z handled forward/back, the player controller consumed axis.turn for yaw while the follow camera tracked yaw/pitch offsets without pointer lock, and the frame loop wires keyboard input through the controller and camera each frame
- Remap the keyboard axes so WASD provides strafe/forward movement, keep run/jump/crouch bindings, and expose arrow-key look axes alongside run state
- Add pointer-lock mouse look with yaw/pitch clamping, include arrow-key look fallback, and update the player controller to move relative to camera yaw while preserving fly/gravity behaviour; register and tear down pointer lock in both entry paths

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68da6ec24c2c8327bf795163ffc12bcf