### PR TITLE
Adjust Acropolis terrace shadow casting and snapping set

### DIFF
--- a/src/buildings/createCity.js
+++ b/src/buildings/createCity.js
@@ -110,7 +110,7 @@ export async function createCity({ renderer, scene, ground: groundOverrides } = 
   };
 
   const namedTargets = new Set();
-  ['Parthenon', 'Acropolis', 'AcropolisGroup'].forEach((name) => {
+  ['Parthenon', 'Acropolis'].forEach((name) => {
     const rootTarget = ensureNamedObject(root, name);
     const sceneTarget = ensureNamedObject(scene, name);
     if (rootTarget) {

--- a/src/buildings/ground.js
+++ b/src/buildings/ground.js
@@ -107,7 +107,7 @@ function buildAcropolisMesa(scene, materials, options) {
     const geometry = new THREE.CylinderGeometry(radius, radius, stepHeight, 48, 1, false);
     const mesh = new THREE.Mesh(geometry, terraceMaterial);
     mesh.name = `AcropolisTerrace:${terraces - i}`;
-    mesh.castShadow = false;
+    mesh.castShadow = true;
     mesh.receiveShadow = true;
     mesh.position.y = stepBottom + stepHeight / 2;
     acropolisGroup.add(mesh);


### PR DESCRIPTION
## Summary
- enable Acropolis terrace meshes to cast shadows for better lighting
- limit Acropolis height snapping to the named temple groups only

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68db2a8c07e88327a428aca0b2b45f93