### PR TITLE
Add Athens plan layout with new civic landmarks

### DIFF
--- a/data/athens_places.geojson
+++ b/data/athens_places.geojson
@@ -441,6 +441,74 @@
         "license": "CC BY 4.0",
         "kind": "wall_corridor"
       }
+    },
+    {
+      "type": "Feature",
+      "name": "Agora",
+      "geometry": { "type": "Point", "coordinates": [23.7229, 37.9753] },
+      "properties": { "category": "landmark" }
+    },
+    {
+      "type": "Feature",
+      "name": "Stoa of Attalos",
+      "geometry": { "type": "Point", "coordinates": [23.7249, 37.975] },
+      "properties": { "category": "landmark" }
+    },
+    {
+      "type": "Feature",
+      "name": "Tholos",
+      "geometry": { "type": "Point", "coordinates": [23.7224, 37.9742] },
+      "properties": { "category": "landmark" }
+    },
+    {
+      "type": "Feature",
+      "name": "Theater of Dionysus",
+      "geometry": { "type": "Point", "coordinates": [23.726, 37.9705] },
+      "properties": { "category": "landmark" }
+    },
+    {
+      "type": "Feature",
+      "name": "Stadium",
+      "geometry": { "type": "Point", "coordinates": [23.7416, 37.9681] },
+      "properties": { "category": "landmark" }
+    },
+    {
+      "type": "Feature",
+      "name": "CityGate South",
+      "geometry": { "type": "Point", "coordinates": [23.7255, 37.9665] },
+      "properties": { "category": "landmark" }
+    },
+    {
+      "type": "Feature",
+      "name": "Port Quay A",
+      "geometry": { "type": "Point", "coordinates": [23.6436, 37.9412] },
+      "properties": { "category": "landmark" }
+    },
+    {
+      "type": "Feature",
+      "name": "Long Walls - Western",
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [23.7255, 37.9665],
+          [23.706, 37.9515],
+          [23.6436, 37.9412]
+        ]
+      },
+      "properties": { "category": "landmark" }
+    },
+    {
+      "type": "Feature",
+      "name": "Long Walls - Eastern",
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [23.7255, 37.9665],
+          [23.71, 37.953],
+          [23.6488, 37.9418]
+        ]
+      },
+      "properties": { "category": "landmark" }
     }
   ],
   "note": "Representative points for visualization; temple offsets approximate to align with Agora overlays."

--- a/src/buildings/createCityExtended.js
+++ b/src/buildings/createCityExtended.js
@@ -5,10 +5,13 @@ import { createStoa } from './stoa.js';
 import { createTheater } from './theater.js';
 import { createHouseBlock } from './houses.js';
 import { createCityWalls, createGate } from './gatesWalls.js';
-import { snapGroupToGround } from '../physics/groundProject.js';
+import { snapGroupToGround, sampleGroundY } from '../physics/groundProject.js';
 import { markGround, collectGround } from '../physics/groundRegistry.js';
+import { createTholos } from './tholos.js';
+import { createStadium } from './stadium.js';
+import { createPort } from './port.js';
 
