### PR TITLE
Fix assetUrl handling of absolute bases

### DIFF
--- a/src/utils/assetUrl.js
+++ b/src/utils/assetUrl.js
@@ -1,4 +1,41 @@
+const ABSOLUTE_URL_REGEX = /^[a-zA-Z][a-zA-Z\d+\-.]*:\/\//;
+
+function resolveBaseUrl() {
+  if (
+    typeof import.meta !== 'undefined' &&
+    import.meta &&
+    import.meta.env &&
+    typeof import.meta.env.BASE_URL === 'string'
+  ) {
+    return import.meta.env.BASE_URL;
+  }
+
+  if (
+    typeof process !== 'undefined' &&
+    process &&
+    process.env &&
+    typeof process.env.BASE_URL === 'string'
+  ) {
+    return process.env.BASE_URL;
+  }
+
+  return '/';
+}
+
 export function assetUrl(rel) {
-  const base = import.meta.env.BASE_URL || '/';
-  return (base + rel.replace(/^\/+/, '')).replace(/\/{2,}/g, '/');
+  const base = resolveBaseUrl();
+
+  if (ABSOLUTE_URL_REGEX.test(rel)) {
+    return rel;
+  }
+
+  if (ABSOLUTE_URL_REGEX.test(base)) {
+    return new URL(rel, base).toString();
+  }
+
+  const normalizedBase = base.endsWith('/') ? base : `${base}/`;
+  const normalizedRel = rel.replace(/^\/+/, '');
+  const combined = normalizedBase + normalizedRel;
+
+  return combined.replace(/\/{2,}/g, '/');
 }

--- a/tests/asset-url.test.js
+++ b/tests/asset-url.test.js
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { assetUrl } from '../src/utils/assetUrl.js';
+
+function withBaseUrl(value, fn) {
+  const previous = process.env.BASE_URL;
+  if (typeof value === 'undefined') {
+    delete process.env.BASE_URL;
+  } else {
+    process.env.BASE_URL = value;
+  }
+
+  try {
+    return fn();
+  } finally {
+    if (typeof previous === 'undefined') {
+      delete process.env.BASE_URL;
+    } else {
+      process.env.BASE_URL = previous;
+    }
+  }
+}
+
+test('assetUrl resolves URLs for different base formats', async (t) => {
+  await t.test('joins relative base and asset path', () => {
+    withBaseUrl('/static/', () => {
+      assert.equal(
+        assetUrl('models/tree.glb'),
+        '/static/models/tree.glb'
+      );
+    });
+  });
+
+  await t.test('preserves protocol delimiters for absolute bases', () => {
+    withBaseUrl('https://cdn.example.com/assets/', () => {
+      assert.equal(
+        assetUrl('textures/sky.jpg'),
+        'https://cdn.example.com/assets/textures/sky.jpg'
+      );
+    });
+  });
+
+  await t.test('allows absolute asset paths to pass through unchanged', () => {
+    withBaseUrl('https://cdn.example.com/assets/', () => {
+      assert.equal(
+        assetUrl('https://images.example.com/sky.jpg'),
+        'https://images.example.com/sky.jpg'
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- ensure assetUrl preserves protocol delimiters when resolving assets and allow process.env-based fallback
- add unit tests that cover relative and absolute base and asset combinations

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68db4368d29083279733c4b2359b5bbd