### PR TITLE
Support sloped ground tiles

### DIFF
--- a/src/ground/dirt.js
+++ b/src/ground/dirt.js
@@ -123,10 +123,19 @@ export function createDirtMaterial({ repeat = 16, anisotropy = 8 } = {}) {
   return mat;
 }
 
+/**
+ * @typedef {Object} DirtOptions
+ * @property {number} [height=0]                       Global Y offset for the tile.
+ * @property {{x?:number, z?:number}} [slope]          Linear slope (rise per meter) along local X and Z axes.
+ * @property {{nw?:number, ne?:number, se?:number, sw?:number}} [cornerHeights] Explicit per-corner heights in meters.
+ */
+
 export function createDirtGround({
   size = 200,
   repeat = 16,
   height = 0,
+  slope,
+  cornerHeights,
   receiveShadow = true,
   anisotropy = 8,
   expandForSeams = false,
@@ -140,6 +149,40 @@ export function createDirtGround({
 
   const geo = new THREE.PlaneGeometry(geometrySize, geometrySize, 1, 1);
   geo.rotateX(-Math.PI / 2);
+
+  const positionAttribute = geo.getAttribute('position');
+  const halfSize = geometrySize / 2;
+  let updatedVertices = false;
+
+  if (positionAttribute && cornerHeights) {
+    const bl = cornerHeights.sw ?? 0;
+    const br = cornerHeights.se ?? 0;
+    const tl = cornerHeights.nw ?? 0;
+    const tr = cornerHeights.ne ?? 0;
+
+    positionAttribute.setY(0, positionAttribute.getY(0) + bl);
+    positionAttribute.setY(1, positionAttribute.getY(1) + br);
+    positionAttribute.setY(2, positionAttribute.getY(2) + tl);
+    positionAttribute.setY(3, positionAttribute.getY(3) + tr);
+    updatedVertices = true;
+  } else if (positionAttribute && slope && (slope.x || slope.z)) {
+    const sx = slope.x ?? 0;
+    const sz = slope.z ?? 0;
+    if (halfSize > 0) {
+      for (let i = 0; i < positionAttribute.count; i += 1) {
+        const x = positionAttribute.getX(i);
+        const z = positionAttribute.getZ(i);
+        const dy = (x / halfSize) * sx + (z / halfSize) * sz;
+        positionAttribute.setY(i, positionAttribute.getY(i) + dy);
+      }
+      updatedVertices = true;
+    }
+  }
+
+  if (updatedVertices) {
+    positionAttribute.needsUpdate = true;
+    geo.computeVertexNormals();
+  }
 
   const finalHeight = typeof height === 'number' ? height : 0;
   const finalBias = typeof heightBias === 'number' ? heightBias : 0;

--- a/src/ground/grass.js
+++ b/src/ground/grass.js
@@ -100,10 +100,19 @@ function configureTexture(baseTexture, { repeat, anisotropy }) {
   return texture;
 }
 
+/**
+ * @typedef {Object} GrassOptions
+ * @property {number} [height=0.02]                       Global Y offset for the tile.
+ * @property {{x?:number, z?:number}} [slope]             Linear slope (rise per meter) along local X and Z axes.
+ * @property {{nw?:number, ne?:number, se?:number, sw?:number}} [cornerHeights] Explicit per-corner heights in meters.
+ */
+
 export function createGrassGround({
   size = 200,
   repeat = 16,
   height = 0.02,           // slight offset so it doesn’t z-fight with dirt if overlapped
+  slope,
+  cornerHeights,
   receiveShadow = true,
   anisotropy = 8,
   expandForSeams = false,
@@ -115,6 +124,41 @@ export function createGrassGround({
   const geometrySize = expandForSeams ? baseSize + TILE_SEAM_EPSILON * 2 : baseSize;
   const geo = new THREE.PlaneGeometry(geometrySize, geometrySize, 1, 1);
   geo.rotateX(-Math.PI / 2);
+
+  const positionAttribute = geo.getAttribute('position');
+  const halfSize = geometrySize / 2;
+  let updatedVertices = false;
+
+  if (positionAttribute && cornerHeights) {
+    const bl = cornerHeights.sw ?? 0;
+    const br = cornerHeights.se ?? 0;
+    const tl = cornerHeights.nw ?? 0;
+    const tr = cornerHeights.ne ?? 0;
+
+    positionAttribute.setY(0, positionAttribute.getY(0) + bl);
+    positionAttribute.setY(1, positionAttribute.getY(1) + br);
+    positionAttribute.setY(2, positionAttribute.getY(2) + tl);
+    positionAttribute.setY(3, positionAttribute.getY(3) + tr);
+    updatedVertices = true;
+  } else if (positionAttribute && slope && (slope.x || slope.z)) {
+    const sx = slope.x ?? 0;
+    const sz = slope.z ?? 0;
+    if (halfSize > 0) {
+      for (let i = 0; i < positionAttribute.count; i += 1) {
+        const x = positionAttribute.getX(i);
+        const z = positionAttribute.getZ(i);
+        const dy = (x / halfSize) * sx + (z / halfSize) * sz;
+        positionAttribute.setY(i, positionAttribute.getY(i) + dy);
+      }
+      updatedVertices = true;
+    }
+  }
+
+  if (updatedVertices) {
+    positionAttribute.needsUpdate = true;
+    geo.computeVertexNormals();
+  }
+
   const finalHeight = Math.max(typeof height === 'number' ? height : 0.02, 0.02);
   geo.translate(0, finalHeight, 0);
 

--- a/src/ground/index.js
+++ b/src/ground/index.js
@@ -220,6 +220,17 @@ function computeTileBounds(position, size) {
   };
 }
 
+function averageCornerHeight(cornerHeights) {
+  if (!cornerHeights || typeof cornerHeights !== 'object') return 0;
+  const corners = ['nw', 'ne', 'se', 'sw'];
+  let total = 0;
+  for (const key of corners) {
+    const value = cornerHeights[key];
+    total += typeof value === 'number' ? value : 0;
+  }
+  return total / corners.length;
+}
+
 const SKIRT_DIRECTIONS = [
   { key: 'east',  axis: 'x', dir:  1, axisCoord: 'x', perpCoord: 'z', axisMin: 'minX', axisMax: 'maxX', perpMin: 'minZ', perpMax: 'maxZ' },
   { key: 'west',  axis: 'x', dir: -1, axisCoord: 'x', perpCoord: 'z', axisMin: 'minX', axisMax: 'maxX', perpMin: 'minZ', perpMax: 'maxZ' },
@@ -411,8 +422,8 @@ function createFoundationBlendRingMesh({ size, repeat, anisotropy } = {}) {
  * You can toggle visibility on each layer independently.
  *
  * @param {Object} options
- * @param {Object} [options.dirtOptions]  - Options passed to createDirtGround
- * @param {Object} [options.grassOptions] - Options passed to createGrassGround
+ * @param {Object} [options.dirtOptions]  - Options passed to createDirtGround (supports height, slope, cornerHeights, etc.)
+ * @param {Object} [options.grassOptions] - Options passed to createGrassGround (supports height, slope, cornerHeights, etc.)
  * @param {boolean} [options.showDirt=true]
  * @param {boolean} [options.showGrass=true]
  * @param {Object[]} [options.tiles]      - Explicit tile definitions. If omitted a grid will be generated.
@@ -427,6 +438,8 @@ function createFoundationBlendRingMesh({ size, repeat, anisotropy } = {}) {
  *
  * Tile definitions may specify `disableUnderBuilding` to suppress dirt/grass meshes and
  * `addFoundationBlendRing` to render a subtle inset ring around pads.
+ * Per-tile `dirtOptions` and `grassOptions` are forwarded to the respective ground builders,
+ * allowing custom `height`, `slope`, or `cornerHeights` per tile.
  * @returns {{
  *   root: THREE.Group,
  *   dirt: THREE.Group,
@@ -522,11 +535,13 @@ export function createGroundLayered({
     };
 
     const baseDirtHeight = typeof dirtConfig.height === 'number' ? dirtConfig.height : 0;
+    const baseDirtBias = typeof dirtConfig.heightBias === 'number' ? dirtConfig.heightBias : 0;
+    const baseCornerAverage = averageCornerHeight(dirtConfig.cornerHeights);
 
     let dirtGroup = null;
     let dirtMesh = null;
     let dirtSize;
-    let surfaceY = tile.position.y + baseDirtHeight;
+    let surfaceY = tile.position.y + baseDirtHeight + baseDirtBias + baseCornerAverage;
 
     if (!disableForBuilding && tile.enableDirt) {
       const dirt = createDirtGround(dirtConfig);
@@ -537,7 +552,7 @@ export function createGroundLayered({
       dirtGroup = dirt;
       dirtMesh = dirt.children.find(child => child?.isMesh) ?? null;
       dirtSize = dirtConfig.size;
-      surfaceY = tile.position.y + baseDirtHeight;
+      surfaceY = tile.position.y + baseDirtHeight + baseDirtBias + baseCornerAverage;
     }
 
     if (!disableForBuilding && tile.enableGrass) {


### PR DESCRIPTION
## Summary
- allow dirt ground tiles to accept slope or corner height overrides and update geometry normals
- mirror the same elevation controls for grass tiles
- document and forward the new options through the layered ground builder while tracking averaged corner height for skirts

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_b_68db0b2785fc8327be478d8263c3d049