### PR TITLE
fix: load sky JPGs via SkyManager

### DIFF
--- a/src/engine/safeEntry.js
+++ b/src/engine/safeEntry.js
@@ -1,5 +1,5 @@
 import * as THREE from 'three';
-import { applySky } from '../scene/sky.ts';
+import { initSky, setSky, reapplySky } from '../sky/SkyManager.ts';
 
 export async function createSafeScene(canvasSelector = 'canvas') {
   const canvas = typeof document !== 'undefined' ? document.querySelector(canvasSelector) : null;
@@ -19,10 +19,12 @@ export async function createSafeScene(canvasSelector = 'canvas') {
   camera.position.set(0, 3.5, 7);
   scene.add(camera);
 
+  initSky(renderer);
   try {
-    await applySky(scene, renderer);
+    await setSky(scene, 'assets/sky/day.jpg');
   } catch (error) {
-    console.warn('[safeEntry] applySky failed.', error);
+    console.warn('[safeEntry] setSky failed.', error);
+    reapplySky(scene);
   }
 
   const ambient = new THREE.AmbientLight(0xffffff, 0.35);

--- a/src/entry/boot.ts
+++ b/src/entry/boot.ts
@@ -1,7 +1,7 @@
 import * as THREE from 'three';
 import { createStats } from '../debug/statsShim.js';
 import { setupGround, updateTrees } from '../main.js';
-import { applySky } from '../scene/sky.ts';
+import { initSky, setSky, reapplySky } from '../sky/SkyManager.ts';
 import boot from '../core/bootstrap.js';
 import createKeyboard from '../input/keyboard.js';
 import { createPlayerController } from '../player/playerController.js';
@@ -29,6 +29,7 @@ import { AmbientAPI, AMBIENT_TRACKS, initAmbient } from '../audio/ambient';
 import { createFootsteps } from '../audio/footsteps.js';
 import { attachNpcAudio } from '../audio/npcAudio.js';
 import { createHUD } from '../ui/hud.js';
+import { createTimeSky, setTimeOfDay, setSkyEnabled, isSkyEnabled, getTimeOfDay } from '../sky/timeSky.js';
 import { createMountainRim as createHorizonMountainRim } from '../horizon/mountainRim.js';
 import { movementConfig } from '../config/movement.ts';
 
@@ -360,86 +361,23 @@ export async function runAthens(options: RunOptions = {}) {
   };
 
   const environmentMode = options.skyMode ?? options.preset ?? 'day';
-  let currentSkyMode = typeof environmentMode === 'string' && environmentMode ? environmentMode : 'day';
-  let skyEnabled = true;
-  let cachedSky: {
-    background: THREE.Texture | THREE.Color | null;
-    environment: THREE.Texture | THREE.CubeTexture | null;
-  } = {
-    background: (scene.background as THREE.Texture | THREE.Color | null) ?? null,
-    environment: (scene.environment as THREE.Texture | THREE.CubeTexture | null) ?? null
-  };
+  const initialSkyMode =
+    typeof environmentMode === 'string' && environmentMode ? environmentMode : 'day';
 
-  const updateSkyCache = () => {
-    cachedSky = {
-      background: (scene.background as THREE.Texture | THREE.Color | null) ?? null,
-      environment: (scene.environment as THREE.Texture | THREE.CubeTexture | null) ?? null
-    };
-  };
+  initSky(renderer);
+  let bootSkyApplied = false;
+  try {
+    const result = await setSky(scene, 'assets/sky/day.jpg');
+    bootSkyApplied = Boolean(result);
+  } catch (error) {
+    console.warn('[Athens][Boot] setSky failed for initial load.', error);
+  }
+  if (!bootSkyApplied) {
+    reapplySky(scene);
+  }
 
-  const applyDefaultSkyBackground = () => {
-    scene.background = new THREE.Color(DEFAULT_BACKGROUND_HEX);
-    scene.environment = null;
-    renderer.setClearColor(DEFAULT_BACKGROUND_HEX, 1);
-  };
-
-  const restoreCachedSky = () => {
-    if (cachedSky.background) {
-      scene.background = cachedSky.background;
-    } else {
-      scene.background = new THREE.Color(DEFAULT_BACKGROUND_HEX);
-    }
-    scene.environment = cachedSky.environment ?? null;
-    renderer.setClearColor(DEFAULT_BACKGROUND_HEX, 1);
-  };
-
-  const notifySkyEnabledChange = (enabled: boolean) => {
-    if (typeof window === 'undefined' || typeof window.dispatchEvent !== 'function') {
-      return;
-    }
-    try {
-      window.dispatchEvent(new CustomEvent('athens:sky-enabled-changed', { detail: { enabled } }));
-    } catch (_) {
-      // ignored
-    }
-  };
-
-  const applySkyForMode = async (mode: string) => {
-    const normalized = typeof mode === 'string' && mode ? mode : 'day';
-    currentSkyMode = normalized;
-    try {
-      await applySky(scene, renderer, normalized);
-    } catch (error) {
-      console.warn('[Athens][Boot] applySky failed', error);
-    }
-    updateSkyCache();
-    if (!skyEnabled) {
-      applyDefaultSkyBackground();
-    }
-    return normalized;
-  };
-
-  const setSkyEnabledInternal = (enabled: boolean) => {
-    const normalized = Boolean(enabled);
-    if (skyEnabled === normalized) {
-      return skyEnabled;
-    }
-    skyEnabled = normalized;
-    if (skyEnabled) {
-      if (!cachedSky.background && !cachedSky.environment) {
-        applySkyForMode(currentSkyMode).catch(() => {});
-      } else {
-        restoreCachedSky();
-      }
-    } else {
-      applyDefaultSkyBackground();
-    }
-    applyHorizonVisibility(skyEnabled || resolveHorizonEnabled());
-    notifySkyEnabledChange(skyEnabled);
-    return skyEnabled;
-  };
-
-  await applySkyForMode(environmentMode);
+  await createTimeSky(renderer, scene, initialSkyMode);
+  applyHorizonVisibility(isSkyEnabled() || resolveHorizonEnabled());
 
   if (typeof setupGround === 'function') {
     try {
@@ -488,14 +426,17 @@ export async function runAthens(options: RunOptions = {}) {
     return trackId;
   };
 
+  const initialAmbientMode = getTimeOfDay() ?? initialSkyMode;
+
   if (!ambientOverrideSelected) {
-    applyAmbientForMode(environmentMode, true);
+    applyAmbientForMode(initialAmbientMode, true);
   }
 
   const handleTimeOfDay = async (mode: string) => {
-    const appliedMode = await applySkyForMode(mode);
-    applyAmbientForMode(appliedMode, true);
-    return appliedMode;
+    const appliedMode = await setTimeOfDay(mode);
+    const effectiveMode = appliedMode ?? getTimeOfDay() ?? initialSkyMode;
+    applyAmbientForMode(effectiveMode, true);
+    return effectiveMode;
   };
 
   const handleVolume = (value: number) => {
@@ -503,7 +444,11 @@ export async function runAthens(options: RunOptions = {}) {
     audio.setMasterVolume(value);
   };
 
-  const handleSkyEnabled = (enabled: boolean) => setSkyEnabledInternal(enabled);
+  const handleSkyEnabled = (enabled: boolean) => {
+    const result = setSkyEnabled(enabled);
+    applyHorizonVisibility(result || resolveHorizonEnabled());
+    return result;
+  };
 
   applyQualityPreset('high');
 
@@ -515,6 +460,7 @@ export async function runAthens(options: RunOptions = {}) {
   });
 
   let removeSkyHotkey: (() => void) | null = null;
+  let removeSkyEnabledListener: (() => void) | null = null;
   if (typeof window !== 'undefined' && window.addEventListener) {
     const handleSkyToggleKey = (event: KeyboardEvent) => {
       if (event.defaultPrevented || event.altKey || event.metaKey || event.ctrlKey) {
@@ -529,11 +475,20 @@ export async function runAthens(options: RunOptions = {}) {
       }
       const code = typeof event.code === 'string' ? event.code : '';
       if (code === 'KeyK') {
-        handleSkyEnabled(!skyEnabled);
+        handleSkyEnabled(!isSkyEnabled());
       }
     };
     window.addEventListener('keydown', handleSkyToggleKey);
     removeSkyHotkey = () => window.removeEventListener('keydown', handleSkyToggleKey);
+
+    const handleSkyStateChanged = (event: Event) => {
+      const detail = (event as CustomEvent)?.detail;
+      const enabled = typeof detail?.enabled === 'boolean' ? detail.enabled : isSkyEnabled();
+      applyHorizonVisibility(enabled || resolveHorizonEnabled());
+    };
+    window.addEventListener('athens:sky-enabled-changed', handleSkyStateChanged as EventListener);
+    removeSkyEnabledListener = () =>
+      window.removeEventListener('athens:sky-enabled-changed', handleSkyStateChanged as EventListener);
   }
 
   markGround(scene);
@@ -938,6 +893,7 @@ export async function runAthens(options: RunOptions = {}) {
         window.removeEventListener('keydown', resumeAudioContext);
       }
       removeSkyHotkey?.();
+      removeSkyEnabledListener?.();
       const panel = stats?.dom;
       if (panel && panel.parentNode === container) {
         container.removeChild(panel);

--- a/src/entry/initializeAthens.js
+++ b/src/entry/initializeAthens.js
@@ -18,7 +18,7 @@ import { seedCameraBehindPlayer } from '../camera/seedCameraBehindPlayer.js';
 import { createPlayerController } from '../player/playerController.js';
 import { assetUrl } from '../utils/assetUrl.js';
 import { createGameLoop } from '../engine/loop.js';
-import { applySky } from '../scene/sky.ts';
+import { initSky, setSky, reapplySky } from '../sky/SkyManager.ts';
 import { movementConfig } from '../config/movement.ts';
 import { markGround, collectGround } from '../physics/groundRegistry.js';
 import { markColliders, collectColliders, buildAABBs } from '../physics/colliderRegistry.js';
@@ -392,7 +392,17 @@ export async function initializeAthens(options = {}) {
     };
   }
 
-  const skyTask = applySky(scene, renderer);
+  initSky(renderer);
+  let initialSkyApplied = false;
+  try {
+    const result = await setSky(scene, 'assets/sky/day.jpg');
+    initialSkyApplied = Boolean(result);
+  } catch (error) {
+    console.warn('[Athens] setSky failed during initializeAthens.', error);
+  }
+  if (!initialSkyApplied) {
+    reapplySky(scene);
+  }
 
   const ambientMuted = searchParams ? searchParams.get('mute') === '1' : false;
   const ambientOverrideSelected = searchParams ? searchParams.has('amb') : false;
@@ -471,9 +481,6 @@ export async function initializeAthens(options = {}) {
     applyAmbientForMode(environmentController.mode, true);
   }
 
-  await skyTask.catch((error) => {
-    console.warn('[Athens] applySky failed.', error);
-  });
 
   // CITYPLAN_START
   await setupGround(scene, renderer, { layout, layoutConfig });

--- a/src/sky/SkyManager.ts
+++ b/src/sky/SkyManager.ts
@@ -1,0 +1,201 @@
+import * as THREE from 'three';
+
+export type SkyResource = {
+  path: string;
+  url: string;
+  texture: THREE.Texture;
+  envMap: THREE.Texture | null;
+  envTarget: THREE.WebGLRenderTarget | null;
+};
+
+let activeRenderer: THREE.WebGLRenderer | null = null;
+let textureLoader: THREE.TextureLoader | null = null;
+let pmremGenerator: THREE.PMREMGenerator | null = null;
+let lastResource: SkyResource | null = null;
+
+const loadedResources = new Map<string, SkyResource>();
+const loadTasks = new Map<string, Promise<SkyResource>>();
+
+function ensureLoader() {
+  if (!textureLoader) {
+    textureLoader = new THREE.TextureLoader();
+  }
+  return textureLoader;
+}
+
+function disposePmremGenerator() {
+  if (pmremGenerator) {
+    pmremGenerator.dispose();
+    pmremGenerator = null;
+  }
+}
+
+function ensurePmremGenerator() {
+  if (!activeRenderer) {
+    return null;
+  }
+  if (!pmremGenerator) {
+    pmremGenerator = new THREE.PMREMGenerator(activeRenderer);
+    pmremGenerator.compileEquirectangularShader();
+  }
+  return pmremGenerator;
+}
+
+function ensureRendererColorSpace() {
+  if (!activeRenderer) {
+    return;
+  }
+  const renderer = activeRenderer as THREE.WebGLRenderer & { outputColorSpace?: string; outputEncoding?: number };
+  const srgb = (THREE as any).SRGBColorSpace;
+  if (srgb && typeof renderer.outputColorSpace !== 'undefined') {
+    renderer.outputColorSpace = srgb;
+  } else if (typeof renderer.outputEncoding !== 'undefined' && (THREE as any).sRGBEncoding) {
+    renderer.outputEncoding = (THREE as any).sRGBEncoding;
+  }
+}
+
+function setTextureColorSpace(texture: THREE.Texture) {
+  const srgb = (THREE as any).SRGBColorSpace;
+  if (srgb && typeof (texture as any).colorSpace !== 'undefined') {
+    (texture as any).colorSpace = srgb;
+  } else if (typeof (texture as any).encoding !== 'undefined' && (THREE as any).sRGBEncoding) {
+    (texture as any).encoding = (THREE as any).sRGBEncoding;
+  }
+}
+
+function resolveUrl(path: string | null | undefined) {
+  if (!path) {
+    return null;
+  }
+  const trimmed = `${path}`.trim();
+  if (!trimmed) {
+    return null;
+  }
+  if (/^https?:\/\//i.test(trimmed)) {
+    return trimmed;
+  }
+  const sanitized = trimmed.replace(/^\/+/, '');
+  if (typeof document !== 'undefined' && typeof document.baseURI === 'string' && document.baseURI) {
+    try {
+      return new URL(sanitized, document.baseURI).toString();
+    } catch (_) {
+      // ignored
+    }
+  }
+  const baseFromImport = (import.meta as any)?.env?.BASE_URL;
+  if (typeof baseFromImport === 'string' && baseFromImport.length > 0) {
+    const normalized = baseFromImport.endsWith('/') ? baseFromImport : `${baseFromImport}/`;
+    return `${normalized}${sanitized}`.replace(/^\/+/, '');
+  }
+  if (typeof window !== 'undefined' && typeof window.location === 'object') {
+    try {
+      return new URL(sanitized, window.location.href).toString();
+    } catch (_) {
+      // ignored
+    }
+  }
+  return sanitized;
+}
+
+async function loadResource(path: string) {
+  const normalizedPath = `${path}`.trim();
+  if (loadedResources.has(normalizedPath)) {
+    return loadedResources.get(normalizedPath)!;
+  }
+  if (loadTasks.has(normalizedPath)) {
+    return loadTasks.get(normalizedPath)!;
+  }
+
+  const url = resolveUrl(normalizedPath);
+  if (!url) {
+    throw new Error(`SkyManager: Unable to resolve URL for path "${path}".`);
+  }
+
+  const loader = ensureLoader();
+  const pmrem = ensurePmremGenerator();
+
+  const task = new Promise<SkyResource>((resolve, reject) => {
+    loader.load(
+      url,
+      (texture) => {
+        try {
+          texture.mapping = THREE.EquirectangularReflectionMapping;
+          setTextureColorSpace(texture);
+          texture.needsUpdate = true;
+
+          let envTarget: THREE.WebGLRenderTarget | null = null;
+          let envMap: THREE.Texture | null = null;
+          if (pmrem) {
+            envTarget = pmrem.fromEquirectangular(texture);
+            envMap = envTarget.texture;
+          }
+
+          const resource: SkyResource = {
+            path: normalizedPath,
+            url,
+            texture,
+            envMap,
+            envTarget
+          };
+          loadedResources.set(normalizedPath, resource);
+          resolve(resource);
+        } catch (error) {
+          reject(error);
+        }
+      },
+      undefined,
+      (error) => {
+        reject(error ?? new Error(`SkyManager: Failed to load texture at ${url}`));
+      }
+    );
+  }).finally(() => {
+    loadTasks.delete(normalizedPath);
+  });
+
+  loadTasks.set(normalizedPath, task);
+  return task;
+}
+
+function applyResource(scene: THREE.Scene, resource: SkyResource) {
+  if (!scene || !resource) {
+    return;
+  }
+  scene.background = resource.texture;
+  scene.environment = resource.envMap ?? null;
+}
+
+export function initSky(renderer: THREE.WebGLRenderer | null | undefined) {
+  if (!renderer) {
+    return;
+  }
+  if (activeRenderer && renderer !== activeRenderer) {
+    disposePmremGenerator();
+  }
+  activeRenderer = renderer;
+  ensureRendererColorSpace();
+  ensurePmremGenerator();
+}
+
+export async function setSky(scene: THREE.Scene | null | undefined, path: string) {
+  if (!scene) {
+    return null;
+  }
+  if (!path) {
+    return null;
+  }
+  if (!activeRenderer) {
+    throw new Error('SkyManager: initSky(renderer) must be called before setSky().');
+  }
+  const resource = await loadResource(path);
+  applyResource(scene, resource);
+  lastResource = resource;
+  return resource;
+}
+
+export function reapplySky(scene: THREE.Scene | null | undefined) {
+  if (!scene || !lastResource) {
+    return null;
+  }
+  applyResource(scene, lastResource);
+  return lastResource;
+}

--- a/src/sky/timeSky.js
+++ b/src/sky/timeSky.js
@@ -1,5 +1,5 @@
 import * as THREE from 'three';
-import { assetUrl } from '../utils/assetUrl.js';
+import { initSky, setSky, reapplySky } from './SkyManager.ts';
 
 const DEFAULT_BACKGROUND_COLOR = 0x202834;
 
@@ -33,18 +33,16 @@ const MODE_ALIASES = new Map(
   })
 );
 
-const loader = new THREE.TextureLoader();
-const cache = new Map();
-const loadTasks = new Map();
 const loggedFailures = new Set();
-let pmremGenerator = null;
 let activeRenderer = null;
 let activeScene = null;
 let currentMode = null;
-let currentEntry = null;
 let skyEnabled = true;
 let hotkeyAttached = false;
 let manualSkyOverride = null;
+let hasLoadedSkyTexture = false;
+let lastSuccessfulMode = null;
+let lastSuccessfulPath = null;
 
 function resolveMode(mode) {
   if (!mode) {
@@ -65,7 +63,9 @@ function resolveMode(mode) {
   return null;
 }
 
-const DEFAULT_BACKGROUND = new THREE.Color(DEFAULT_BACKGROUND_COLOR);
+function normalizeMode(mode) {
+  return resolveMode(mode) ?? 'day';
+}
 
 function detectSkyOverride() {
   if (typeof window === 'undefined') {
@@ -82,123 +82,23 @@ function detectSkyOverride() {
 
 manualSkyOverride = detectSkyOverride();
 
-function applyDefaultBackground() {
-  if (!activeScene) {
+function applySolidBackground(hex) {
+  if (activeScene) {
+    activeScene.background = new THREE.Color(hex);
+    activeScene.environment = null;
+  }
+  if (activeRenderer) {
+    activeRenderer.setClearColor(hex, 1);
+  }
+}
+
+function applyFallbackForMode(mode) {
+  if (hasLoadedSkyTexture) {
     return;
   }
-  activeScene.background = DEFAULT_BACKGROUND.clone();
-  activeScene.environment = null;
-}
-
-function ensureColorSpace(texture) {
-  if (!texture) {
-    return;
-  }
-  if ('colorSpace' in texture) {
-    texture.colorSpace = THREE.SRGBColorSpace;
-  } else if ('encoding' in texture) {
-    texture.encoding = THREE.sRGBEncoding;
-  }
-}
-
-function ensurePmrem(renderer) {
-  if (!pmremGenerator && renderer) {
-    pmremGenerator = new THREE.PMREMGenerator(renderer);
-    pmremGenerator.compileEquirectangularShader();
-  }
-  return pmremGenerator;
-}
-
-function normalizeMode(mode) {
-  return resolveMode(mode) ?? 'day';
-}
-
-function fallbackEntry(mode) {
   const config = MODE_CONFIG[mode] || {};
-  const color = new THREE.Color(config.fallbackColor ?? DEFAULT_BACKGROUND_COLOR);
-  return { background: color, envMap: null, mode };
-}
-
-async function loadSky(mode) {
-  if (cache.has(mode)) {
-    return cache.get(mode);
-  }
-  if (loadTasks.has(mode)) {
-    return loadTasks.get(mode);
-  }
-
-  const task = new Promise((resolve) => {
-    const config = MODE_CONFIG[mode];
-    if (!config?.path) {
-      const entry = fallbackEntry(mode);
-      cache.set(mode, entry);
-      resolve(entry);
-      return;
-    }
-
-    const url = assetUrl(config.path);
-
-    loader.load(
-      url,
-      (texture) => {
-        ensureColorSpace(texture);
-        texture.mapping = THREE.EquirectangularReflectionMapping;
-        texture.needsUpdate = true;
-
-        const generator = ensurePmrem(activeRenderer);
-        let envTarget = null;
-        let envMap = null;
-        if (generator) {
-          envTarget = generator.fromEquirectangular(texture);
-          envMap = envTarget.texture;
-        }
-
-        const entry = {
-          background: texture,
-          envMap,
-          envTarget,
-          mode
-        };
-        cache.set(mode, entry);
-        resolve(entry);
-      },
-      undefined,
-      () => {
-        if (!loggedFailures.has(mode)) {
-          console.warn(`[timeSky] Failed to load sky texture for "${mode}" (${url}). Falling back to solid color.`);
-          loggedFailures.add(mode);
-        }
-        const entry = fallbackEntry(mode);
-        cache.set(mode, entry);
-        resolve(entry);
-      }
-    );
-  }).finally(() => {
-    loadTasks.delete(mode);
-  });
-
-  loadTasks.set(mode, task);
-  return task;
-}
-
-function applySky(entry) {
-  if (!activeScene || !entry) {
-    return;
-  }
-  currentEntry = entry;
-  currentMode = entry.mode;
-  if (!skyEnabled) {
-    applyDefaultBackground();
-    return;
-  }
-  if (entry.background?.isTexture) {
-    activeScene.background = entry.background;
-  } else if (entry.background instanceof THREE.Color) {
-    activeScene.background = entry.background;
-  } else {
-    activeScene.background = null;
-  }
-  activeScene.environment = entry.envMap || null;
+  const color = config.fallbackColor ?? DEFAULT_BACKGROUND_COLOR;
+  applySolidBackground(color);
 }
 
 function notifySkyEnabledChange() {
@@ -212,22 +112,59 @@ function notifySkyEnabledChange() {
   }
 }
 
+async function loadSkyForMode(mode) {
+  const config = MODE_CONFIG[mode] || null;
+  if (!config?.path) {
+    applyFallbackForMode(mode);
+    return false;
+  }
+  if (!activeRenderer || !activeScene) {
+    return false;
+  }
+
+  initSky(activeRenderer);
+
+  try {
+    const resource = await setSky(activeScene, config.path);
+    if (resource) {
+      hasLoadedSkyTexture = true;
+      lastSuccessfulMode = mode;
+      lastSuccessfulPath = config.path;
+      return true;
+    }
+  } catch (error) {
+    if (!loggedFailures.has(mode)) {
+      console.warn(`[timeSky] Failed to load sky texture for "${mode}" (${config.path}).`, error);
+      loggedFailures.add(mode);
+    }
+  }
+
+  if (!hasLoadedSkyTexture) {
+    applyFallbackForMode(mode);
+  }
+  return false;
+}
+
 export async function createTimeSky(renderer, scene, initial = 'day') {
   activeRenderer = renderer || activeRenderer;
   activeScene = scene || activeScene;
-  ensurePmrem(activeRenderer);
+  if (activeRenderer) {
+    initSky(activeRenderer);
+  }
+  if (activeScene && skyEnabled && hasLoadedSkyTexture) {
+    reapplySky(activeScene);
+  }
+
   const hasOverride = Boolean(manualSkyOverride);
   const normalized = hasOverride ? manualSkyOverride : normalizeMode(initial);
-  const entry = await loadSky(normalized);
-  applySky(entry);
+  currentMode = normalized;
 
-  // Prefetch other modes without blocking.
-  Object.keys(MODE_CONFIG).forEach((mode) => {
-    if (mode !== normalized) {
-      loadSky(mode).catch(() => {});
-    }
-  });
+  if (!skyEnabled) {
+    applySolidBackground(DEFAULT_BACKGROUND_COLOR);
+    return { mode: currentMode };
+  }
 
+  await loadSkyForMode(normalized);
   return { mode: currentMode };
 }
 
@@ -236,13 +173,18 @@ export async function setTimeOfDay(mode) {
     return currentMode ?? manualSkyOverride;
   }
   const normalized = normalizeMode(mode);
-  const entry = await loadSky(normalized);
-  applySky(entry);
-  return currentMode;
+  const previousMode = currentMode;
+  const success = skyEnabled ? await loadSkyForMode(normalized) : false;
+  if (success) {
+    currentMode = normalized;
+  } else if (previousMode == null) {
+    currentMode = normalized;
+  }
+  return currentMode ?? previousMode ?? normalized;
 }
 
 export function getTimeOfDay() {
-  return currentMode;
+  return currentMode ?? lastSuccessfulMode;
 }
 
 export function isSkyEnabled() {
@@ -260,17 +202,15 @@ export function setSkyEnabled(enabled) {
     return skyEnabled;
   }
   if (!skyEnabled) {
-    applyDefaultBackground();
-  } else if (currentEntry) {
-    applySky(currentEntry);
+    applySolidBackground(DEFAULT_BACKGROUND_COLOR);
+  } else if (hasLoadedSkyTexture && lastSuccessfulPath) {
+    reapplySky(activeScene);
   } else if (currentMode) {
-    loadSky(currentMode)
-      .then((entry) => {
-        if (skyEnabled) {
-          applySky(entry);
-        }
-      })
-      .catch(() => {});
+    loadSkyForMode(currentMode).catch(() => {});
+  } else if (lastSuccessfulMode) {
+    loadSkyForMode(lastSuccessfulMode).catch(() => {});
+  } else {
+    applyFallbackForMode('day');
   }
   notifySkyEnabledChange();
   return skyEnabled;


### PR DESCRIPTION
## Summary
- add a SkyManager helper that resolves base-URL safe JPG paths, caches textures, and can reapply the active sky
- switch boot and time-of-day logic to SkyManager so the main scene and HUD toggles reuse valid sky textures and dispatch horizon updates
- update initializeAthens and safe entry bootstraps to initialise the day sky via SkyManager and fall back to the cached texture if loading fails

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68db3ef25a88832790fcaad660e6420a