### PR TITLE
Fix forward movement direction

### DIFF
--- a/src/player/playerController.js
+++ b/src/player/playerController.js
@@ -170,7 +170,7 @@ export function createPlayerController(
         viewDirection.normalize();
       }
 
-      moveDirection.copy(viewDirection).negate();
+      moveDirection.copy(viewDirection);
       if (moveDirection.lengthSq() < 1e-6) {
         moveDirection.set(0, 0, 1);
       } else {


### PR DESCRIPTION
## Summary
- align the player's forward movement direction with the camera heading so pressing W no longer causes the avatar to spin

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68da820bb898832791dd8b549101086f