### PR TITLE
Add developer landmark placer tooling

### DIFF
--- a/src/buildings/createCityExtended.js
+++ b/src/buildings/createCityExtended.js
@@ -35,27 +35,61 @@ export async function createCityExtended({ renderer, scene, layout = 'classic', 
       Port_Quay_A: { x: 10, y: 'ground', z: 160 }
     };
 
+    // PLACER_START
+    const placerOverrides = layoutConfig?.positions && typeof layoutConfig.positions === 'object'
+      ? layoutConfig.positions
+      : null;
+
+    const applyConfigOverride = (current, override) => {
+      if (override instanceof THREE.Vector3) {
+        return { x: override.x, y: override.y, z: override.z };
+      }
+      if (Array.isArray(override)) {
+        const [ox, oy, oz] = override;
+        return {
+          x: Number.isFinite(ox) ? ox : current.x,
+          y: Number.isFinite(oy) ? oy : current.y,
+          z: Number.isFinite(oz) ? oz : current.z
+        };
+      }
+      if (override && typeof override === 'object') {
+        const next = { ...current };
+        if ('x' in override && override.x !== undefined) {
+          next.x = Number.isFinite(override.x) ? override.x : Number.isFinite(Number(override.x)) ? Number(override.x) : override.x;
+        }
+        if ('y' in override && override.y !== undefined) {
+          next.y = Number.isFinite(override.y) ? override.y : Number.isFinite(Number(override.y)) ? Number(override.y) : override.y;
+        }
+        if ('z' in override && override.z !== undefined) {
+          next.z = Number.isFinite(override.z) ? override.z : Number.isFinite(Number(override.z)) ? Number(override.z) : override.z;
+        }
+        return next;
+      }
+      if (typeof override === 'number') {
+        return { ...current, y: override };
+      }
+      return current;
+    };
+    // PLACER_END
+
     const plateauHeight = typeof scene?.userData?.acropolis?.plateauHeight === 'number'
       ? scene.userData.acropolis.plateauHeight
       : null;
 
     const resolveConfigEntry = (key) => {
       const preset = PRESET[key] ? { ...PRESET[key] } : {};
-      const override = layoutConfig?.[key];
-      if (override instanceof THREE.Vector3) {
-        return { x: override.x, y: override.y, z: override.z };
+      const sources = [];
+      if (layoutConfig?.[key] !== undefined) {
+        sources.push(layoutConfig[key]);
       }
-      if (Array.isArray(override)) {
-        const [ox = preset.x ?? 0, oy = preset.y ?? 0, oz = preset.z ?? 0] = override;
-        return { x: ox, y: oy, z: oz };
+      if (placerOverrides?.[key] !== undefined) {
+        sources.push(placerOverrides[key]);
       }
-      if (override && typeof override === 'object') {
-        return { ...preset, ...override };
+      let resolved = { ...preset };
+      for (const source of sources) {
+        resolved = applyConfigOverride(resolved, source);
       }
-      if (typeof override === 'number') {
-        return { ...preset, y: override };
-      }
-      return preset;
+      return resolved;
     };
 
     const resolvePosition = (key, fallback = new THREE.Vector3()) => {

--- a/src/dev/landmarkPlacer.js
+++ b/src/dev/landmarkPlacer.js
@@ -1,0 +1,414 @@
+// PLACER_START
+import * as THREE from 'three';
+
+const DEFAULT_LANDMARKS = [
+  'Agora',
+  'Stoa_of_Attalos',
+  'Tholos',
+  'Theater_of_Dionysus',
+  'Stadium',
+  'CityGate_South',
+  'Port_Quay_A'
+];
+
+const KEY_BINDINGS = {
+  next: 'n',
+  prev: 'p',
+  save: 's',
+  cancel: 'Escape'
+};
+
+const POINTER_BUTTON_PRIMARY = 0;
+
+function isGround(mesh) {
+  if (!mesh) return false;
+  if (mesh.userData?.isGround) return true;
+  const name = mesh.name ? String(mesh.name) : '';
+  return /ground|terrain|grass|soil|floor/i.test(name);
+}
+
+function createLabelSprite(text) {
+  if (typeof document === 'undefined') {
+    const fallback = new THREE.Sprite(new THREE.SpriteMaterial({ color: 0xffffff }));
+    fallback.scale.setScalar(0.01);
+    return fallback;
+  }
+  const canvas = document.createElement('canvas');
+  canvas.width = 256;
+  canvas.height = 128;
+  const ctx = canvas.getContext('2d');
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  ctx.fillStyle = 'rgba(15, 23, 42, 0.9)';
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  ctx.fillStyle = '#facc15';
+  ctx.font = 'bold 48px sans-serif';
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.fillText(text, canvas.width / 2, canvas.height / 2);
+  const texture = new THREE.CanvasTexture(canvas);
+  texture.encoding = THREE.sRGBEncoding;
+  texture.anisotropy = 4;
+  const material = new THREE.SpriteMaterial({ map: texture, transparent: true, depthTest: false, depthWrite: false });
+  const sprite = new THREE.Sprite(material);
+  sprite.scale.set(6, 3, 1);
+  sprite.userData.__canvas = canvas;
+  sprite.userData.__context = ctx;
+  sprite.userData.__texture = texture;
+  return sprite;
+}
+
+function updateLabelSprite(sprite, text) {
+  const canvas = sprite?.userData?.__canvas;
+  const ctx = sprite?.userData?.__context;
+  const texture = sprite?.userData?.__texture;
+  if (!canvas || !ctx || !texture) {
+    return;
+  }
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  ctx.fillStyle = 'rgba(15, 23, 42, 0.9)';
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  ctx.fillStyle = '#facc15';
+  ctx.font = 'bold 48px sans-serif';
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.fillText(text, canvas.width / 2, canvas.height / 2);
+  texture.needsUpdate = true;
+}
+
+function createHud() {
+  if (typeof document === 'undefined') {
+    return null;
+  }
+  const hud = document.createElement('div');
+  hud.style.position = 'fixed';
+  hud.style.left = '16px';
+  hud.style.bottom = '24px';
+  hud.style.padding = '12px 16px';
+  hud.style.background = 'rgba(15, 23, 42, 0.75)';
+  hud.style.color = '#f8fafc';
+  hud.style.fontFamily = 'system-ui, sans-serif';
+  hud.style.fontSize = '14px';
+  hud.style.lineHeight = '1.4';
+  hud.style.borderRadius = '8px';
+  hud.style.boxShadow = '0 6px 18px rgba(2, 6, 23, 0.4)';
+  hud.style.pointerEvents = 'none';
+  hud.style.zIndex = '9999';
+  hud.style.display = 'none';
+  document.body.appendChild(hud);
+  return hud;
+}
+
+function normalizeVector3(input) {
+  if (!input) return null;
+  if (input.isVector3) {
+    return { x: input.x, y: input.y, z: input.z };
+  }
+  const { x, y, z } = input;
+  const toNumber = (value) => {
+    if (Number.isFinite(value)) return value;
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  };
+  const nx = toNumber(x);
+  const ny = toNumber(y);
+  const nz = toNumber(z);
+  if (nx == null || ny == null || nz == null) {
+    return null;
+  }
+  return { x: nx, y: ny, z: nz };
+}
+
+function clonePositions(map) {
+  const result = {};
+  for (const [key, value] of Object.entries(map)) {
+    const normalized = normalizeVector3(value);
+    if (normalized) {
+      result[key] = { ...normalized };
+    }
+  }
+  return result;
+}
+
+export function createLandmarkPlacer({
+  scene,
+  camera,
+  renderer,
+  groundSampler,
+  input,
+  onSave
+} = {}) {
+  if (!scene || !camera || !renderer) {
+    throw new Error('createLandmarkPlacer requires scene, camera, and renderer.');
+  }
+
+  const raycaster = new THREE.Raycaster();
+  const pointer = new THREE.Vector2();
+  const hud = createHud();
+
+  const ghost = new THREE.Group();
+  ghost.name = 'LandmarkPlacerGhost';
+  const ringGeometry = new THREE.RingGeometry(0.35, 0.6, 32);
+  const ringMaterial = new THREE.MeshBasicMaterial({ color: 0xfacc15, transparent: true, opacity: 0.8, side: THREE.DoubleSide });
+  const ring = new THREE.Mesh(ringGeometry, ringMaterial);
+  ring.rotation.x = -Math.PI / 2;
+  ghost.add(ring);
+  const pointerLine = new THREE.Mesh(
+    new THREE.CylinderGeometry(0.02, 0.02, 1, 12),
+    new THREE.MeshBasicMaterial({ color: 0xfacc15, transparent: true, opacity: 0.6 })
+  );
+  pointerLine.position.y = 0.5;
+  ghost.add(pointerLine);
+  const label = createLabelSprite('Landmark');
+  label.position.set(0, 2.2, 0);
+  ghost.add(label);
+  ghost.visible = false;
+
+  const state = {
+    enabled: false,
+    names: [...DEFAULT_LANDMARKS],
+    index: 0,
+    positions: {},
+    lastHit: null
+  };
+
+  let groundMeshes = [];
+
+  const listeners = {
+    pointermove: null,
+    pointerdown: null,
+    keydown: null
+  };
+
+  function collectGroundMeshes() {
+    const meshes = [];
+    scene.traverse((child) => {
+      if (child && child.isMesh && isGround(child)) {
+        meshes.push(child);
+      }
+    });
+    return meshes;
+  }
+
+  function currentName() {
+    return state.names[state.index] ?? null;
+  }
+
+  function updateHud() {
+    if (!hud) return;
+    if (!state.enabled) {
+      hud.style.display = 'none';
+      hud.textContent = '';
+      return;
+    }
+    const name = currentName() || '—';
+    const saved = state.positions[name] ? ' (set)' : '';
+    hud.innerHTML = `
+      <div style="font-weight:600;margin-bottom:4px;">Landmark Placer</div>
+      <div>Landmark: <span style="color:#facc15;">${name}</span>${saved}</div>
+      <div style="margin-top:6px;opacity:0.8;">Hotkeys: Next [N], Prev [P], Save [S], Cancel [Esc/L]</div>
+    `;
+    hud.style.display = 'block';
+  }
+
+  function updateGhostFromHit(hit) {
+    if (!hit) {
+      ghost.visible = false;
+      state.lastHit = null;
+      return;
+    }
+    ghost.visible = true;
+    ghost.position.copy(hit.point);
+    ghost.position.y = hit.point.y;
+    pointerLine.scale.set(1, 1, 1);
+    pointerLine.position.y = 0.5;
+    const name = currentName();
+    if (name) {
+      updateLabelSprite(label, name);
+    }
+    state.lastHit = hit;
+  }
+
+  function raycastGroundFromMouse(event) {
+    if (!renderer?.domElement) return null;
+    const rect = renderer.domElement.getBoundingClientRect();
+    const x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
+    const y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
+    pointer.set(x, y);
+    raycaster.setFromCamera(pointer, camera);
+    const candidates = groundMeshes.length ? groundMeshes : collectGroundMeshes();
+    const intersections = raycaster.intersectObjects(candidates, true);
+    if (intersections.length) {
+      const hit = intersections[0];
+      return { point: hit.point.clone(), object: hit.object, hit };
+    }
+    return null;
+  }
+
+  function handlePointerMove(event) {
+    if (!state.enabled) return;
+    const hit = raycastGroundFromMouse(event);
+    updateGhostFromHit(hit);
+  }
+
+  function handlePointerDown(event) {
+    if (!state.enabled) return;
+    if (event.button !== POINTER_BUTTON_PRIMARY) return;
+    const hit = state.lastHit || raycastGroundFromMouse(event);
+    if (!hit || !hit.point) return;
+    const name = currentName();
+    if (!name) return;
+    const y = typeof groundSampler === 'function'
+      ? groundSampler(hit.point.x, hit.point.z)
+      : hit.point.y;
+    const finalY = typeof y === 'number' ? y : hit.point.y;
+    state.positions[name] = { x: hit.point.x, y: finalY, z: hit.point.z };
+    updateHud();
+  }
+
+  function clampIndex(index) {
+    if (!state.names.length) return 0;
+    if (index < 0) return (state.names.length + index % state.names.length) % state.names.length;
+    return index % state.names.length;
+  }
+
+  function selectNext(step = 1) {
+    if (!state.names.length) return;
+    state.index = clampIndex(state.index + step);
+    updateHud();
+    if (state.lastHit) {
+      updateGhostFromHit(state.lastHit);
+    }
+  }
+
+  function selectPrev() {
+    selectNext(-1);
+  }
+
+  function handleKeyDown(event) {
+    if (!state.enabled) return;
+    const key = event.key.length === 1 ? event.key.toLowerCase() : event.key;
+    if (key === KEY_BINDINGS.next) {
+      event.preventDefault();
+      selectNext(1);
+      return;
+    }
+    if (key === KEY_BINDINGS.prev) {
+      event.preventDefault();
+      selectPrev();
+      return;
+    }
+    if (key === KEY_BINDINGS.save) {
+      event.preventDefault();
+      triggerSave();
+      return;
+    }
+    if (event.key === KEY_BINDINGS.cancel || key === KEY_BINDINGS.cancel.toLowerCase()) {
+      event.preventDefault();
+      api.disable();
+    }
+  }
+
+  function triggerSave() {
+    if (typeof onSave === 'function') {
+      const payload = clonePositions(state.positions);
+      onSave(payload);
+    }
+  }
+
+  function bindListeners() {
+    if (!renderer?.domElement) return;
+    listeners.pointermove = handlePointerMove;
+    listeners.pointerdown = handlePointerDown;
+    listeners.keydown = handleKeyDown;
+    renderer.domElement.addEventListener('pointermove', listeners.pointermove);
+    renderer.domElement.addEventListener('pointerdown', listeners.pointerdown);
+    if (typeof window !== 'undefined') {
+      window.addEventListener('keydown', listeners.keydown);
+    }
+  }
+
+  function unbindListeners() {
+    if (renderer?.domElement && listeners.pointermove) {
+      renderer.domElement.removeEventListener('pointermove', listeners.pointermove);
+    }
+    if (renderer?.domElement && listeners.pointerdown) {
+      renderer.domElement.removeEventListener('pointerdown', listeners.pointerdown);
+    }
+    if (listeners.keydown && typeof window !== 'undefined') {
+      window.removeEventListener('keydown', listeners.keydown);
+    }
+    listeners.pointermove = null;
+    listeners.pointerdown = null;
+    listeners.keydown = null;
+  }
+
+  const api = {
+    enable() {
+      if (state.enabled) return;
+      state.enabled = true;
+      groundMeshes = collectGroundMeshes();
+      if (!scene.getObjectByName(ghost.name)) {
+        scene.add(ghost);
+      }
+      ghost.visible = false;
+      bindListeners();
+      updateHud();
+    },
+    disable() {
+      if (!state.enabled) return;
+      state.enabled = false;
+      ghost.visible = false;
+      state.lastHit = null;
+      unbindListeners();
+      updateHud();
+    },
+    isEnabled() {
+      return state.enabled;
+    },
+    getState() {
+      return {
+        enabled: state.enabled,
+        current: currentName(),
+        index: state.index,
+        names: [...state.names],
+        positions: clonePositions(state.positions)
+      };
+    },
+    setList(list) {
+      if (!Array.isArray(list) || list.length === 0) {
+        return;
+      }
+      state.names = [...list];
+      state.index = 0;
+      updateHud();
+    },
+    next() {
+      selectNext(1);
+    },
+    prev() {
+      selectPrev();
+    },
+    save() {
+      triggerSave();
+    },
+    set(name, position) {
+      if (!name || !position) return;
+      const normalized = normalizeVector3(position);
+      if (!normalized) return;
+      state.positions[name] = normalized;
+      updateHud();
+    },
+    list() {
+      return [...state.names];
+    },
+    export() {
+      return clonePositions(state.positions);
+    },
+    refreshGround() {
+      groundMeshes = collectGroundMeshes();
+    }
+  };
+
+  return api;
+}
+// PLACER_END

--- a/src/entry/initializeAthens.js
+++ b/src/entry/initializeAthens.js
@@ -5,6 +5,9 @@ import { createStats } from '../debug/statsShim.js';
 import { setupGround, updateTrees } from '../main.js';
 import { loadLandmarks } from '../landmarks-loader.js';
 import { createLandmarkOverlay } from '../map/landmarks.js';
+// PLACER_START
+import { createLandmarkPlacer } from '../dev/landmarkPlacer.js';
+// PLACER_END
 import { buildRoadNetwork } from '../roads/roadNetwork.js';
 import { collectRoadPoints } from '../roads/collectRoadPoints.js';
 import { createNpcManager } from '../npc/npcSystem.js';
@@ -510,6 +513,169 @@ export async function initializeAthens(options = {}) {
   if (!groundMeshes.length) {
     console.warn('[npc] no ground meshes');
   }
+  // PLACER_START
+  const landmarkSequence = [
+    'Agora',
+    'Stoa_of_Attalos',
+    'Tholos',
+    'Theater_of_Dionysus',
+    'Stadium',
+    'CityGate_South',
+    'Port_Quay_A'
+  ];
+  const devLandmarkOptions = options?.dev?.landmarkPlacer;
+  const shouldAttachLandmarkPlacer = devLandmarkOptions !== false;
+  let landmarkPlacer = null;
+  if (typeof window !== 'undefined' && shouldAttachLandmarkPlacer) {
+    const activeList = Array.isArray(devLandmarkOptions?.landmarks) && devLandmarkOptions.landmarks.length
+      ? [...devLandmarkOptions.landmarks]
+      : landmarkSequence;
+    const groundSampler = (x, z) => sampleGroundY(x, z, groundMeshes, { fromY: 400 });
+    const ensureDevNamespace = () => {
+      window.dev = window.dev || {};
+      window.dev.landmarks = window.dev.landmarks || {};
+      return window.dev.landmarks;
+    };
+    const handleSave = (positions = {}) => {
+      const devApi = ensureDevNamespace();
+      const payload = {
+        layout: 'athensPlan',
+        layoutConfig: { positions: {} }
+      };
+      const parseNumber = (value) => {
+        const parsed = Number(value);
+        return Number.isFinite(parsed) ? parsed : null;
+      };
+      const names = typeof landmarkPlacer?.list === 'function' ? landmarkPlacer.list() : activeList;
+      names.forEach((name) => {
+        const entry = positions?.[name];
+        if (entry && typeof entry === 'object') {
+          const x = parseNumber(entry.x);
+          const y = parseNumber(entry.y);
+          const z = parseNumber(entry.z);
+          if (x != null && y != null && z != null) {
+            payload.layoutConfig.positions[name] = { x, y, z };
+          }
+        }
+      });
+      const exportString = JSON.stringify(payload, null, 2);
+      devApi.lastExport = exportString;
+      devApi.lastPayload = payload;
+      // eslint-disable-next-line no-console
+      console.log('[Athens][Landmarks] Exported landmark positions:', exportString);
+      if (typeof devApi.onSave === 'function') {
+        try {
+          devApi.onSave(payload);
+        } catch (error) {
+          console.warn('[Athens][Landmarks] onSave handler error.', error);
+        }
+      }
+    };
+
+    landmarkPlacer = createLandmarkPlacer({
+      scene,
+      camera,
+      renderer,
+      groundSampler,
+      onSave: handleSave
+    });
+    if (typeof landmarkPlacer?.setList === 'function') {
+      landmarkPlacer.setList(activeList);
+    }
+    scene.userData.landmarkPlacer = landmarkPlacer;
+
+    const devApi = ensureDevNamespace();
+    devApi.enable = () => {
+      landmarkPlacer.enable?.();
+      return landmarkPlacer.isEnabled?.() ?? false;
+    };
+    devApi.disable = () => {
+      landmarkPlacer.disable?.();
+      return landmarkPlacer.isEnabled?.() ?? false;
+    };
+    devApi.toggle = () => {
+      if (landmarkPlacer.isEnabled?.()) {
+        landmarkPlacer.disable?.();
+      } else {
+        landmarkPlacer.enable?.();
+      }
+      return landmarkPlacer.isEnabled?.() ?? false;
+    };
+    devApi.next = () => landmarkPlacer.next?.();
+    devApi.prev = () => landmarkPlacer.prev?.();
+    devApi.save = () => {
+      landmarkPlacer.save?.();
+      return devApi.lastExport ?? null;
+    };
+    devApi.set = (name, position) => landmarkPlacer.set?.(name, position);
+    devApi.setList = (list) => landmarkPlacer.setList?.(list);
+    devApi.list = () => (typeof landmarkPlacer.list === 'function' ? landmarkPlacer.list() : [...activeList]);
+    devApi.export = () => {
+      const positions = landmarkPlacer.export?.() || {};
+      const payload = {
+        layout: 'athensPlan',
+        layoutConfig: { positions: {} }
+      };
+      devApi.list().forEach((name) => {
+        const entry = positions?.[name];
+        if (entry && typeof entry === 'object') {
+          payload.layoutConfig.positions[name] = { ...entry };
+        }
+      });
+      return payload;
+    };
+    devApi.positions = () => landmarkPlacer.export?.() || {};
+    devApi.getState = () => landmarkPlacer.getState?.();
+    devApi.refreshGround = () => landmarkPlacer.refreshGround?.();
+    devApi.lastExport = devApi.lastExport ?? null;
+    devApi.lastPayload = devApi.lastPayload ?? null;
+    if (typeof devApi.saveToFile !== 'function') {
+      devApi.saveToFile = () => {
+        console.info('[Athens][Landmarks] saveToFile hook not implemented.');
+      };
+    }
+
+    const toggleKey = typeof devLandmarkOptions?.toggleKey === 'string'
+      ? devLandmarkOptions.toggleKey.toLowerCase()
+      : 'l';
+    const shouldIgnoreEvent = (event) => {
+      const target = event?.target;
+      if (!target || typeof target !== 'object') {
+        return false;
+      }
+      if (target.isContentEditable) {
+        return true;
+      }
+      const element = typeof HTMLElement !== 'undefined' && target instanceof HTMLElement ? target : null;
+      if (!element) {
+        return false;
+      }
+      const tag = element.tagName;
+      if (!tag) return false;
+      const normalized = tag.toLowerCase();
+      if (normalized === 'input' || normalized === 'textarea' || normalized === 'select') {
+        return true;
+      }
+      return Boolean(element.closest?.('input, textarea, select, [contenteditable="true"]'));
+    };
+    const toggleHandler = (event) => {
+      if (!landmarkPlacer) return;
+      if (typeof event?.key !== 'string') return;
+      if (shouldIgnoreEvent(event)) return;
+      if (event.key.toLowerCase() !== toggleKey) return;
+      event.preventDefault();
+      devApi.toggle();
+    };
+    if (window.__athensLandmarkToggleHandler) {
+      window.removeEventListener('keydown', window.__athensLandmarkToggleHandler);
+    }
+    window.__athensLandmarkToggleHandler = toggleHandler;
+    window.addEventListener('keydown', toggleHandler);
+  }
+  if (!scene.userData.landmarkPlacer) {
+    scene.userData.landmarkPlacer = landmarkPlacer;
+  }
+  // PLACER_END
   if (city?.root && groundMeshes.length) {
     const snapOpts = { hover: 0.03, fromY: 300 };
     snapChildrenToGround(city.root, groundMeshes, snapOpts);


### PR DESCRIPTION
## Summary
- introduce a developer landmark placer utility with ghost marker, HUD, and save/export helpers
- wire the placer into Athens initialization with keyboard toggle, dev console API, and payload export handling
- allow the extended city builder to honor layoutConfig.position overrides when rendering athensPlan landmarks

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_b_68db38f1cb38832782be058960677e48