### PR TITLE
feat: support sloped ground tiles via heightFn

### DIFF
--- a/src/ground/dirt.js
+++ b/src/ground/dirt.js
@@ -99,6 +99,82 @@ export function createSharedDirtTexture({ repeat, anisotropy } = {}) {
   return configureTexture(baseTexture, { repeat, anisotropy });
 }
 
+function normalizeCornerHeightsInput(input) {
+  if (!input) return null;
+
+  const keys = ['nw', 'ne', 'sw', 'se'];
+  let source = null;
+
+  if (Array.isArray(input)) {
+    const [nw, ne, sw, se] = input;
+    source = { nw, ne, sw, se };
+  } else if (typeof input === 'object') {
+    source = input;
+  } else {
+    return null;
+  }
+
+  const result = { nw: 0, ne: 0, sw: 0, se: 0 };
+  let hasData = false;
+
+  keys.forEach((key) => {
+    if (Object.prototype.hasOwnProperty.call(source, key)) {
+      hasData = true;
+    }
+    const value = source[key];
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      result[key] = value;
+      hasData = true;
+    }
+  });
+
+  return hasData ? result : null;
+}
+
+function applyCornerHeightsToAttribute(attribute, heights, baseY = 0) {
+  if (!attribute || !heights) return false;
+
+  const vector = new THREE.Vector3();
+  const count = attribute.count ?? 0;
+  if (!count) return false;
+
+  let minX = Infinity;
+  let maxX = -Infinity;
+  let minZ = Infinity;
+  let maxZ = -Infinity;
+
+  for (let i = 0; i < count; i += 1) {
+    vector.fromBufferAttribute(attribute, i);
+    if (vector.x < minX) minX = vector.x;
+    if (vector.x > maxX) maxX = vector.x;
+    if (vector.z < minZ) minZ = vector.z;
+    if (vector.z > maxZ) maxZ = vector.z;
+  }
+
+  const deltaX = maxX - minX;
+  const deltaZ = maxZ - minZ;
+
+  const nw = heights.nw ?? 0;
+  const ne = heights.ne ?? 0;
+  const sw = heights.sw ?? 0;
+  const se = heights.se ?? 0;
+
+  for (let i = 0; i < count; i += 1) {
+    vector.fromBufferAttribute(attribute, i);
+    const tx = deltaX !== 0 ? THREE.MathUtils.clamp((vector.x - minX) / deltaX, 0, 1) : 0;
+    const tz = deltaZ !== 0 ? THREE.MathUtils.clamp((vector.z - minZ) / deltaZ, 0, 1) : 0;
+
+    const north = THREE.MathUtils.lerp(nw, ne, tx);
+    const south = THREE.MathUtils.lerp(sw, se, tx);
+    const interpolated = THREE.MathUtils.lerp(south, north, tz);
+
+    attribute.setY(i, baseY + interpolated);
+  }
+
+  attribute.needsUpdate = true;
+  return true;
+}
+
 export function createDirtMaterial({ repeat = 16, anisotropy = 8 } = {}) {
   const color = configureTexture(loadBaseTexture(), { repeat, anisotropy });
 
@@ -127,7 +203,8 @@ export function createDirtMaterial({ repeat = 16, anisotropy = 8 } = {}) {
  * @typedef {Object} DirtOptions
  * @property {number} [height=0]                       Global Y offset for the tile.
  * @property {{x?:number, z?:number}} [slope]          Linear slope (rise per meter) along local X and Z axes.
- * @property {{nw?:number, ne?:number, se?:number, sw?:number}} [cornerHeights] Explicit per-corner heights in meters.
+ * @property {{nw?:number, ne?:number, se?:number, sw?:number}|[number,number,number,number]} [cornerHeights]
+ *          Explicit per-corner height offsets in meters. Array order: [nw, ne, sw, se].
  */
 
 export function createDirtGround({
@@ -151,21 +228,24 @@ export function createDirtGround({
   geo.rotateX(-Math.PI / 2);
 
   const positionAttribute = geo.getAttribute('position');
+  const finalHeight = typeof height === 'number' ? height : 0;
+  const finalBias = typeof heightBias === 'number' ? heightBias : 0;
+  const baseY = finalHeight + finalBias;
+
+  const normalizedCorners = normalizeCornerHeightsInput(cornerHeights);
+  let appliedCornerHeights = false;
+
+  if (positionAttribute && normalizedCorners) {
+    appliedCornerHeights = applyCornerHeightsToAttribute(positionAttribute, normalizedCorners, baseY);
+    if (appliedCornerHeights) {
+      geo.computeVertexNormals();
+    }
+  }
+
   const halfSize = geometrySize / 2;
   let updatedVertices = false;
 
-  if (positionAttribute && cornerHeights) {
-    const bl = cornerHeights.sw ?? 0;
-    const br = cornerHeights.se ?? 0;
-    const tl = cornerHeights.nw ?? 0;
-    const tr = cornerHeights.ne ?? 0;
-
-    positionAttribute.setY(0, positionAttribute.getY(0) + bl);
-    positionAttribute.setY(1, positionAttribute.getY(1) + br);
-    positionAttribute.setY(2, positionAttribute.getY(2) + tl);
-    positionAttribute.setY(3, positionAttribute.getY(3) + tr);
-    updatedVertices = true;
-  } else if (positionAttribute && slope && (slope.x || slope.z)) {
+  if (!appliedCornerHeights && positionAttribute && slope && (slope.x || slope.z)) {
     const sx = slope.x ?? 0;
     const sz = slope.z ?? 0;
     if (halfSize > 0) {
@@ -184,9 +264,12 @@ export function createDirtGround({
     geo.computeVertexNormals();
   }
 
-  const finalHeight = typeof height === 'number' ? height : 0;
-  const finalBias = typeof heightBias === 'number' ? heightBias : 0;
-  geo.translate(0, finalHeight + finalBias, 0);
+  if (!appliedCornerHeights) {
+    const translateY = baseY;
+    if (translateY !== 0) {
+      geo.translate(0, translateY, 0);
+    }
+  }
 
   const mat = createDirtMaterial({ repeat, anisotropy });
   // Avoid z-fighting with other coplanar layers

--- a/src/ground/grass.js
+++ b/src/ground/grass.js
@@ -100,11 +100,88 @@ function configureTexture(baseTexture, { repeat, anisotropy }) {
   return texture;
 }
 
+function normalizeCornerHeightsInput(input) {
+  if (!input) return null;
+
+  const keys = ['nw', 'ne', 'sw', 'se'];
+  let source = null;
+
+  if (Array.isArray(input)) {
+    const [nw, ne, sw, se] = input;
+    source = { nw, ne, sw, se };
+  } else if (typeof input === 'object') {
+    source = input;
+  } else {
+    return null;
+  }
+
+  const result = { nw: 0, ne: 0, sw: 0, se: 0 };
+  let hasData = false;
+
+  keys.forEach((key) => {
+    if (Object.prototype.hasOwnProperty.call(source, key)) {
+      hasData = true;
+    }
+    const value = source[key];
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      result[key] = value;
+      hasData = true;
+    }
+  });
+
+  return hasData ? result : null;
+}
+
+function applyCornerHeightsToAttribute(attribute, heights, baseY = 0) {
+  if (!attribute || !heights) return false;
+
+  const vector = new THREE.Vector3();
+  const count = attribute.count ?? 0;
+  if (!count) return false;
+
+  let minX = Infinity;
+  let maxX = -Infinity;
+  let minZ = Infinity;
+  let maxZ = -Infinity;
+
+  for (let i = 0; i < count; i += 1) {
+    vector.fromBufferAttribute(attribute, i);
+    if (vector.x < minX) minX = vector.x;
+    if (vector.x > maxX) maxX = vector.x;
+    if (vector.z < minZ) minZ = vector.z;
+    if (vector.z > maxZ) maxZ = vector.z;
+  }
+
+  const deltaX = maxX - minX;
+  const deltaZ = maxZ - minZ;
+
+  const nw = heights.nw ?? 0;
+  const ne = heights.ne ?? 0;
+  const sw = heights.sw ?? 0;
+  const se = heights.se ?? 0;
+
+  for (let i = 0; i < count; i += 1) {
+    vector.fromBufferAttribute(attribute, i);
+    const tx = deltaX !== 0 ? THREE.MathUtils.clamp((vector.x - minX) / deltaX, 0, 1) : 0;
+    const tz = deltaZ !== 0 ? THREE.MathUtils.clamp((vector.z - minZ) / deltaZ, 0, 1) : 0;
+
+    const north = THREE.MathUtils.lerp(nw, ne, tx);
+    const south = THREE.MathUtils.lerp(sw, se, tx);
+    const interpolated = THREE.MathUtils.lerp(south, north, tz);
+
+    attribute.setY(i, baseY + interpolated);
+  }
+
+  attribute.needsUpdate = true;
+  return true;
+}
+
 /**
  * @typedef {Object} GrassOptions
  * @property {number} [height=0.02]                       Global Y offset for the tile.
  * @property {{x?:number, z?:number}} [slope]             Linear slope (rise per meter) along local X and Z axes.
- * @property {{nw?:number, ne?:number, se?:number, sw?:number}} [cornerHeights] Explicit per-corner heights in meters.
+ * @property {{nw?:number, ne?:number, se?:number, sw?:number}|[number,number,number,number]} [cornerHeights]
+ *          Explicit per-corner height offsets in meters. Array order: [nw, ne, sw, se].
  */
 
 export function createGrassGround({
@@ -126,21 +203,21 @@ export function createGrassGround({
   geo.rotateX(-Math.PI / 2);
 
   const positionAttribute = geo.getAttribute('position');
+  const normalizedCorners = normalizeCornerHeightsInput(cornerHeights);
+  const finalHeight = Math.max(typeof height === 'number' ? height : 0.02, 0.02);
+  let appliedCornerHeights = false;
+
+  if (positionAttribute && normalizedCorners) {
+    appliedCornerHeights = applyCornerHeightsToAttribute(positionAttribute, normalizedCorners, finalHeight);
+    if (appliedCornerHeights) {
+      geo.computeVertexNormals();
+    }
+  }
+
   const halfSize = geometrySize / 2;
   let updatedVertices = false;
 
-  if (positionAttribute && cornerHeights) {
-    const bl = cornerHeights.sw ?? 0;
-    const br = cornerHeights.se ?? 0;
-    const tl = cornerHeights.nw ?? 0;
-    const tr = cornerHeights.ne ?? 0;
-
-    positionAttribute.setY(0, positionAttribute.getY(0) + bl);
-    positionAttribute.setY(1, positionAttribute.getY(1) + br);
-    positionAttribute.setY(2, positionAttribute.getY(2) + tl);
-    positionAttribute.setY(3, positionAttribute.getY(3) + tr);
-    updatedVertices = true;
-  } else if (positionAttribute && slope && (slope.x || slope.z)) {
+  if (!appliedCornerHeights && positionAttribute && slope && (slope.x || slope.z)) {
     const sx = slope.x ?? 0;
     const sz = slope.z ?? 0;
     if (halfSize > 0) {
@@ -159,8 +236,12 @@ export function createGrassGround({
     geo.computeVertexNormals();
   }
 
-  const finalHeight = Math.max(typeof height === 'number' ? height : 0.02, 0.02);
-  geo.translate(0, finalHeight, 0);
+  if (!appliedCornerHeights) {
+    const translateY = finalHeight;
+    if (translateY !== 0) {
+      geo.translate(0, translateY, 0);
+    }
+  }
 
   const color = configureTexture(loadBaseTexture(), { repeat, anisotropy });
 

--- a/src/ground/index.js
+++ b/src/ground/index.js
@@ -14,6 +14,7 @@ export const GroundType = Object.freeze({
 const DEFAULT_TILE_GRID = Object.freeze({ columns: 5, rows: 5 });
 const BUILDING_NAME_PATTERN = /(foundation|building|pad)/i;
 const BUILDING_USERDATA_KEYS = ['building', 'buildingPad', 'foundation', 'isBuilding', 'isFoundation'];
+const CORNER_KEYS = ['nw', 'ne', 'sw', 'se'];
 
 // Skirt tuning values (world units).
 const SKIRT_MIN_DELTA = 0.03;
@@ -220,15 +221,87 @@ function computeTileBounds(position, size) {
   };
 }
 
-function averageCornerHeight(cornerHeights) {
-  if (!cornerHeights || typeof cornerHeights !== 'object') return 0;
-  const corners = ['nw', 'ne', 'se', 'sw'];
-  let total = 0;
-  for (const key of corners) {
-    const value = cornerHeights[key];
-    total += typeof value === 'number' ? value : 0;
+function normalizeCornerHeights(value) {
+  if (!value) return null;
+
+  let source = null;
+  if (Array.isArray(value)) {
+    const [nw, ne, sw, se] = value;
+    source = { nw, ne, sw, se };
+  } else if (typeof value === 'object') {
+    source = value;
+  } else {
+    return null;
   }
-  return total / corners.length;
+
+  const result = { nw: 0, ne: 0, sw: 0, se: 0 };
+  let hasData = false;
+
+  CORNER_KEYS.forEach((key) => {
+    if (Object.prototype.hasOwnProperty.call(source, key)) {
+      hasData = true;
+    }
+    const valueForKey = source[key];
+    if (typeof valueForKey === 'number' && Number.isFinite(valueForKey)) {
+      result[key] = valueForKey;
+      hasData = true;
+    }
+  });
+
+  return hasData ? result : null;
+}
+
+function combineCornerHeights(...values) {
+  let combined = null;
+  values.forEach((value) => {
+    const normalized = normalizeCornerHeights(value);
+    if (!normalized) return;
+    if (!combined) {
+      combined = { nw: 0, ne: 0, sw: 0, se: 0 };
+    }
+    CORNER_KEYS.forEach((key) => {
+      combined[key] += normalized[key] ?? 0;
+    });
+  });
+  return combined;
+}
+
+function cornerHeightsToArray(value) {
+  const normalized = normalizeCornerHeights(value);
+  if (!normalized) return null;
+  return [
+    normalized.nw ?? 0,
+    normalized.ne ?? 0,
+    normalized.sw ?? 0,
+    normalized.se ?? 0,
+  ];
+}
+
+function safeSampleHeight(fn, x, z) {
+  if (typeof fn !== 'function') return 0;
+  try {
+    const value = fn(x, z);
+    return (typeof value === 'number' && Number.isFinite(value)) ? value : 0;
+  } catch {
+    return 0;
+  }
+}
+
+function averageCornerHeight(cornerHeights) {
+  const normalized = normalizeCornerHeights(cornerHeights);
+  if (!normalized) return 0;
+
+  let total = 0;
+  let count = 0;
+  CORNER_KEYS.forEach((key) => {
+    const value = normalized[key];
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      total += value;
+      count += 1;
+    }
+  });
+
+  return count > 0 ? total / count : 0;
 }
 
 const SKIRT_DIRECTIONS = [
@@ -435,6 +508,7 @@ function createFoundationBlendRingMesh({ size, repeat, anisotropy } = {}) {
  * @param {boolean} [options.addFoundationBlendRing=false] - Adds optional blend ring when dirt is disabled.
  * @param {boolean} [options.preventTileSeams=true] - Expand tile geometry slightly to hide seams.
  * @param {boolean} [options.stabilizeTileOverlap=true] - Apply a subtle alternating height bias to dirt tiles.
+ * @param {(x:number, z:number)=>number} [options.heightFn] - Optional sampler returning additional height per world X/Z corner.
  *
  * Tile definitions may specify `disableUnderBuilding` to suppress dirt/grass meshes and
  * `addFoundationBlendRing` to render a subtle inset ring around pads.
@@ -464,6 +538,7 @@ export function createGroundLayered({
   addFoundationBlendRing = false,
   preventTileSeams = true,
   stabilizeTileOverlap = true,
+  heightFn,
 } = {}) {
   const root = new THREE.Group();
   root.name = 'ground:root';
@@ -503,6 +578,7 @@ export function createGroundLayered({
 
   const enableSeamPrevention = !!preventTileSeams;
   const enableTileStabilization = !!stabilizeTileOverlap;
+  const sampleHeightFn = typeof heightFn === 'function' ? heightFn : null;
 
   const tileInstances = [];
 
@@ -534,6 +610,47 @@ export function createGroundLayered({
       expandForSeams: tile.grassOptions?.expandForSeams ?? grassOptions.expandForSeams ?? enableSeamPrevention,
     };
 
+    const sizeForSampling = typeof dirtConfig.size === 'number'
+      ? dirtConfig.size
+      : (typeof grassConfig.size === 'number' ? grassConfig.size : fallbackSize ?? resolvedDefaultSize);
+
+    let coverageSize = typeof sizeForSampling === 'number' ? sizeForSampling : resolvedDefaultSize;
+    let bounds = computeTileBounds(tile.position, coverageSize);
+
+    let sampledCorners = null;
+    if (sampleHeightFn) {
+      sampledCorners = {
+        nw: safeSampleHeight(sampleHeightFn, bounds.minX, bounds.maxZ),
+        ne: safeSampleHeight(sampleHeightFn, bounds.maxX, bounds.maxZ),
+        sw: safeSampleHeight(sampleHeightFn, bounds.minX, bounds.minZ),
+        se: safeSampleHeight(sampleHeightFn, bounds.maxX, bounds.minZ),
+      };
+    }
+
+    const existingDirtCorners = dirtConfig.cornerHeights;
+    const existingGrassCorners = grassConfig.cornerHeights;
+
+    const combinedDirtCorners = combineCornerHeights(sampledCorners, existingDirtCorners);
+    const combinedGrassCorners = combineCornerHeights(sampledCorners, existingGrassCorners);
+
+    const finalDirtCornerArray = combinedDirtCorners
+      ? cornerHeightsToArray(combinedDirtCorners)
+      : cornerHeightsToArray(existingDirtCorners);
+    if (finalDirtCornerArray) {
+      dirtConfig.cornerHeights = finalDirtCornerArray;
+    } else {
+      delete dirtConfig.cornerHeights;
+    }
+
+    const finalGrassCornerArray = combinedGrassCorners
+      ? cornerHeightsToArray(combinedGrassCorners)
+      : cornerHeightsToArray(existingGrassCorners);
+    if (finalGrassCornerArray) {
+      grassConfig.cornerHeights = finalGrassCornerArray;
+    } else {
+      delete grassConfig.cornerHeights;
+    }
+
     const baseDirtHeight = typeof dirtConfig.height === 'number' ? dirtConfig.height : 0;
     const baseDirtBias = typeof dirtConfig.heightBias === 'number' ? dirtConfig.heightBias : 0;
     const baseCornerAverage = averageCornerHeight(dirtConfig.cornerHeights);
@@ -562,8 +679,13 @@ export function createGroundLayered({
       grassLayer.add(grass);
     }
 
-    const coverageSize = dirtSize ?? fallbackSize ?? resolvedDefaultSize;
-    const bounds = computeTileBounds(tile.position, coverageSize);
+    if (typeof dirtSize === 'number' && Number.isFinite(dirtSize)) {
+      coverageSize = dirtSize;
+    }
+    if (!(coverageSize > 0)) {
+      coverageSize = fallbackSize ?? resolvedDefaultSize;
+    }
+    bounds = computeTileBounds(tile.position, coverageSize);
 
     // Optional foundation blend ring around disabled (building pad) tiles
     if (addFoundationBlendRing && tile.addFoundationBlendRing && disableForBuilding) {

--- a/src/scene/ground.js
+++ b/src/scene/ground.js
@@ -45,6 +45,15 @@ function isGroundDebugEnabled() {
   }
 }
 
+function isSlopeDemoEnabled() {
+  if (typeof window === 'undefined') return false;
+  try {
+    return new URLSearchParams(window.location.search).get('slopeDemo') === '1';
+  } catch {
+    return false;
+  }
+}
+
 // Signature stays the same as your current code expects.
 export async function loadGround(scene, renderer, options = {}) {
   const {
@@ -66,6 +75,7 @@ export async function loadGround(scene, renderer, options = {}) {
     addFoundationBlendRing = false,
     preventTileSeams,
     stabilizeTileOverlap,
+    heightFn,
   } = options;
 
   const hasShowDirtOverride = Object.prototype.hasOwnProperty.call(options, 'showDirt');
@@ -75,6 +85,11 @@ export async function loadGround(scene, renderer, options = {}) {
   const initialShowGrass = hasShowGrassOverride ? !!showGrass : true;
 
   if (!__groundSingleton) {
+    let effectiveHeightFn = typeof heightFn === 'function' ? heightFn : undefined;
+    if (!effectiveHeightFn && isSlopeDemoEnabled()) {
+      effectiveHeightFn = (x) => 0.002 * x;
+    }
+
     const layeredOptions = {
       dirtOptions: { size, repeat, height: 0, ...dirtOptions },
       grassOptions: { size, repeat, height: 0.02, ...grassOptions },
@@ -88,6 +103,10 @@ export async function loadGround(scene, renderer, options = {}) {
       addElevationSkirts,
       addFoundationBlendRing,
     };
+
+    if (effectiveHeightFn) {
+      layeredOptions.heightFn = effectiveHeightFn;
+    }
 
     if (typeof preventTileSeams === 'boolean') {
       layeredOptions.preventTileSeams = preventTileSeams;


### PR DESCRIPTION
## Summary
- add per-corner height warping for dirt and grass meshes with recomputed normals
- expose an optional heightFn in createGroundLayered to sample tile corner heights and keep debug/elevation data accurate
- wire an optional slope demo heightFn in loadGround behind the `?slopeDemo=1` query parameter

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68db27ea2d3c8327a7ab26c42c2b3c6c