### PR TITLE
fix: prevent ground tile seams and stabilize overlaps

### DIFF
--- a/src/ground/dirt.js
+++ b/src/ground/dirt.js
@@ -9,6 +9,7 @@ import { applyDoubleSidedGroundSupport } from './double-sided.js';
 const textureLoader = new THREE.TextureLoader();
 let cachedBaseTexture = null;
 const pendingTextureUpdates = new Set();
+const TILE_SEAM_EPSILON = 0.01;
 
 function flushPendingTextureUpdates(baseTexture) {
   if (pendingTextureUpdates.size === 0) return;
@@ -105,13 +106,19 @@ export function createDirtGround({
   height = 0,
   receiveShadow = true,
   anisotropy = 8,
+  expandForSeams = false,
+  heightBias = 0,
 } = {}) {
   const group = new THREE.Group();
   group.name = 'ground:dirt';
 
-  const geo = new THREE.PlaneGeometry(size, size, 1, 1);
+  const baseSize = Math.max(typeof size === 'number' ? size : 200, 0);
+  const geometrySize = expandForSeams ? baseSize + TILE_SEAM_EPSILON * 2 : baseSize;
+  const geo = new THREE.PlaneGeometry(geometrySize, geometrySize, 1, 1);
   geo.rotateX(-Math.PI / 2);
-  geo.translate(0, height, 0);
+  const finalHeight = typeof height === 'number' ? height : 0;
+  const finalBias = typeof heightBias === 'number' ? heightBias : 0;
+  geo.translate(0, finalHeight + finalBias, 0);
 
   const color = configureTexture(loadBaseTexture(), { repeat, anisotropy });
 

--- a/src/ground/grass.js
+++ b/src/ground/grass.js
@@ -9,6 +9,7 @@ import { applyDoubleSidedGroundSupport } from './double-sided.js';
 const textureLoader = new THREE.TextureLoader();
 let cachedBaseTexture = null;
 const pendingTextureUpdates = new Set();
+const TILE_SEAM_EPSILON = 0.01;
 
 function flushPendingTextureUpdates(baseTexture) {
   if (pendingTextureUpdates.size === 0) return;
@@ -105,11 +106,14 @@ export function createGrassGround({
   height = 0.02,           // slight offset so it doesn’t z-fight with dirt if overlapped
   receiveShadow = true,
   anisotropy = 8,
+  expandForSeams = false,
 } = {}) {
   const group = new THREE.Group();
   group.name = 'ground:grass';
 
-  const geo = new THREE.PlaneGeometry(size, size, 1, 1);
+  const baseSize = Math.max(typeof size === 'number' ? size : 200, 0);
+  const geometrySize = expandForSeams ? baseSize + TILE_SEAM_EPSILON * 2 : baseSize;
+  const geo = new THREE.PlaneGeometry(geometrySize, geometrySize, 1, 1);
   geo.rotateX(-Math.PI / 2);
   const finalHeight = Math.max(typeof height === 'number' ? height : 0.02, 0.02);
   geo.translate(0, finalHeight, 0);

--- a/src/ground/index.js
+++ b/src/ground/index.js
@@ -71,6 +71,8 @@ function createGridTiles({
         position: new THREE.Vector3(x, 0, z),
         enableDirt: true,
         enableGrass: true,
+        gridX: col,
+        gridZ: row,
       });
     }
   }
@@ -105,6 +107,8 @@ function normalizeTile(tile, { defaultSize, defaultRepeat }) {
     dirtName,
     grassName,
     name,
+    gridX,
+    gridZ,
   } = tile;
 
   const vectorPosition = position ? toVector3(position) : toVector3({ x, y, z });
@@ -119,6 +123,8 @@ function normalizeTile(tile, { defaultSize, defaultRepeat }) {
     grassOptions: grassOptions && typeof grassOptions === 'object' ? { ...grassOptions } : undefined,
     dirtName: dirtName ?? (name ? `${name}:dirt` : undefined),
     grassName: grassName ?? (name ? `${name}:grass` : undefined),
+    gridX: typeof gridX === 'number' ? gridX : undefined,
+    gridZ: typeof gridZ === 'number' ? gridZ : undefined,
   };
 }
 
@@ -137,7 +143,13 @@ function buildTileDefinitions({
   let definitions = [];
 
   if (Array.isArray(tiles) && tiles.length > 0) {
-    definitions = tiles.map(t => normalizeTile(t, { defaultSize: effectiveSize, defaultRepeat: effectiveRepeat }));
+    definitions = tiles
+      .map(t => normalizeTile(t, { defaultSize: effectiveSize, defaultRepeat: effectiveRepeat }))
+      .map((tile, index) => ({
+        ...tile,
+        gridX: typeof tile.gridX === 'number' ? tile.gridX : index,
+        gridZ: typeof tile.gridZ === 'number' ? tile.gridZ : 0,
+      }));
   } else {
     const gridTiles = createGridTiles({
       grid: tileGrid ?? DEFAULT_TILE_GRID,
@@ -169,6 +181,8 @@ function buildTileDefinitions({
  * @param {number} [options.tileSize]     - Base tile size (used for generated tiles and as fallback for explicit tiles).
  * @param {number} [options.tileRepeat]   - Base texture repeat for generated tiles.
  * @param {number|{x?:number,z?:number}} [options.tileSpacing=0] - Gap/overlap between generated tiles.
+ * @param {boolean} [options.preventTileSeams=true] - Expand tile geometry slightly to hide seams.
+ * @param {boolean} [options.stabilizeTileOverlap=true] - Apply a subtle alternating height bias to dirt tiles.
  * @returns {{ root: THREE.Group, dirt: THREE.Group, grass: THREE.Group }}
  */
 export function createGroundLayered({
@@ -181,6 +195,8 @@ export function createGroundLayered({
   tileSize,
   tileRepeat,
   tileSpacing = 0,
+  preventTileSeams = true,
+  stabilizeTileOverlap = true,
 } = {}) {
   const root = new THREE.Group();
   root.name = 'ground:root';
@@ -216,13 +232,30 @@ export function createGroundLayered({
     defaultRepeat: resolvedDefaultRepeat,
   });
 
+  const enableSeamPrevention = !!preventTileSeams;
+  const enableTileStabilization = !!stabilizeTileOverlap;
+
   tileDefinitions.forEach((tile, index) => {
     if (tile.enableDirt) {
+      const ix = Math.floor(typeof tile.gridX === 'number' ? tile.gridX : index);
+      const iz = Math.floor(typeof tile.gridZ === 'number' ? tile.gridZ : 0);
+      const stabilizationBias = ((ix + iz) & 1) ? 0.001 : 0;
+      const resolvedDirtHeightBias =
+        tile.dirtOptions?.heightBias ??
+        dirtOptions.heightBias ??
+        (enableTileStabilization ? stabilizationBias : 0);
+      const resolvedDirtSeamExpansion =
+        tile.dirtOptions?.expandForSeams ??
+        dirtOptions.expandForSeams ??
+        enableSeamPrevention;
+
       const dirt = createDirtGround({
         ...dirtOptions,
         ...(tile.dirtOptions ?? {}),
         size: tile.dirtOptions?.size ?? tile.size ?? dirtOptions.size ?? resolvedDefaultSize,
         repeat: tile.dirtOptions?.repeat ?? tile.repeat ?? dirtOptions.repeat ?? resolvedDefaultRepeat,
+        expandForSeams: resolvedDirtSeamExpansion,
+        heightBias: resolvedDirtHeightBias,
       });
       dirt.name = tile.dirtName ?? `ground:dirt:tile:${index}`;
       dirt.position.copy(tile.position);
@@ -230,11 +263,16 @@ export function createGroundLayered({
     }
 
     if (tile.enableGrass) {
+      const resolvedGrassSeamExpansion =
+        tile.grassOptions?.expandForSeams ??
+        grassOptions.expandForSeams ??
+        enableSeamPrevention;
       const grass = createGrassGround({
         ...grassOptions,
         ...(tile.grassOptions ?? {}),
         size: tile.grassOptions?.size ?? tile.size ?? grassOptions.size ?? resolvedDefaultSize,
         repeat: tile.grassOptions?.repeat ?? tile.repeat ?? grassOptions.repeat ?? resolvedDefaultRepeat,
+        expandForSeams: resolvedGrassSeamExpansion,
       });
       grass.name = tile.grassName ?? `ground:grass:tile:${index}`;
       grass.position.copy(tile.position);


### PR DESCRIPTION
## Summary
- expand dirt and grass tile geometry behind a preventTileSeams flag to hide cracks between grid tiles
- add per-tile dirt height bias when stabilizeTileOverlap is enabled to avoid z-fighting while keeping grass offset intact

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68da822ac95c83279ec5b29b01ee8294