### PR TITLE
Fix flight controls to use Space/Shift for vertical movement

### DIFF
--- a/src/config/movement.ts
+++ b/src/config/movement.ts
@@ -2,6 +2,7 @@ export interface FlightConfig {
   toggleKey?: string;
   toggleKeys?: string[];
   horizontalSpeed?: number;
+  verticalSpeed?: number;
   verticalAcceleration?: number;
   verticalMaxSpeed?: number;
   verticalDamping?: number;
@@ -38,6 +39,11 @@ export interface MovementConfig {
   camera?: MovementCameraConfig;
 }
 
+export const FLIGHT = {
+  verticalSpeed: 6,
+  horizontalSpeed: 8
+} as const;
+
 export const movementConfig: MovementConfig = {
   walkSpeed: 4,
   runMultiplier: 1.7,
@@ -46,7 +52,8 @@ export const movementConfig: MovementConfig = {
   flight: {
     toggleKey: 'KeyF',
     toggleKeys: ['KeyF', 'KeyX'],
-    horizontalSpeed: 8,
+    horizontalSpeed: FLIGHT.horizontalSpeed,
+    verticalSpeed: FLIGHT.verticalSpeed,
     verticalAcceleration: 20,
     verticalMaxSpeed: 12,
     verticalDamping: 8,

--- a/src/entry/boot.ts
+++ b/src/entry/boot.ts
@@ -527,8 +527,8 @@ export async function runAthens(options: RunOptions = {}) {
           return;
         }
       }
-      const key = typeof event.key === 'string' ? event.key.toLowerCase() : '';
-      if (key === 'k') {
+      const code = typeof event.code === 'string' ? event.code : '';
+      if (code === 'KeyK') {
         handleSkyEnabled(!skyEnabled);
       }
     };
@@ -825,7 +825,7 @@ export async function runAthens(options: RunOptions = {}) {
       const moveDistance = playerDelta.length();
       const currentSpeed = delta > 1e-6 ? moveDistance / Math.max(delta, 1e-6) : 0;
 
-      const jumpDown = Boolean(keyboard.isDown?.('Space'));
+      const jumpDown = !flying && Boolean(keyboard.isDown?.('Space'));
       const jumpRequested = jumpDown && !previousJumpDown;
       previousJumpDown = jumpDown;
 

--- a/src/input/keyboard.js
+++ b/src/input/keyboard.js
@@ -77,6 +77,15 @@ export function createKeyboard(target = typeof window !== 'undefined' ? window :
   const handleKeyDown = (event) => {
     const code = normalizeCode(event);
 
+    if (code === 'Space') {
+      if (typeof event.preventDefault === 'function') {
+        event.preventDefault();
+      }
+      if (typeof event.stopPropagation === 'function') {
+        event.stopPropagation();
+      }
+    }
+
     if (!RELEVANT_KEYS.has(code)) {
       return;
     }

--- a/src/player/playerController.js
+++ b/src/player/playerController.js
@@ -2,7 +2,7 @@ import * as THREE from 'three';
 import { snapToGround } from '../physics/groundSnap.js';
 import { keepUpright } from '../physics/upright.js';
 import { Capsule, resolveCapsuleVsAABBs } from '../physics/collision.js';
-import { movementConfig } from '../config/movement.ts';
+import { movementConfig, FLIGHT as FLIGHT_DEFAULTS } from '../config/movement.ts';
 import { sanitizeVec3, DEFAULT_PLAYER } from '../utils/sanitize.ts';
 
 const moveDirection = new THREE.Vector3();
@@ -43,16 +43,18 @@ const defaultToggleKeys = (() => {
 const toggleKeySet = new Set(defaultToggleKeys.length ? defaultToggleKeys : [FLIGHT_TOGGLE_KEY]);
 const FLIGHT_HORIZONTAL_SPEED = Number.isFinite(flightOptions.horizontalSpeed)
   ? flightOptions.horizontalSpeed
-  : 8;
-const FLIGHT_VERTICAL_ACCEL = Number.isFinite(flightOptions.verticalAcceleration)
-  ? flightOptions.verticalAcceleration
-  : 20;
-const FLIGHT_VERTICAL_MAX_SPEED = Number.isFinite(flightOptions.verticalMaxSpeed)
-  ? flightOptions.verticalMaxSpeed
-  : 12;
-const FLIGHT_VERTICAL_DAMPING = Number.isFinite(flightOptions.verticalDamping)
-  ? Math.max(0, flightOptions.verticalDamping)
-  : 8;
+  : FLIGHT_DEFAULTS.horizontalSpeed;
+const FLIGHT_VERTICAL_SPEED = (() => {
+  const configured = Number.isFinite(flightOptions.verticalSpeed)
+    ? flightOptions.verticalSpeed
+    : Number.isFinite(flightOptions.verticalMaxSpeed)
+    ? flightOptions.verticalMaxSpeed
+    : FLIGHT_DEFAULTS.verticalSpeed;
+  if (!Number.isFinite(configured)) {
+    return FLIGHT_DEFAULTS.verticalSpeed;
+  }
+  return Math.max(0, configured);
+})();
 const FLIGHT_NUDGE_UP = Number.isFinite(flightOptions.nudgeUp) ? flightOptions.nudgeUp : 0.25;
 const FLIGHT_EXIT_HOVER = Number.isFinite(flightOptions.exitHover) ? flightOptions.exitHover : 0.05;
 const FLIGHT_GRACE_FRAMES = Number.isFinite(flightOptions.startGraceFrames)
@@ -325,10 +327,8 @@ export function createPlayerController(
 
     if (isFlying) {
       physicsState.vy = 0;
-      targetVelocity.y = Number.isFinite(velocity.y) ? velocity.y : 0;
-    } else {
-      targetVelocity.y = 0;
     }
+    targetVelocity.y = 0;
 
     // Accel/lerp velocity
     const accel = Number.isFinite(acceleration) ? Math.max(acceleration, 0) : 10;
@@ -340,27 +340,16 @@ export function createPlayerController(
       const ascendHeld = isAnyKeyDown(currentKeyboard, ascendKeySet);
       const descendHeld = isAnyKeyDown(currentKeyboard, descendKeySet);
       const verticalInput = (ascendHeld ? 1 : 0) - (descendHeld ? 1 : 0);
-      const verticalAccel = Math.max(0, Number.isFinite(FLIGHT_VERTICAL_ACCEL) ? FLIGHT_VERTICAL_ACCEL : 0);
-      const maxVertical = Math.max(
-        0,
-        Number.isFinite(FLIGHT_VERTICAL_MAX_SPEED) ? FLIGHT_VERTICAL_MAX_SPEED : Number.isFinite(flightSpeed) ? flightSpeed : 12
-      );
-      if (verticalInput !== 0 && verticalAccel > 0 && dtSafe > 0) {
-        velocity.y = THREE.MathUtils.clamp(
-          velocity.y + verticalInput * verticalAccel * dtSafe,
-          -maxVertical,
-          maxVertical
-        );
-      } else if (FLIGHT_VERTICAL_DAMPING > 0 && dtSafe > 0) {
-        const dampingDelta = FLIGHT_VERTICAL_DAMPING * dtSafe;
-        if (velocity.y > 0) {
-          velocity.y = Math.max(0, velocity.y - dampingDelta);
-        } else if (velocity.y < 0) {
-          velocity.y = Math.min(0, velocity.y + dampingDelta);
-        }
-        if (Math.abs(velocity.y) < 1e-3) {
-          velocity.y = 0;
-        }
+      const verticalSpeed = Number.isFinite(FLIGHT_VERTICAL_SPEED)
+        ? Math.max(0, FLIGHT_VERTICAL_SPEED)
+        : FLIGHT_DEFAULTS.verticalSpeed;
+      if (verticalInput !== 0 && verticalSpeed > 0) {
+        velocity.y = verticalInput * verticalSpeed;
+      } else {
+        velocity.y = 0;
+      }
+      if (!Number.isFinite(velocity.y)) {
+        velocity.y = 0;
       }
       sanitizeVec3(velocity, ZERO_VECTOR);
     } else {


### PR DESCRIPTION
## Audit
- `src/input/keyboard.js` captures keyboard state via `keydown`/`keyup` but did not suppress the browser’s default Space behavior.
- `src/player/playerController.js` handled flight ascend/descend with acceleration while `src/entry/boot.ts` still triggered jump via Space, causing conflicts when `isFlying` was true.

## Summary
- Prevent the browser and service worker from intercepting Space presses and continue normalizing keyboard look/move codes by `event.code`.
- Introduce reusable flight speed defaults and use them to compute deterministic vertical velocity while flying.
- Block jump requests while flying and normalize the sky toggle hotkey to use `event.code`.

## Testing
- Not run (not requested).

------
https://chatgpt.com/codex/tasks/task_b_68db38440938832783ce346f5d2eea9d