### PR TITLE
Fix ground layer render ordering

### DIFF
--- a/src/ground/dirt.js
+++ b/src/ground/dirt.js
@@ -139,6 +139,7 @@ export function createDirtGround({
   const mesh = new THREE.Mesh(geo, mat);
   applyDoubleSidedGroundSupport(mesh);
   mesh.receiveShadow = receiveShadow;
+  mesh.renderOrder = 0;
 
   group.add(mesh);
   return group;


### PR DESCRIPTION
## Summary
- Audit: `createGroundLayered` composes layered dirt/grass tiles; `createDirtGround` builds the base plane at height 0 with polygon offset 1/1 but no render order, while `createGrassGround` lifts the plane to at least 0.02 with renderOrder 1 and no polygon offset.
- Set the dirt mesh renderOrder to 0 so the base layer draws beneath the grass without flicker.

## Testing
- Not run (not requested).

------
https://chatgpt.com/codex/tasks/task_b_68da810fb76483279cb6d1f37f2feb62