### PR TITLE
feat: spawn player outside city walls safely

### DIFF
--- a/src/entry/boot.ts
+++ b/src/entry/boot.ts
@@ -21,7 +21,7 @@ import {
 } from '../utils/sanitize';
 import { markGround, collectGround } from '../physics/groundRegistry.js';
 import { snapToGround } from '../physics/groundSnap.js';
-import { chooseSpawn, placeOnGround, ensureFeetAtLocalZero, groundYAt } from '../utils/spawn.ts';
+import { ensureFeetAtLocalZero, groundYAt } from '../utils/spawn.ts';
 import { createNpcManager } from '../npc/simpleNpcManager.js';
 import { markColliders, collectColliders, buildAABBs } from '../physics/colliderRegistry.js';
 import { AudioManager } from '../audio/AudioManager.js';
@@ -31,6 +31,7 @@ import { attachNpcAudio } from '../audio/npcAudio.js';
 import { createHUD } from '../ui/hud.js';
 import { createMountainRim as createHorizonMountainRim } from '../horizon/mountainRim.js';
 import { movementConfig } from '../config/movement.ts';
+import { spawnPlayerOutsideWalls } from '../player/spawnPlayerOutsideWalls.ts';
 
 type TransformState = {
   pos?: Partial<THREE.Vector3> | { x?: number | null; y?: number | null; z?: number | null } | null;
@@ -565,8 +566,6 @@ export async function runAthens(options: RunOptions = {}) {
   }
   ensureFeetAtLocalZero(playerObject);
 
-  const spawnPosition = chooseSpawn(scene, true);
-
   const resolveSavedState = (): SavedState | null => {
     if (options?.savedState) {
       return options.savedState;
@@ -658,14 +657,23 @@ export async function runAthens(options: RunOptions = {}) {
 
   restoreCameraAndPlayer(savedState);
 
+  const groundSnapSkip = { value: 0 };
+
   if (!hasSavedPlayerPos) {
-    playerObject.position.copy(spawnPosition);
-    placeOnGround(playerObject, groundMeshes.length ? groundMeshes : scene, { clearance: 0.02 });
+    await spawnPlayerOutsideWalls({
+      scene,
+      player: playerObject,
+      groundObjects: groundMeshes.length ? groundMeshes : null,
+      margin: 6,
+      skipSnapFramesFlag: groundSnapSkip
+    });
   }
 
   if (groundMeshes.length) {
     const initialState = { vy: 0, lastGoodY: playerObject.position.y };
-    snapToGround(playerObject, groundMeshes, initialState, 0);
+    if (!(groundSnapSkip.value > 0)) {
+      snapToGround(playerObject, groundMeshes, initialState, 0);
+    }
   }
 
   const cameraSettings = movementConfig?.camera ?? {};
@@ -696,7 +704,8 @@ export async function runAthens(options: RunOptions = {}) {
     runMultiplier: Number.isFinite(movementConfig?.runMultiplier) ? movementConfig.runMultiplier : 1.7,
     acceleration: Number.isFinite(movementConfig?.acceleration) ? movementConfig.acceleration : 10,
     turnLerp: 0.18,
-    colliders
+    colliders,
+    groundSnapSkipRef: groundSnapSkip
   });
   playerController.setGroundMeshes?.(groundMeshes);
   playerController.setColliders?.(colliders);

--- a/src/player/placeOnGroundSafe.ts
+++ b/src/player/placeOnGroundSafe.ts
@@ -1,0 +1,44 @@
+import * as THREE from 'three';
+
+const _ray = new THREE.Raycaster();
+const _origin = new THREE.Vector3();
+const _down = new THREE.Vector3(0, -1, 0);
+
+const WATER_NAMES = ['water', 'lake', 'ocean'];
+const SKY_NAMES = ['sky'];
+
+function shouldIgnoreHit(object: THREE.Object3D | null | undefined) {
+  if (!object) return false;
+  const name = (object.name || '').toLowerCase();
+  return WATER_NAMES.some((token) => name.includes(token)) || SKY_NAMES.some((token) => name.includes(token));
+}
+
+export function groundYAt(
+  scene: THREE.Scene,
+  x: number,
+  z: number,
+  startY = 1000,
+  include: THREE.Object3D[] | null = null
+) {
+  if (!scene) return 0;
+  const originY = Number.isFinite(startY) ? startY : 1000;
+  _origin.set(Number.isFinite(x) ? x : 0, originY, Number.isFinite(z) ? z : 0);
+  _ray.set(_origin, _down);
+
+  let targets: THREE.Object3D[] = [];
+  if (Array.isArray(include) && include.length) {
+    targets = include;
+  } else {
+    targets = [scene];
+  }
+
+  const hits = _ray.intersectObjects(targets, true);
+  for (const hit of hits) {
+    if (shouldIgnoreHit(hit.object)) continue;
+    const y = hit?.point?.y;
+    if (Number.isFinite(y)) {
+      return y;
+    }
+  }
+  return 0;
+}

--- a/src/player/playerController.js
+++ b/src/player/playerController.js
@@ -107,7 +107,8 @@ export function createPlayerController(
     runMultiplier = Number.isFinite(movementConfig?.runMultiplier) ? movementConfig.runMultiplier : 1.7,
     acceleration = Number.isFinite(movementConfig?.acceleration) ? movementConfig.acceleration : 10,
     turnLerp = 0.18, // kept for API compatibility
-    colliders: initialColliders = []
+    colliders: initialColliders = [],
+    groundSnapSkipRef = null
   } = {}
 ) {
   let controlledObject = object3d || null;
@@ -116,6 +117,8 @@ export function createPlayerController(
   let colliderAabbs = Array.isArray(initialColliders) ? initialColliders : [];
 
   const capsule = new Capsule(0.45, 1.6);
+
+  let groundSnapSkip = typeof groundSnapSkipRef === 'object' ? groundSnapSkipRef : null;
 
   const physicsState = {
     vy: 0,
@@ -438,7 +441,11 @@ export function createPlayerController(
 
     // Ground & upright stabilization
     if (!isFlying) {
-      snapToGround(controlledObject, groundMeshes, physicsState, dt);
+      if (groundSnapSkip && Number.isFinite(groundSnapSkip.value) && groundSnapSkip.value > 0) {
+        groundSnapSkip.value = Math.max(0, Math.floor(groundSnapSkip.value) - 1);
+      } else {
+        snapToGround(controlledObject, groundMeshes, physicsState, dt);
+      }
     }
     sanitizePosition(controlledObject.position);
     capsule.setPosition(controlledObject.position.x, controlledObject.position.y, controlledObject.position.z);
@@ -451,6 +458,9 @@ export function createPlayerController(
     setKeyboard,
     setGroundMeshes,
     setColliders,
+    setGroundSnapSkipRef(nextRef) {
+      groundSnapSkip = typeof nextRef === 'object' ? nextRef : null;
+    },
     isRunning() {
       return runningState;
     },

--- a/src/player/spawnOutsideWalls.ts
+++ b/src/player/spawnOutsideWalls.ts
@@ -1,0 +1,43 @@
+import * as THREE from 'three';
+
+function isValidBox(box: THREE.Box3 | null | undefined) {
+  if (!box) return false;
+  const { min, max } = box;
+  return [min.x, min.y, min.z, max.x, max.y, max.z].every(Number.isFinite) && max.x >= min.x && max.z >= min.z;
+}
+
+export function findWallsBounds(
+  scene: THREE.Scene,
+  names = ['CityWalls', 'Walls', 'Fortifications']
+): THREE.Box3 | null {
+  if (!scene) return null;
+  let walls: THREE.Object3D | null = null;
+  for (const n of names) {
+    if (!n) continue;
+    const candidate = scene.getObjectByName(n);
+    if (candidate) {
+      walls = candidate;
+      break;
+    }
+  }
+  if (!walls) return null;
+  const box = new THREE.Box3().setFromObject(walls);
+  if (!isValidBox(box) || box.isEmpty()) {
+    return null;
+  }
+  return box;
+}
+
+export function pickSpawnOutside(box: THREE.Box3, margin = 5) {
+  const safeMargin = Number.isFinite(margin) ? Math.max(0, margin) : 0;
+  if (!isValidBox(box)) {
+    return { x: 20, z: -20, yaw: 0 };
+  }
+  const centerX = (box.min.x + box.max.x) * 0.5;
+  const spawnX = Number.isFinite(centerX) ? centerX : 0;
+  const spawnZ = Number.isFinite(box.min.z)
+    ? box.min.z - safeMargin
+    : -safeMargin;
+  const yawFacingCity = 0;
+  return { x: spawnX, z: spawnZ, yaw: yawFacingCity };
+}

--- a/src/player/spawnPlayerOutsideWalls.ts
+++ b/src/player/spawnPlayerOutsideWalls.ts
@@ -1,0 +1,75 @@
+import * as THREE from 'three';
+import { computeHalfBodyHeight } from './spawnUtils.ts';
+import { findWallsBounds, pickSpawnOutside } from './spawnOutsideWalls.ts';
+import { groundYAt } from './placeOnGroundSafe.ts';
+
+export type SkipFlag = { value: number } | null;
+
+const DEFAULT_FALLBACK = { x: 20, z: -20, yaw: 0 };
+const UP_AXIS = new THREE.Vector3(0, 1, 0);
+
+function sanitizeNumber(value: number, fallback = 0) {
+  return Number.isFinite(value) ? value : fallback;
+}
+
+export async function spawnPlayerOutsideWalls(opts: {
+  scene: THREE.Scene;
+  player: THREE.Object3D;
+  controller?: { setPosition?: (x: number, y: number, z: number) => void } | null;
+  groundObjects?: THREE.Object3D[] | null;
+  halfBodyOverride?: number;
+  margin?: number;
+  faceYaw?: number;
+  skipSnapFramesFlag?: SkipFlag;
+}) {
+  const {
+    scene,
+    player,
+    controller,
+    groundObjects = null,
+    halfBodyOverride,
+    margin = 6,
+    faceYaw,
+    skipSnapFramesFlag
+  } = opts;
+
+  if (!scene || !player) return;
+
+  const wallsBox = findWallsBounds(scene);
+  const spawnBase = wallsBox ? pickSpawnOutside(wallsBox, margin) : DEFAULT_FALLBACK;
+  const x = sanitizeNumber(spawnBase.x, DEFAULT_FALLBACK.x);
+  const z = sanitizeNumber(spawnBase.z, DEFAULT_FALLBACK.z);
+  const yaw = typeof faceYaw === 'number' && Number.isFinite(faceYaw) ? faceYaw : sanitizeNumber(spawnBase.yaw, 0);
+
+  const groundY = groundYAt(scene, x, z, 1000, groundObjects ?? null);
+  const resolvedGroundY = Number.isFinite(groundY) ? groundY : 0;
+
+  let halfHeight: number;
+  if (Number.isFinite(halfBodyOverride) && (halfBodyOverride as number) > 0.05) {
+    halfHeight = halfBodyOverride as number;
+  } else {
+    halfHeight = computeHalfBodyHeight(player);
+  }
+  if (!Number.isFinite(halfHeight) || halfHeight <= 0) {
+    halfHeight = 0.9;
+  }
+
+  const targetY = resolvedGroundY + halfHeight;
+
+  if (controller?.setPosition) {
+    controller.setPosition(x, targetY, z);
+  } else if (player.position) {
+    player.position.set(x, targetY, z);
+  }
+
+  if (player.quaternion) {
+    player.quaternion.setFromAxisAngle(UP_AXIS, yaw);
+  }
+
+  player.updateMatrixWorld?.(true);
+
+  if (skipSnapFramesFlag && typeof skipSnapFramesFlag === 'object') {
+    skipSnapFramesFlag.value = Number.isFinite(skipSnapFramesFlag.value) ? Math.max(1, Math.floor(skipSnapFramesFlag.value)) : 1;
+    skipSnapFramesFlag.value += 1;
+  }
+}

--- a/src/player/spawnUtils.ts
+++ b/src/player/spawnUtils.ts
@@ -1,0 +1,23 @@
+import * as THREE from 'three';
+
+export function computeApproxBodyHeight(obj: THREE.Object3D, fallback = 1.8) {
+  if (!obj) return fallback;
+  const box = new THREE.Box3().setFromObject(obj);
+  if (!Number.isFinite(box.min.y) || !Number.isFinite(box.max.y)) {
+    return fallback;
+  }
+  const height = box.max.y - box.min.y;
+  if (!Number.isFinite(height) || height <= 0.1) {
+    return fallback;
+  }
+  return height;
+}
+
+export function computeHalfBodyHeight(obj: THREE.Object3D, fallback = 1.8) {
+  const full = computeApproxBodyHeight(obj, fallback);
+  const half = full * 0.5;
+  if (!Number.isFinite(half) || half <= 0.05) {
+    return Math.max(0.05, fallback * 0.5);
+  }
+  return half;
+}


### PR DESCRIPTION
## Audit
- Player boot flow relied on `chooseSpawn` + `placeOnGround`, dropping the avatar inside the walls before an immediate `snapToGround`, which often clipped into nearby geometry.
- Ground stabilization always ran every frame via `snapToGround`, so there was no grace period for intentional hover or flight states.

## Summary
- Add utilities to locate city wall bounds, sample safe ground height, and approximate the player's body height for hover placement.
- Spawn new players outside the wall bounds at ground height plus half their body height, skipping initial ground snap frames to avoid clipping.
- Allow the player controller to honor a shared snap-skip flag so gravity/snap resumes smoothly after the hover spawn.

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68db40a5e46c8327974bf2e70db8bc50