### PR TITLE
Fix camera seeding and WASD movement

### DIFF
--- a/src/camera/followCamera.js
+++ b/src/camera/followCamera.js
@@ -5,7 +5,7 @@ const tempQuaternion = new THREE.Quaternion();
 const targetWorldPosition = new THREE.Vector3();
 const desiredPosition = new THREE.Vector3();
 const lookOffset = new THREE.Vector3();
-const cameraForward = new THREE.Vector3();
+const spherical = new THREE.Spherical();
 
 const MIN_PITCH = THREE.MathUtils.degToRad(-85);
 const MAX_PITCH = THREE.MathUtils.degToRad(85);
@@ -22,13 +22,6 @@ function computeBaseParameters(offset) {
   const basePitch = horizontal > 1e-5 ? Math.atan2(offsetVector.y, horizontal) : 0;
   const baseYaw = Math.atan2(offsetVector.x, offsetVector.z);
   return { radius, basePitch, baseYaw };
-}
-
-function wrapAngle(angle) {
-  if (!Number.isFinite(angle)) {
-    return 0;
-  }
-  return THREE.MathUtils.euclideanModulo(angle + Math.PI, Math.PI * 2) - Math.PI;
 }
 
 export function createFollowCamera(
@@ -52,12 +45,22 @@ export function createFollowCamera(
 
   let currentTarget = target || null;
   const base = computeBaseParameters(options.offset);
-  const pitchMin = MIN_PITCH - base.basePitch;
-  const pitchMax = MAX_PITCH - base.basePitch;
+  const rigState = (() => {
+    if (!camera || typeof camera !== 'object') {
+      return { yaw: 0, pitch: 0, distance: base.radius };
+    }
+    const existing = (camera).__rigState;
+    if (existing && typeof existing === 'object') {
+      if (!Number.isFinite(existing.distance) || existing.distance <= 0) {
+        existing.distance = base.radius;
+      }
+      return existing;
+    }
+    const state = { yaw: 0, pitch: 0, distance: base.radius };
+    (camera).__rigState = state;
+    return state;
+  })();
 
-  let yawOffset = 0;
-  let pitchOffset = 0;
-  let cachedTargetYaw = 0;
   let pointerElement = null;
   let accumulatedMouseDX = 0;
   let accumulatedMouseDY = 0;
@@ -68,17 +71,18 @@ export function createFollowCamera(
   const browserWindow = typeof window !== 'undefined' ? window : null;
   const browserDocument = typeof document !== 'undefined' ? document : null;
 
-  const getTargetYaw = () => {
-    if (!currentTarget) {
-      return cachedTargetYaw;
+  const sanitizeYaw = (value) => {
+    if (!Number.isFinite(value)) {
+      return 0;
     }
-    currentTarget.getWorldDirection(cameraForward);
-    cameraForward.y = 0;
-    if (cameraForward.lengthSq() > 1e-6) {
-      cameraForward.normalize();
-      cachedTargetYaw = Math.atan2(cameraForward.x, cameraForward.z);
+    return THREE.MathUtils.euclideanModulo(value + Math.PI, Math.PI * 2) - Math.PI;
+  };
+
+  const sanitizePitch = (value) => {
+    if (!Number.isFinite(value)) {
+      return 0;
     }
-    return cachedTargetYaw;
+    return THREE.MathUtils.clamp(value, MIN_PITCH, MAX_PITCH);
   };
 
   const computeDesired = (out = desiredPosition) => {
@@ -86,19 +90,18 @@ export function createFollowCamera(
       return out.set(0, 0, 0);
     }
 
-    const targetYaw = getTargetYaw();
-    const finalYaw = targetYaw + yawOffset + base.baseYaw;
-    const finalPitch = THREE.MathUtils.clamp(base.basePitch + pitchOffset, MIN_PITCH, MAX_PITCH);
-    const radius = base.radius;
-    const horizontal = Math.cos(finalPitch) * radius;
-
-    out.set(
-      Math.sin(finalYaw) * horizontal,
-      Math.sin(finalPitch) * radius,
-      Math.cos(finalYaw) * horizontal
-    );
+    const yaw = sanitizeYaw(rigState.yaw);
+    const pitch = sanitizePitch(rigState.pitch);
+    const radius = Number.isFinite(rigState.distance) && rigState.distance > 1e-3
+      ? rigState.distance
+      : base.radius;
 
     currentTarget.getWorldPosition(targetWorldPosition);
+
+    spherical.radius = radius;
+    spherical.theta = yaw;
+    spherical.phi = Math.PI / 2 - pitch;
+    out.setFromSpherical(spherical);
     out.add(targetWorldPosition);
     return out;
   };
@@ -214,24 +217,25 @@ export function createFollowCamera(
       }
     }
 
-    if (!Number.isFinite(yawOffset)) {
-      yawOffset = 0;
+    if (!Number.isFinite(rigState.yaw)) {
+      rigState.yaw = 0;
     }
-    if (!Number.isFinite(pitchOffset)) {
-      pitchOffset = 0;
+    if (!Number.isFinite(rigState.pitch)) {
+      rigState.pitch = 0;
     }
 
     if (accumulatedMouseDX !== 0 || accumulatedMouseDY !== 0) {
-      yawOffset += accumulatedMouseDX * MOUSE_SENSITIVITY;
-      pitchOffset -= accumulatedMouseDY * MOUSE_SENSITIVITY;
+      rigState.yaw += accumulatedMouseDX * MOUSE_SENSITIVITY;
+      rigState.pitch -= accumulatedMouseDY * MOUSE_SENSITIVITY;
       accumulatedMouseDX = 0;
       accumulatedMouseDY = 0;
     }
 
-    yawOffset += lookX * options.yawSpeed * dtSafe;
-    pitchOffset += lookY * options.pitchSpeed * dtSafe;
-    pitchOffset = THREE.MathUtils.clamp(pitchOffset, pitchMin, pitchMax);
-    yawOffset = wrapAngle(yawOffset);
+    rigState.yaw += lookX * options.yawSpeed * dtSafe;
+    rigState.pitch += lookY * options.pitchSpeed * dtSafe;
+
+    rigState.pitch = sanitizePitch(rigState.pitch);
+    rigState.yaw = sanitizeYaw(rigState.yaw);
 
     const lerpAlpha = computeLerpAlpha(dt);
     computeDesired(desiredPosition);
@@ -241,6 +245,9 @@ export function createFollowCamera(
     currentTarget.getWorldQuaternion(tempQuaternion);
     lookOffset.applyQuaternion(tempQuaternion);
     tempPosition.copy(targetWorldPosition).add(lookOffset);
+    if (tempPosition.distanceToSquared(camera.position) < 1e-9) {
+      tempPosition.y += 0.001;
+    }
     camera.lookAt(tempPosition);
   };
 
@@ -254,6 +261,9 @@ export function createFollowCamera(
     currentTarget.getWorldQuaternion(tempQuaternion);
     lookOffset.applyQuaternion(tempQuaternion);
     tempPosition.copy(targetWorldPosition).add(lookOffset);
+    if (tempPosition.distanceToSquared(camera.position) < 1e-9) {
+      tempPosition.y += 0.001;
+    }
     camera.lookAt(tempPosition);
   };
 
@@ -264,12 +274,15 @@ export function createFollowCamera(
     currentTarget = nextTarget;
     currentTarget.getWorldPosition(targetWorldPosition);
     tempPosition.copy(camera.position).sub(targetWorldPosition);
+    const distance = tempPosition.length();
     const horizontal = Math.sqrt(tempPosition.x * tempPosition.x + tempPosition.z * tempPosition.z);
     const worldPitch = horizontal > 1e-6 ? Math.atan2(tempPosition.y, horizontal) : 0;
     const worldYaw = Math.atan2(tempPosition.x, tempPosition.z);
-    const targetYaw = getTargetYaw();
-    yawOffset = wrapAngle(worldYaw - targetYaw - base.baseYaw);
-    pitchOffset = THREE.MathUtils.clamp(worldPitch - base.basePitch, pitchMin, pitchMax);
+    if (!Number.isFinite(rigState.distance) || rigState.distance <= 0) {
+      rigState.distance = distance > 1e-6 ? distance : base.radius;
+    }
+    rigState.pitch = sanitizePitch(worldPitch);
+    rigState.yaw = sanitizeYaw(worldYaw);
     syncImmediate();
   };
 

--- a/src/camera/seedCameraBehindPlayer.js
+++ b/src/camera/seedCameraBehindPlayer.js
@@ -1,0 +1,81 @@
+import * as THREE from 'three';
+
+const tempForward = new THREE.Vector3();
+const tempTarget = new THREE.Vector3();
+const tempSpherical = new THREE.Spherical();
+const tempLook = new THREE.Vector3();
+const tempQuaternion = new THREE.Quaternion();
+
+export function seedCameraBehindPlayer(player, camera, opts = {}) {
+  if (!player || !camera || typeof camera !== 'object') {
+    return;
+  }
+
+  const followDistance = Number.isFinite(opts.followDistance) && opts.followDistance > 0
+    ? opts.followDistance
+    : 6;
+  const shoulderHeight = Number.isFinite(opts.shoulderHeight) ? opts.shoulderHeight : 1.6;
+  const basePitchDeg = Number.isFinite(opts.pitchDeg) ? opts.pitchDeg : -15;
+  const pitch = THREE.MathUtils.degToRad(basePitchDeg);
+
+  tempForward.set(0, 0, 1);
+  if (typeof player?.getWorldQuaternion === 'function') {
+    player.getWorldQuaternion(tempQuaternion);
+    tempForward.applyQuaternion(tempQuaternion);
+  } else if (player?.quaternion instanceof THREE.Quaternion) {
+    tempForward.applyQuaternion(player.quaternion);
+  }
+
+  if (
+    !Number.isFinite(tempForward.x) ||
+    !Number.isFinite(tempForward.y) ||
+    !Number.isFinite(tempForward.z) ||
+    tempForward.lengthSq() < 1e-6
+  ) {
+    tempForward.set(0, 0, 1);
+  }
+
+  tempForward.y = 0;
+  if (tempForward.lengthSq() < 1e-6) {
+    tempForward.set(0, 0, 1);
+  } else {
+    tempForward.normalize();
+  }
+
+  const yaw = Math.atan2(tempForward.x, tempForward.z) + Math.PI;
+
+  const target = typeof player.getWorldPosition === 'function'
+    ? player.getWorldPosition(tempTarget)
+    : tempTarget.copy(player.position ?? new THREE.Vector3());
+  target.y += shoulderHeight;
+
+  tempSpherical.radius = followDistance;
+  tempSpherical.theta = yaw;
+  tempSpherical.phi = Math.PI / 2 - pitch;
+  camera.position.setFromSpherical(tempSpherical).add(target);
+
+  tempLook.copy(target);
+  if (tempLook.distanceToSquared(camera.position) < 1e-9) {
+    tempLook.y += 0.001;
+  }
+  camera.lookAt(tempLook);
+
+  const rigState = (() => {
+    if (!camera || typeof camera !== 'object') {
+      return null;
+    }
+    if (camera.__rigState && typeof camera.__rigState === 'object') {
+      return camera.__rigState;
+    }
+    camera.__rigState = {};
+    return camera.__rigState;
+  })();
+
+  if (rigState) {
+    rigState.yaw = yaw;
+    rigState.pitch = pitch;
+    rigState.distance = followDistance;
+  }
+}
+
+export default seedCameraBehindPlayer;

--- a/src/entry/boot.ts
+++ b/src/entry/boot.ts
@@ -8,6 +8,7 @@ import createKeyboard from '../input/keyboard.js';
 import { createPlayerController } from '../player/playerController.js';
 import { loadPlayerAvatar, PlayerAvatar } from '../player/playerAvatar.ts';
 import { createFollowCamera } from '../camera/followCamera.js';
+import { seedCameraBehindPlayer } from '../camera/seedCameraBehindPlayer.js';
 import { installRenderGuard } from '../safety/hardenPositions';
 import {
   DEFAULT_CAMERA,
@@ -532,15 +533,13 @@ export async function runAthens(options: RunOptions = {}) {
     placeOnGround(playerObject, groundMeshes.length ? groundMeshes : scene, { clearance: 0.02 });
   }
 
-  if (!hasSavedCameraPos) {
-    const camBack = 6;
-    const camUp = 3;
-    camera.position.set(spawnPosition.x + camBack, spawnPosition.y + camUp, spawnPosition.z + camBack);
-  }
-
   if (groundMeshes.length) {
     const initialState = { vy: 0, lastGoodY: playerObject.position.y };
     snapToGround(playerObject, groundMeshes, initialState, 0);
+  }
+
+  if (!hasSavedCameraPos) {
+    seedCameraBehindPlayer(playerObject, camera, { followDistance: 6, shoulderHeight: 1.6, pitchDeg: -15 });
   }
 
   sanitizeVec3(playerObject.position, DEFAULT_PLAYER);

--- a/src/entry/initializeAthens.js
+++ b/src/entry/initializeAthens.js
@@ -11,6 +11,7 @@ import { createNpcManager } from '../npc/npcSystem.js';
 import { createMainCharacter } from '../npc/mainCharacter.js';
 import { createKeyboard } from '../input/keyboard.js';
 import { createFollowCamera } from '../camera/followCamera.js';
+import { seedCameraBehindPlayer } from '../camera/seedCameraBehindPlayer.js';
 import { createPlayerController } from '../player/playerController.js';
 import { assetUrl } from '../utils/assetUrl.js';
 import { createGameLoop } from '../engine/loop.js';
@@ -802,6 +803,11 @@ export async function initializeAthens(options = {}) {
   const savedState = resolveSavedState();
   restoreCameraAndPlayer(savedState);
 
+  if (!savedState?.camera?.pos) {
+    seedCameraBehindPlayer(playerObject, camera, { followDistance: 6, shoulderHeight: 1.6, pitchDeg: -15 });
+    followCamera.syncImmediate?.();
+  }
+
   if (mainCharacter?.ready?.then) {
     mainCharacter.ready.then(() => {
       const resolvedPlayer = mainCharacter.object3d || findPlayerObject() || scene.getObjectByName('MainCharacter');
@@ -817,8 +823,7 @@ export async function initializeAthens(options = {}) {
           restoreCameraAndPlayer(savedState);
         } else {
           sanitizeVec3(playerObject.position, DEFAULT_PLAYER);
-          sanitizeVec3(camera.position, DEFAULT_CAMERA);
-          camera.lookAt(playerObject.position);
+          seedCameraBehindPlayer(playerObject, camera, { followDistance: 6, shoulderHeight: 1.6, pitchDeg: -15 });
         }
         followCamera.syncImmediate?.();
         if (placeholderPlayer && placeholderPlayer.parent) {

--- a/src/player/playerController.js
+++ b/src/player/playerController.js
@@ -157,36 +157,43 @@ export function createPlayerController(
 
     targetVelocity.set(0, 0, 0);
     let desiredYaw = yaw;
+
+    const cameraRigState = camera && typeof camera === 'object' ? camera.__rigState : null;
+    const rigYawRaw = cameraRigState && Number.isFinite(cameraRigState.yaw) ? cameraRigState.yaw : NaN;
+    const rigYaw = Number.isFinite(rigYawRaw)
+      ? THREE.MathUtils.euclideanModulo(rigYawRaw + Math.PI, Math.PI * 2) - Math.PI
+      : (() => {
+          if (typeof camera.getWorldDirection === 'function') {
+            camera.getWorldDirection(viewDirection);
+            const yawFromCamera = Math.atan2(viewDirection.x, viewDirection.z);
+            return Number.isFinite(yawFromCamera) ? yawFromCamera : 0;
+          }
+          return 0;
+        })();
+
+    if (cameraRigState && Number.isFinite(rigYaw)) {
+      cameraRigState.yaw = rigYaw;
+    }
+
+    moveDirection.set(Math.sin(rigYaw), 0, Math.cos(rigYaw));
+    if (moveDirection.lengthSq() < 1e-6) {
+      moveDirection.set(0, 0, 1);
+    } else {
+      moveDirection.normalize();
+    }
+
+    rightVector.crossVectors(UP, moveDirection);
+    if (rightVector.lengthSq() < 1e-6) {
+      rightVector.set(1, 0, 0);
+    } else {
+      rightVector.normalize();
+    }
+
+    const forwardInput = THREE.MathUtils.clamp(-axisZ, -1, 1);
+    const strafeInput = THREE.MathUtils.clamp(axisX, -1, 1);
+
     if (hasMoveInput) {
-      if (typeof camera.getWorldDirection === 'function') {
-        camera.getWorldDirection(viewDirection);
-      } else {
-        viewDirection.set(0, 0, -1);
-      }
-      viewDirection.y = 0;
-      if (viewDirection.lengthSq() < 1e-6) {
-        viewDirection.set(0, 0, -1);
-      } else {
-        viewDirection.normalize();
-      }
-
-      moveDirection.copy(viewDirection);
-      if (moveDirection.lengthSq() < 1e-6) {
-        moveDirection.set(0, 0, 1);
-      } else {
-        moveDirection.normalize();
-      }
-
-      rightVector.crossVectors(UP, moveDirection);
-      if (rightVector.lengthSq() < 1e-6) {
-        rightVector.set(1, 0, 0);
-      } else {
-        rightVector.normalize();
-      }
-
       desiredMove.set(0, 0, 0);
-      const forwardInput = THREE.MathUtils.clamp(-axisZ, -1, 1);
-      const strafeInput = THREE.MathUtils.clamp(axisX, -1, 1);
       desiredMove
         .addScaledVector(moveDirection, forwardInput)
         .addScaledVector(rightVector, strafeInput);


### PR DESCRIPTION
## Audit
- Update order: `keyboard.update` → `playerController.update` → `followCamera.update` → render in `boot.ts` (and equivalent in `initializeAthens.js`).
- Original movement relied on `camera.getWorldDirection` rather than a persisted yaw, so starting with the camera in front caused W to spin the player.
- Camera yaw/pitch offsets were re-derived from the player's facing each frame, and the startup camera position was only a rough diagonal offset, so initial movement could produce unexpected rotation.

## Summary
- Persist follow-camera yaw/pitch/distance state, clamp pitch, and avoid zero-length look targets while applying pointer lock deltas.
- Seed the camera behind the player when no saved camera pose exists and share that yaw/pitch with the rig state.
- Drive WASD movement from the camera yaw (A/D strafe) using the shared rig state instead of re-querying camera forward vectors.

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68daffc7c37883279f49277efaad5681