### PR TITLE
Normalize fallback keyboard aliases for AZERTY

### DIFF
--- a/src/input/keyboard.js
+++ b/src/input/keyboard.js
@@ -25,6 +25,8 @@ const KEY_FALLBACK_MAP = new Map([
   ['a', 'KeyA'],
   ['s', 'KeyS'],
   ['d', 'KeyD'],
+  ['z', 'KeyW'],
+  ['q', 'KeyA'],
   ['arrowup', 'ArrowUp'],
   ['arrowdown', 'ArrowDown'],
   ['arrowleft', 'ArrowLeft'],
@@ -35,8 +37,6 @@ const KEY_FALLBACK_MAP = new Map([
   ['x', 'KeyX'],
   ['c', 'KeyC'],
   ['e', 'KeyE'],
-  ['q', 'KeyQ'],
-  ['z', 'KeyZ'],
   ['shift', 'ShiftLeft'],
   ['control', 'ControlLeft']
 ]);

--- a/tests/keyboard-controls.test.js
+++ b/tests/keyboard-controls.test.js
@@ -73,3 +73,28 @@ test('keyboard normalizes events without code to maintain controls', () => {
 
   keyboard.dispose();
 });
+
+test('keyboard maps azerty movement aliases without triggering descend', () => {
+  const target = createMockTarget();
+  const keyboard = createKeyboard(target);
+  const keydown = target.listeners.get('keydown');
+  const keyup = target.listeners.get('keyup');
+
+  keydown({ key: 'z' });
+  assert.strictEqual(keyboard.isDown('KeyW'), true);
+  assert.strictEqual(keyboard.axis.z, -1);
+
+  keyup({ key: 'z' });
+  assert.strictEqual(keyboard.axis.z, 0);
+
+  keydown({ key: 'q' });
+  assert.strictEqual(keyboard.isDown('KeyA'), true);
+  assert.strictEqual(keyboard.axis.x, -1);
+  assert.strictEqual(keyboard.isDown('KeyQ'), false);
+
+  keyup({ key: 'q' });
+
+  assert.strictEqual(keyboard.axis.x, 0);
+
+  keyboard.dispose();
+});


### PR DESCRIPTION
## Summary
- update the keyboard fallback map so layout-dependent keys like `z` and `q` register the same movement axes as `KeyW`/`KeyA`
- add a regression test covering AZERTY-style input without `event.code`, ensuring the fallback does not trigger flying descent

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68da7fc7847c8327ac1955894bd434cc