-export async function createCityExtended({ renderer, scene } = {}) {
+export async function createCityExtended({ renderer, scene, layout = 'classic', layoutConfig = {} } = {}) {
   const materials = await loadMaterials(renderer);
   const root = new THREE.Group();
   root.name = 'AthensCity_Extended';
@@ -20,81 +23,244 @@ export async function createCityExtended({ renderer, scene } = {}) {
   markGround(scene ?? root);
   const groundMeshes = collectGround(scene ?? root);
 
-  const heph = createTemple(materials, {
-    footprint: [22, 45],
-    columns: [6, 13],
-    position: new THREE.Vector3(-60, 0, 30),
-    groundMeshes
-  });
-  heph.name = 'Temple_of_Hephaestus';
-  root.add(heph);
+  if (layout === 'athensPlan') {
+    // CITYPLAN_START
+    const PRESET = {
+      Agora: { x: -40, y: 'ground', z: 30 },
+      Stoa_of_Attalos: { x: -20, y: 'ground', z: 20 },
+      Tholos: { x: -48, y: 'ground', z: 18 },
+      Theater_of_Dionysus: { x: 35, y: 'ground', z: 15 },
+      Stadium: { x: 80, y: 'ground', z: 10 },
+      CityGate_South: { x: 10, y: 'ground', z: 110 },
+      Port_Quay_A: { x: 10, y: 'ground', z: 160 }
+    };
 
-  const stoa = createStoa(materials, {
-    length: 120,
-    depth: 16,
-    colSpacing: 5,
-    position: new THREE.Vector3(80, 0, -40),
-    groundMeshes
-  });
-  stoa.name = 'Stoa_of_Attalos';
-  root.add(stoa);
+    const plateauHeight = typeof scene?.userData?.acropolis?.plateauHeight === 'number'
+      ? scene.userData.acropolis.plateauHeight
+      : null;
 
-  const theater = createTheater(materials, {
-    radius: 55,
-    steps: 18,
-    position: new THREE.Vector3(150, 0, 120),
-    groundMeshes
-  });
-  theater.name = 'Theater_of_Dionysus';
-  root.add(theater);
+    const resolveConfigEntry = (key) => {
+      const preset = PRESET[key] ? { ...PRESET[key] } : {};
+      const override = layoutConfig?.[key];
+      if (override instanceof THREE.Vector3) {
+        return { x: override.x, y: override.y, z: override.z };
+      }
+      if (Array.isArray(override)) {
+        const [ox = preset.x ?? 0, oy = preset.y ?? 0, oz = preset.z ?? 0] = override;
+        return { x: ox, y: oy, z: oz };
+      }
+      if (override && typeof override === 'object') {
+        return { ...preset, ...override };
+      }
+      if (typeof override === 'number') {
+        return { ...preset, y: override };
+      }
+      return preset;
+    };
 
-  const housesNW = createHouseBlock(materials, {
-    rows: 3,
-    cols: 4,
-    spacing: 14,
-    position: new THREE.Vector3(40, 0, -100),
-    groundMeshes
-  });
-  housesNW.name = 'Houses_NW';
-  root.add(housesNW);
+    const resolvePosition = (key, fallback = new THREE.Vector3()) => {
+      const config = resolveConfigEntry(key);
+      const position = fallback.clone();
+      const x = typeof config.x === 'number' ? config.x : fallback.x;
+      const z = typeof config.z === 'number' ? config.z : fallback.z;
+      let yValue = config.y;
+      if (yValue === 'ground' && groundMeshes.length) {
+        const sampled = sampleGroundY(x, z, groundMeshes, { fromY: 400 });
+        if (typeof sampled === 'number') {
+          yValue = sampled;
+        } else {
+          yValue = fallback.y;
+        }
+      } else if (yValue === 'acropolis' && typeof plateauHeight === 'number') {
+        yValue = plateauHeight;
+      } else if (typeof yValue !== 'number') {
+        yValue = fallback.y ?? 0;
+      }
+      position.set(x, yValue ?? 0, z);
+      return position;
+    };
 
-  const housesNE = createHouseBlock(materials, {
-    rows: 3,
-    cols: 4,
-    spacing: 14,
-    position: new THREE.Vector3(120, 0, -100),
-    groundMeshes
-  });
-  housesNE.name = 'Houses_NE';
-  root.add(housesNE);
+    const applyLayoutToExisting = (key) => {
+      const target = scene?.getObjectByName?.(key);
+      if (!target) {
+        return;
+      }
+      const currentPosition = target.position instanceof THREE.Vector3 ? target.position : new THREE.Vector3();
+      const desired = resolvePosition(key, currentPosition);
+      target.position.copy(desired);
+      target.updateMatrixWorld?.();
+    };
 
-  const wallPath = [
-    new THREE.Vector3(-220, 0, -200),
-    new THREE.Vector3(220, 0, -200),
-    new THREE.Vector3(220, 0, 220),
-    new THREE.Vector3(-220, 0, 220),
-    new THREE.Vector3(-220, 0, -200)
-  ];
-  const walls = createCityWalls(materials, {
-    path: wallPath,
-    towerEvery: 120,
-    height: 9,
-    thickness: 4,
-    groundMeshes
-  });
-  walls.name = 'CityWalls';
-  root.add(walls);
+    applyLayoutToExisting('Agora');
 
-  const gate = createGate(materials, {
-    width: 10,
-    height: 8,
-    position: new THREE.Vector3(0, 0, -200),
-    facingYaw: 0,
-    thickness: 4,
-    groundMeshes
-  });
-  gate.name = 'CityGate_North';
-  root.add(gate);
+    const heph = createTemple(materials, {
+      footprint: [22, 45],
+      columns: [6, 13],
+      position: new THREE.Vector3(-60, 0, 45),
+      groundMeshes
+    });
+    heph.name = 'Temple_of_Hephaestus';
+    root.add(heph);
+
+    const stoaPosition = resolvePosition('Stoa_of_Attalos', new THREE.Vector3(80, 0, -40));
+    const stoa = createStoa(materials, {
+      length: 120,
+      depth: 16,
+      colSpacing: 5,
+      position: stoaPosition,
+      groundMeshes
+    });
+    stoa.name = 'Stoa_of_Attalos';
+    root.add(stoa);
+
+    const tholosPosition = resolvePosition('Tholos');
+    const tholos = createTholos(materials, { position: tholosPosition });
+    root.add(tholos);
+
+    const theaterPosition = resolvePosition('Theater_of_Dionysus', new THREE.Vector3(150, 0, 120));
+    const theater = createTheater(materials, {
+      radius: 55,
+      steps: 18,
+      position: theaterPosition,
+      groundMeshes
+    });
+    theater.name = 'Theater_of_Dionysus';
+    root.add(theater);
+
+    const stadiumPosition = resolvePosition('Stadium');
+    const stadium = createStadium(materials, { position: stadiumPosition });
+    root.add(stadium);
+
+    const housesNW = createHouseBlock(materials, {
+      rows: 3,
+      cols: 4,
+      spacing: 14,
+      position: new THREE.Vector3(-90, 0, -60),
+      groundMeshes
+    });
+    housesNW.name = 'Houses_NW';
+    root.add(housesNW);
+
+    const housesNE = createHouseBlock(materials, {
+      rows: 3,
+      cols: 4,
+      spacing: 14,
+      position: new THREE.Vector3(40, 0, -80),
+      groundMeshes
+    });
+    housesNE.name = 'Houses_NE';
+    root.add(housesNE);
+
+    const wallPath = [
+      new THREE.Vector3(-220, 0, -200),
+      new THREE.Vector3(220, 0, -200),
+      new THREE.Vector3(220, 0, 220),
+      new THREE.Vector3(-220, 0, 220),
+      new THREE.Vector3(-220, 0, -200)
+    ];
+    const walls = createCityWalls(materials, {
+      path: wallPath,
+      towerEvery: 120,
+      height: 9,
+      thickness: 4,
+      groundMeshes
+    });
+    walls.name = 'CityWalls';
+    root.add(walls);
+
+    const gatePosition = resolvePosition('CityGate_South', new THREE.Vector3(0, 0, -200));
+    const gate = createGate(materials, {
+      width: 10,
+      height: 8,
+      position: gatePosition,
+      facingYaw: 0,
+      thickness: 4,
+      groundMeshes
+    });
+    gate.name = 'CityGate_South';
+    root.add(gate);
+
+    const portPosition = resolvePosition('Port_Quay_A');
+    const port = createPort(materials, { position: portPosition });
+    root.add(port);
+    // CITYPLAN_END
+  } else {
+    const heph = createTemple(materials, {
+      footprint: [22, 45],
+      columns: [6, 13],
+      position: new THREE.Vector3(-60, 0, 30),
+      groundMeshes
+    });
+    heph.name = 'Temple_of_Hephaestus';
+    root.add(heph);
+
+    const stoa = createStoa(materials, {
+      length: 120,
+      depth: 16,
+      colSpacing: 5,
+      position: new THREE.Vector3(80, 0, -40),
+      groundMeshes
+    });
+    stoa.name = 'Stoa_of_Attalos';
+    root.add(stoa);
+
+    const theater = createTheater(materials, {
+      radius: 55,
+      steps: 18,
+      position: new THREE.Vector3(150, 0, 120),
+      groundMeshes
+    });
+    theater.name = 'Theater_of_Dionysus';
+    root.add(theater);
+
+    const housesNW = createHouseBlock(materials, {
+      rows: 3,
+      cols: 4,
+      spacing: 14,
+      position: new THREE.Vector3(40, 0, -100),
+      groundMeshes
+    });
+    housesNW.name = 'Houses_NW';
+    root.add(housesNW);
+
+    const housesNE = createHouseBlock(materials, {
+      rows: 3,
+      cols: 4,
+      spacing: 14,
+      position: new THREE.Vector3(120, 0, -100),
+      groundMeshes
+    });
+    housesNE.name = 'Houses_NE';
+    root.add(housesNE);
+
+    const wallPath = [
+      new THREE.Vector3(-220, 0, -200),
+      new THREE.Vector3(220, 0, -200),
+      new THREE.Vector3(220, 0, 220),
+      new THREE.Vector3(-220, 0, 220),
+      new THREE.Vector3(-220, 0, -200)
+    ];
+    const walls = createCityWalls(materials, {
+      path: wallPath,
+      towerEvery: 120,
+      height: 9,
+      thickness: 4,
+      groundMeshes
+    });
+    walls.name = 'CityWalls';
+    root.add(walls);
+
+    const gate = createGate(materials, {
+      width: 10,
+      height: 8,
+      position: new THREE.Vector3(0, 0, -200),
+      facingYaw: 0,
+      thickness: 4,
+      groundMeshes
+    });
+    gate.name = 'CityGate_North';
+    root.add(gate);
+  }
 
   root.children.forEach((child) => {
     if (!groundMeshes.length) return;

--- a/src/buildings/port.js
+++ b/src/buildings/port.js
@@ -1,0 +1,49 @@
+import * as THREE from 'three';
+
+export function createPort(materials = {}, opts = {}) {
+  const group = new THREE.Group();
+  group.name = 'Port';
+
+  // CITYPLAN_START
+  const position = opts.position instanceof THREE.Vector3
+    ? opts.position.clone()
+    : new THREE.Vector3().copy(opts.position || new THREE.Vector3());
+  group.position.copy(position);
+
+  const stoneMaterial = materials?.marble || materials?.citywall || new THREE.MeshStandardMaterial({ color: 0xc8c0b4 });
+
+  const quayLength = opts.quayLength ?? 80;
+  const quayWidth = opts.quayWidth ?? 14;
+  const quayHeight = opts.quayHeight ?? 4;
+
+  const quayGeometry = new THREE.BoxGeometry(quayLength, quayHeight, quayWidth);
+  const quay = new THREE.Mesh(quayGeometry, stoneMaterial);
+  quay.castShadow = true;
+  quay.receiveShadow = true;
+  quay.name = 'Port_Quay_A';
+  quay.position.y = quayHeight / 2;
+  group.add(quay);
+
+  const stepsGeometry = new THREE.BoxGeometry(quayLength * 0.6, quayHeight * 0.4, quayWidth * 0.4);
+  const steps = new THREE.Mesh(stepsGeometry, stoneMaterial);
+  steps.castShadow = true;
+  steps.receiveShadow = true;
+  steps.position.set(0, quayHeight * 0.3, -quayWidth * 0.35);
+  group.add(steps);
+
+  const bollardGeometry = new THREE.CylinderGeometry(quayWidth * 0.05, quayWidth * 0.05, quayHeight * 0.4, 12);
+  const bollardCount = Math.max(4, Math.floor(opts.bollardCount ?? 6));
+  const bollardSpacing = quayLength / (bollardCount + 1);
+  for (let i = 0; i < bollardCount; i += 1) {
+    const bollard = new THREE.Mesh(bollardGeometry, stoneMaterial);
+    bollard.castShadow = true;
+    bollard.receiveShadow = true;
+    bollard.position.set(-quayLength / 2 + bollardSpacing * (i + 1), quayHeight * 0.75, -quayWidth * 0.5);
+    group.add(bollard);
+  }
+
+  // CITYPLAN_END
+  return group;
+}
+
+export default createPort;

--- a/src/buildings/stadium.js
+++ b/src/buildings/stadium.js
@@ -1,0 +1,73 @@
+import * as THREE from 'three';
+
+export function createStadium(materials = {}, opts = {}) {
+  const group = new THREE.Group();
+  group.name = 'Stadium';
+
+  // CITYPLAN_START
+  const position = opts.position instanceof THREE.Vector3
+    ? opts.position.clone()
+    : new THREE.Vector3().copy(opts.position || new THREE.Vector3());
+  group.position.copy(position);
+
+  const trackMaterial = materials?.dust?.clone?.()
+    ? materials.dust.clone()
+    : (materials?.dust || materials?.marble || new THREE.MeshStandardMaterial({ color: 0xb5895a }));
+  const stoneMaterial = materials?.marble || materials?.citywall || new THREE.MeshStandardMaterial({ color: 0xd0c8b0 });
+
+  const length = opts.length ?? 140;
+  const width = opts.width ?? 40;
+  const trackWidth = opts.trackWidth ?? 8;
+  const tiers = Math.max(2, Math.floor(opts.tiers ?? 4));
+  const tierHeight = opts.tierHeight ?? 1.2;
+  const tierDepth = opts.tierDepth ?? 4;
+
+  const outerRadius = width / 2;
+  const innerRadius = Math.max(outerRadius - trackWidth, outerRadius * 0.4);
+  const scaleX = length / width;
+
+  const trackGeometry = new THREE.RingGeometry(innerRadius, outerRadius, 48, 1);
+  const track = new THREE.Mesh(trackGeometry, trackMaterial);
+  track.rotation.x = -Math.PI / 2;
+  track.scale.set(scaleX, 1, 1);
+  track.receiveShadow = true;
+  group.add(track);
+
+  const fieldGeometry = new THREE.PlaneGeometry(innerRadius * 2, width * 0.9, 1, 1);
+  const field = new THREE.Mesh(fieldGeometry, trackMaterial);
+  field.rotation.x = -Math.PI / 2;
+  field.scale.set(scaleX, 1, 1);
+  field.receiveShadow = true;
+  field.position.y = -0.02;
+  group.add(field);
+
+  for (let i = 0; i < tiers; i += 1) {
+    const tierInner = outerRadius + i * tierDepth;
+    const tierOuter = tierInner + tierDepth;
+    const tierGeometry = new THREE.RingGeometry(tierInner, tierOuter, 48, 1);
+    const tier = new THREE.Mesh(tierGeometry, stoneMaterial);
+    tier.rotation.x = -Math.PI / 2;
+    tier.scale.set(scaleX, 1, 1);
+    tier.position.y = tierHeight * (i + 1);
+    tier.castShadow = true;
+    tier.receiveShadow = true;
+    tier.name = `Stadium_Tier_${i + 1}`;
+    group.add(tier);
+  }
+
+  const entryGeometry = new THREE.BoxGeometry(trackWidth, tierHeight * tiers, trackWidth * 0.6);
+  const entryA = new THREE.Mesh(entryGeometry, stoneMaterial);
+  entryA.castShadow = true;
+  entryA.receiveShadow = true;
+  entryA.position.set(0, (tierHeight * tiers) / 2, -innerRadius * scaleX * 0.8);
+  group.add(entryA);
+
+  const entryB = entryA.clone();
+  entryB.position.z *= -1;
+  group.add(entryB);
+
+  // CITYPLAN_END
+  return group;
+}
+
+export default createStadium;

--- a/src/buildings/tholos.js
+++ b/src/buildings/tholos.js
@@ -1,0 +1,72 @@
+import * as THREE from 'three';
+
+export function createTholos(materials = {}, opts = {}) {
+  const group = new THREE.Group();
+  group.name = 'Tholos';
+
+  // CITYPLAN_START
+  const position = opts.position instanceof THREE.Vector3
+    ? opts.position.clone()
+    : new THREE.Vector3().copy(opts.position || new THREE.Vector3());
+  group.position.copy(position);
+
+  const stoneMaterial = materials?.marble || materials?.citywall || new THREE.MeshStandardMaterial({ color: 0xd8d0c0 });
+  const roofMaterial = materials?.roof || stoneMaterial;
+
+  const radius = opts.radius ?? 6;
+  const columnHeight = opts.columnHeight ?? 6;
+  const columnCount = opts.columnCount ?? 12;
+  const baseHeight = opts.baseHeight ?? 0.6;
+
+  const baseGeometry = new THREE.CylinderGeometry(radius * 1.05, radius * 1.05, baseHeight, 32);
+  const base = new THREE.Mesh(baseGeometry, stoneMaterial);
+  base.castShadow = true;
+  base.receiveShadow = true;
+  base.position.y = baseHeight / 2;
+  group.add(base);
+
+  const columnGeometry = new THREE.CylinderGeometry(radius * 0.12, radius * 0.16, columnHeight, 16);
+  const columnGroup = new THREE.Group();
+  columnGroup.name = 'Tholos_Columns';
+  const columnY = baseHeight + columnHeight / 2;
+
+  for (let i = 0; i < columnCount; i += 1) {
+    const theta = (i / columnCount) * Math.PI * 2;
+    const x = Math.cos(theta) * radius;
+    const z = Math.sin(theta) * radius;
+    const column = new THREE.Mesh(columnGeometry, stoneMaterial);
+    column.castShadow = true;
+    column.receiveShadow = true;
+    column.position.set(x, columnY, z);
+    columnGroup.add(column);
+  }
+  group.add(columnGroup);
+
+  const architraveHeight = opts.architraveHeight ?? 0.5;
+  const architraveGeometry = new THREE.CylinderGeometry(radius * 1.02, radius * 1.02, architraveHeight, 32);
+  const architrave = new THREE.Mesh(architraveGeometry, stoneMaterial);
+  architrave.castShadow = true;
+  architrave.receiveShadow = true;
+  architrave.position.y = baseHeight + columnHeight + architraveHeight / 2;
+  group.add(architrave);
+
+  const roofHeight = opts.roofHeight ?? columnHeight * 0.45;
+  const roofGeometry = new THREE.ConeGeometry(radius * 0.9, roofHeight, 24);
+  const roof = new THREE.Mesh(roofGeometry, roofMaterial);
+  roof.castShadow = true;
+  roof.receiveShadow = true;
+  roof.position.y = architrave.position.y + architraveHeight / 2 + roofHeight / 2;
+  group.add(roof);
+
+  const capGeometry = new THREE.SphereGeometry(radius * 0.2, 16, 12);
+  const cap = new THREE.Mesh(capGeometry, stoneMaterial);
+  cap.castShadow = true;
+  cap.receiveShadow = true;
+  cap.position.y = roof.position.y + roofHeight / 2 - radius * 0.2;
+  group.add(cap);
+
+  // CITYPLAN_END
+  return group;
+}
+
+export default createTholos;

--- a/src/entry/initializeAthens.js
+++ b/src/entry/initializeAthens.js
@@ -327,6 +327,11 @@ export async function initializeAthens(options = {}) {
 
   const { width: initialWidth, height: initialHeight } = computeContainerSize(container);
 
+  // CITYPLAN_START
+  const layout = options?.layout === 'athensPlan' ? 'athensPlan' : 'classic';
+  const layoutConfig = options?.layoutConfig ?? {};
+  // CITYPLAN_END
+
   const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: false });
   renderer.shadowMap.enabled = true;
   renderer.setClearColor(DEFAULT_BACKGROUND_HEX, 1);
@@ -467,9 +472,13 @@ export async function initializeAthens(options = {}) {
     console.warn('[Athens] applySky failed.', error);
   });
 
-  await setupGround(scene, renderer);
+  // CITYPLAN_START
+  await setupGround(scene, renderer, { layout, layoutConfig });
+  // CITYPLAN_END
 
-  const city = await createCity({ renderer, scene });
+  // CITYPLAN_START
+  const city = await createCity({ renderer, scene, layout, layoutConfig });
+  // CITYPLAN_END
 
   // Grass material application for main ground
   const mainGround = city?.root?.getObjectByName?.('Ground:MainGrass');
@@ -489,7 +498,9 @@ export async function initializeAthens(options = {}) {
   }
 
   // Extended city (provides root + shared materials)
-  const extendedRes = await createCityExtended({ renderer, scene });
+  // CITYPLAN_START
+  const extendedRes = await createCityExtended({ renderer, scene, layout, layoutConfig });
+  // CITYPLAN_END
   const extendedCity = extendedRes?.root ?? null;
   const sharedMaterials = extendedRes?.materials ?? null;
 
@@ -527,7 +538,11 @@ export async function initializeAthens(options = {}) {
   const landmarks = await loadLandmarks({
     scene,
     geoJsonUrl: options.geoJsonUrl ?? DEFAULT_GEOJSON_URL,
-    groundMeshes
+    groundMeshes,
+    // CITYPLAN_START
+    layout,
+    layoutConfig
+    // CITYPLAN_END
   });
 
   const overlayCanvasId = options.overlayCanvasId ?? DEFAULT_OVERLAY_ID;
@@ -543,7 +558,9 @@ export async function initializeAthens(options = {}) {
   // Roads built from collected points (use extended/shared materials if available)
   let roadNetwork = null;
   if (options.enableRoads !== false) {
-    const roadPoints = collectRoadPoints(scene);
+    // CITYPLAN_START
+    const roadPoints = collectRoadPoints(scene, { layout, layoutConfig });
+    // CITYPLAN_END
     if (roadPoints.length >= 2) {
       const roadGroup = buildRoadNetwork({
         scene,

--- a/src/roads/collectRoadPoints.js
+++ b/src/roads/collectRoadPoints.js
@@ -1,6 +1,6 @@
 import * as THREE from 'three';
 
-export function collectRoadPoints(scene) {
+export function collectRoadPoints(scene, options = {}) {
   const points = [];
   const addPoint = (vector) => {
     if (!vector) return;
@@ -33,6 +33,29 @@ export function collectRoadPoints(scene) {
       }
     }
   });
+
+  if ((options?.layout ?? 'classic') === 'athensPlan') {
+    // CITYPLAN_START
+    const anchorNames = [
+      'Agora',
+      'Stoa_of_Attalos',
+      'Tholos',
+      'Theater_of_Dionysus',
+      'Stadium',
+      'CityGate_South',
+      'Port_Quay_A',
+      'AcropolisGroup'
+    ];
+    anchorNames.forEach((anchorName) => {
+      const object = scene.getObjectByName(anchorName);
+      if (!object) {
+        return;
+      }
+      const worldPos = object.getWorldPosition(new THREE.Vector3());
+      addPoint(new THREE.Vector3(worldPos.x, 0, worldPos.z));
+    });
+    // CITYPLAN_END
+  }
 
   const deduped = [];
   const thresholdSq = 9;


### PR DESCRIPTION
## Summary
- add layout handling in the initialization flow to pass through athensPlan configuration
- expand the extended city builder with tholos, stadium, and port structures plus layout-aware placement logic
- append geojson features and road anchors for the athensPlan layout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68db3595ba6c8327861d0dee7ca76047