### PR TITLE
fix: ground player and NPC spawns reliably

### DIFF
--- a/src/npc/npcSystem.js
+++ b/src/npc/npcSystem.js
@@ -5,8 +5,10 @@ import { snapToGround } from '../physics/groundSnap.js';
 import { keepUpright } from '../physics/upright.js';
 import { loadGLTF } from '../loaders/safeGltf.js';
 import { logOnce } from '../utils/logOnce.js';
+import { ensureFeetAtLocalZero, placeOnGround } from '../utils/spawn.ts';
 
-const SNAP_OPTIONS = { gravity: 12, stepMax: 0.6, hover: 0.03 };
+const SNAP_OPTIONS = { gravity: 12, maxStepUp: 0.6, maxDrop: 4, hover: 0.03, rayStart: 1000 };
+const GROUND_CLEARANCE = typeof SNAP_OPTIONS.hover === 'number' ? SNAP_OPTIONS.hover : 0.03;
 const DEFAULT_WALK_SPEED = 1.5;
 const DEFAULT_RUN_SPEED = 3.0;
 const DEFAULT_ACCEL = 6.0;
@@ -411,7 +413,7 @@ function disposeNpcEntity(npc) {
   disposeObject3D(npc.object3d);
 }
 
-function createNpcEntity(config = {}, { scene = null, navContext = null } = {}) {
+function createNpcEntity(config = {}, { scene = null, navContext = null, groundMeshes = [] } = {}) {
   const {
     object3d: providedObject = null,
     modelUrl = null,
@@ -428,8 +430,18 @@ function createNpcEntity(config = {}, { scene = null, navContext = null } = {}) 
   object3d.rotation.x = 0;
   object3d.rotation.z = 0;
 
-  const startPosition = toVector3(initialPosition) || object3d.position.clone();
+  let startPosition = toVector3(initialPosition) || object3d.position.clone();
   object3d.position.copy(startPosition);
+
+  ensureFeetAtLocalZero(object3d);
+
+  const surfaces = Array.isArray(groundMeshes) ? groundMeshes : [];
+  const groundTarget = surfaces.length ? surfaces : scene;
+  if (groundTarget) {
+    placeOnGround(object3d, groundTarget, { clearance: GROUND_CLEARANCE, rayStart: SNAP_OPTIONS.rayStart });
+  }
+
+  startPosition = object3d.position.clone();
 
   if (scene && !object3d.parent) {
     scene.add(object3d);
@@ -449,7 +461,7 @@ function createNpcEntity(config = {}, { scene = null, navContext = null } = {}) 
     speed: 0,
     state: {
       vy: 0,
-      lastGoodY: object3d.position.y || 0,
+      lastGoodY: (object3d.position.y || 0) - GROUND_CLEARANCE,
       yaw: object3d.rotation.y || 0
     },
     modelRoot: null,
@@ -553,8 +565,9 @@ function stepNpc(npc, deltaSeconds, groundMeshes, navContextOverride = null) {
 }
 
 export function createNpc(options = {}) {
-  const { navContext = null, ...npcOptions } = options || {};
-  const npc = createNpcEntity(npcOptions, { navContext });
+  const { navContext = null, groundMeshes: initialGroundMeshes = [], ...npcOptions } = options || {};
+  const defaultGround = Array.isArray(initialGroundMeshes) ? initialGroundMeshes : [];
+  const npc = createNpcEntity(npcOptions, { navContext, groundMeshes: defaultGround });
   return {
     object3d: npc.object3d,
     update(deltaSeconds, context = {}) {
@@ -562,7 +575,8 @@ export function createNpc(options = {}) {
         return;
       }
       const nav = context.navContext || navContext || npc.navContext || null;
-      stepNpc(npc, deltaSeconds, context.groundMeshes, nav);
+      const ground = Array.isArray(context.groundMeshes) ? context.groundMeshes : defaultGround;
+      stepNpc(npc, deltaSeconds, ground, nav);
     },
     dispose() {
       npc.dispose();
@@ -581,7 +595,7 @@ export function createNpcManager(scene, groundMeshes, options = {}) {
   let activeSchedule = mapModeToSchedule(lastTimeMode);
 
   function spawn(config = {}) {
-    const npc = createNpcEntity(config, { scene, navContext });
+    const npc = createNpcEntity(config, { scene, navContext, groundMeshes: surfaces });
     npcs.push(npc);
     const originalDispose = npc.dispose;
     npc.dispose = () => {

--- a/src/npc/simpleNpcManager.js
+++ b/src/npc/simpleNpcManager.js
@@ -2,6 +2,7 @@ import * as THREE from 'three';
 import { snapToGround } from '../physics/groundSnap.js';
 import { keepUpright } from '../physics/upright.js';
 import { Capsule, resolveCapsuleVsAABBs } from '../physics/collision.js';
+import { ensureFeetAtLocalZero, placeOnGround } from '../utils/spawn.ts';
 
 const tempDirection = new THREE.Vector3();
 const flatDirection = new THREE.Vector3();
@@ -89,6 +90,13 @@ export function createNpcManager(scene, initialGroundMeshes = [], { colliders: i
   const spawn = ({ object3d, waypoints, walkSpeed = 1.6, accel = 5.0, turn = 0.18 } = {}) => {
     const npcObject = object3d || buildPlaceholderNpc();
     npcObject.userData.isNpc = true;
+    ensureFeetAtLocalZero(npcObject);
+
+    const spawnClearance = 0.03;
+    const groundTarget = groundMeshes.length ? groundMeshes : scene;
+    if (groundTarget) {
+      placeOnGround(npcObject, groundTarget, { clearance: spawnClearance });
+    }
 
     const path = normalizeWaypoints(waypoints);
     if (path.length === 0) {
@@ -105,7 +113,7 @@ export function createNpcManager(scene, initialGroundMeshes = [], { colliders: i
       velocity: new THREE.Vector3(),
       physics: {
         vy: 0,
-        lastGoodY: npcObject.position?.y ?? 0
+        lastGoodY: (npcObject.position?.y ?? 0) - spawnClearance
       },
       yaw: deriveYaw(npcObject),
       capsule: new Capsule(0.4, 1.5),

--- a/src/physics/groundSnap.js
+++ b/src/physics/groundSnap.js
@@ -1,12 +1,11 @@
-import * as THREE from 'three';
+import { groundYAt } from '../utils/spawn.ts';
 
-const DOWN = new THREE.Vector3(0, -1, 0);
-const RAY_ORIGIN = new THREE.Vector3();
-const RAYCASTER = new THREE.Raycaster();
 const DEFAULT_OPTIONS = {
   gravity: 12,
-  stepMax: 0.6,
-  hover: 0.03
+  hover: 0.03,
+  maxStepUp: 1,
+  maxDrop: 4,
+  rayStart: 1000
 };
 
 function ensureState(state, positionY) {
@@ -25,19 +24,6 @@ function ensureState(state, positionY) {
   return state;
 }
 
-function chooseHit(intersections) {
-  if (!Array.isArray(intersections) || intersections.length === 0) {
-    return null;
-  }
-  for (let i = 0; i < intersections.length; i += 1) {
-    const hit = intersections[i];
-    if (hit && hit.object && hit.point) {
-      return hit;
-    }
-  }
-  return null;
-}
-
 export function snapToGround(object3d, groundMeshes, inputState, deltaSeconds = 0, options = DEFAULT_OPTIONS) {
   if (!object3d) {
     return false;
@@ -45,50 +31,60 @@ export function snapToGround(object3d, groundMeshes, inputState, deltaSeconds = 
 
   const state = ensureState(inputState, object3d.position?.y ?? 0);
   const dt = Number.isFinite(deltaSeconds) && deltaSeconds > 0 ? deltaSeconds : 0;
-  const meshes = Array.isArray(groundMeshes) ? groundMeshes : [];
+  const meshes = Array.isArray(groundMeshes)
+    ? groundMeshes
+    : groundMeshes
+      ? [groundMeshes]
+      : [];
 
   const gravity = Number.isFinite(options?.gravity) ? options.gravity : DEFAULT_OPTIONS.gravity;
-  const stepMax = Number.isFinite(options?.stepMax) ? options.stepMax : DEFAULT_OPTIONS.stepMax;
   const hover = Number.isFinite(options?.hover) ? options.hover : DEFAULT_OPTIONS.hover;
+  const stepMaxRaw = Number.isFinite(options?.maxStepUp)
+    ? options.maxStepUp
+    : Number.isFinite(options?.stepMax)
+      ? options.stepMax
+      : DEFAULT_OPTIONS.maxStepUp;
+  const dropMaxRaw = Number.isFinite(options?.maxDrop) ? options.maxDrop : DEFAULT_OPTIONS.maxDrop;
+  const rayStart = Number.isFinite(options?.rayStart) ? options.rayStart : DEFAULT_OPTIONS.rayStart;
 
-  if (dt > 0) {
-    state.vy += gravity * dt;
+  const maxStepUp = Math.max(0, stepMaxRaw);
+  const maxDrop = Math.max(0, dropMaxRaw);
+
+  const position = object3d.position;
+  if (!position) {
+    return false;
   }
 
-  const vy = state.vy;
-  const fallDistance = vy * dt;
-  const position = object3d.position;
-  const predictedY = position.y - fallDistance;
+  const groundY = groundYAt(position.x, position.z, meshes, rayStart);
 
-  if (meshes.length > 0) {
-    RAY_ORIGIN.copy(position);
-    RAY_ORIGIN.y += 1.2;
+  if (groundY != null) {
+    const targetY = groundY + hover;
+    const delta = targetY - position.y;
+    if (delta > 1e-5) {
+      const step = Math.min(delta, maxStepUp);
+      position.y = step === delta ? targetY : position.y + step;
+    } else if (delta < -1e-5) {
+      const step = Math.max(delta, -maxDrop);
+      position.y = step === delta ? targetY : position.y + step;
+    } else {
+      position.y = targetY;
+    }
+    state.vy = 0;
+    state.lastGoodY = groundY;
+    return true;
+  }
 
-    RAYCASTER.ray.origin.copy(RAY_ORIGIN);
-    RAYCASTER.ray.direction.copy(DOWN);
-    RAYCASTER.near = 0;
-    RAYCASTER.far = Math.max(5, 1.2 + stepMax + hover + Math.abs(vy * 0.5));
-
-    const intersections = RAYCASTER.intersectObjects(meshes, false);
-    const hit = chooseHit(intersections);
-
-    if (hit) {
-      const hitY = hit.point.y;
-      const delta = hitY - predictedY;
-      if (Math.abs(delta) <= stepMax) {
-        position.y = hitY + hover;
-        state.vy = 0;
-        state.lastGoodY = hitY;
-        return true;
-      }
+  if (dt > 0 && Number.isFinite(gravity) && gravity > 0) {
+    state.vy += gravity * dt;
+    const fallDistance = state.vy * dt;
+    if (Number.isFinite(fallDistance) && fallDistance > 0) {
+      const limit = maxDrop > 0 ? maxDrop : fallDistance;
+      position.y -= Math.min(fallDistance, limit);
     }
   }
 
-  position.y = predictedY;
-  state.vy = vy;
-
   const lastGoodY = Number.isFinite(state.lastGoodY) ? state.lastGoodY : position.y;
-  if (lastGoodY - position.y > 2) {
+  if (lastGoodY - position.y > maxDrop + hover) {
     position.y = lastGoodY + hover;
     state.vy = 0;
     state.lastGoodY = lastGoodY;

--- a/src/utils/spawn.ts
+++ b/src/utils/spawn.ts
@@ -14,6 +14,7 @@ const DEF: Required<GroundOpts> = {
 };
 
 const RAY = new THREE.Raycaster();
+const RAY_ORIGIN = new THREE.Vector3();
 const DOWN = new THREE.Vector3(0, -1, 0);
 const UP   = new THREE.Vector3(0, 1, 0);
 
@@ -46,10 +47,19 @@ export function ensureFeetAtLocalZero(obj: THREE.Object3D) {
 }
 
 /** Raycast world (x,z) down to find ground Y from provided ground meshes (or whole scene). */
-export function groundYAt(x:number, z:number, sceneOrMeshes: THREE.Object3D | THREE.Object3D[]): number | null {
-  const targets = Array.isArray(sceneOrMeshes) ? sceneOrMeshes : collectMeshesByName(sceneOrMeshes, ['ground', 'floor', 'terrain', 'plane', 'tile']);
-  if (!targets.length) return 0;
-  RAY.set(new THREE.Vector3(x, 1000, z), DOWN);
+export function groundYAt(
+  x:number,
+  z:number,
+  sceneOrMeshes: THREE.Object3D | THREE.Object3D[],
+  rayStart = DEF.rayStart
+): number | null {
+  const targets = Array.isArray(sceneOrMeshes)
+    ? sceneOrMeshes
+    : collectMeshesByName(sceneOrMeshes, ['ground', 'floor', 'terrain', 'plane', 'tile']);
+  if (!targets.length) return null;
+  const originY = Number.isFinite(rayStart) ? rayStart : DEF.rayStart;
+  RAY_ORIGIN.set(x, originY, z);
+  RAY.set(RAY_ORIGIN, DOWN);
   const hits = RAY.intersectObjects(targets, true);
   if (!hits.length) return null;
   return hits[0].point.y;
@@ -59,9 +69,11 @@ export function groundYAt(x:number, z:number, sceneOrMeshes: THREE.Object3D | TH
 export function placeOnGround(obj: THREE.Object3D, sceneOrMeshes: THREE.Object3D | THREE.Object3D[], opts?: GroundOpts) {
   const O = { ...DEF, ...(opts||{}) };
   ensureFeetAtLocalZero(obj);
-  const y = groundYAt(obj.position.x, obj.position.z, sceneOrMeshes);
-  obj.position.y = ((y ?? 0) + O.clearance);
-  obj.updateMatrixWorld(true);
+  const y = groundYAt(obj.position.x, obj.position.z, sceneOrMeshes, O.rayStart);
+  if (y != null) {
+    obj.position.y = y + O.clearance;
+    obj.updateMatrixWorld(true);
+  }
 }
 
 /** Quick test: is there a roof/ceiling directly above this world position within `height`? */


### PR DESCRIPTION
## Summary
- ensure spawn helpers raycast from a configurable height and only adjust when a ground hit is found
- gently clamp ground snapping to avoid popping while keeping physics fallbacks in place
- normalize NPC placement by zeroing feet and placing each character on visible ground meshes

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68daefac04808327ae69f2e56b3c0a74