### PR TITLE
Add keyboard time-of-day cycling controller and lighting adjustments

### DIFF
--- a/src/entry/boot.ts
+++ b/src/entry/boot.ts
@@ -29,10 +29,17 @@ import { AmbientAPI, AMBIENT_TRACKS, initAmbient } from '../audio/ambient';
 import { createFootsteps } from '../audio/footsteps.js';
 import { attachNpcAudio } from '../audio/npcAudio.js';
 import { createHUD } from '../ui/hud.js';
-import { createTimeSky, setTimeOfDay, setSkyEnabled, isSkyEnabled, getTimeOfDay } from '../sky/timeSky.js';
+import { createTimeSky, setSkyEnabled, isSkyEnabled } from '../sky/timeSky.js';
 import { createMountainRim as createHorizonMountainRim } from '../horizon/mountainRim.js';
 import { movementConfig } from '../config/movement.ts';
 import { spawnPlayerOutsideWalls } from '../player/spawnPlayerOutsideWalls.ts';
+import {
+  initializeTimeMode,
+  setTimeMode as applyTimeMode,
+  shiftTimeForward,
+  shiftTimeBackward,
+  getTimeMode as getCurrentTimeMode
+} from '../time/timeController.ts';
 
 type TransformState = {
   pos?: Partial<THREE.Vector3> | { x?: number | null; y?: number | null; z?: number | null } | null;
@@ -335,6 +342,8 @@ export async function runAthens(options: RunOptions = {}) {
   scene.add(ambientLight);
   scene.add(directionalLight);
 
+  const lightingContext = { renderer, sun: directionalLight, ambient: ambientLight };
+
   const applyQualityPreset = (preset: string) => {
     const normalized = typeof preset === 'string' ? preset.toLowerCase() : '';
     const target: 'low' | 'medium' | 'high' =
@@ -393,6 +402,7 @@ export async function runAthens(options: RunOptions = {}) {
   }
 
   await createTimeSky(renderer, scene, initialSkyMode);
+  const initialTimeMode = await initializeTimeMode(initialSkyMode, lightingContext);
   applyHorizonVisibility(isSkyEnabled() || resolveHorizonEnabled());
 
   if (typeof setupGround === 'function') {
@@ -442,17 +452,17 @@ export async function runAthens(options: RunOptions = {}) {
     return trackId;
   };
 
-  const initialAmbientMode = getTimeOfDay() ?? initialSkyMode;
+  let activeTimeMode = initialTimeMode ?? initialSkyMode;
 
   if (!ambientOverrideSelected) {
-    applyAmbientForMode(initialAmbientMode, true);
+    applyAmbientForMode(activeTimeMode, true);
   }
 
   const handleTimeOfDay = async (mode: string) => {
-    const appliedMode = await setTimeOfDay(mode);
-    const effectiveMode = appliedMode ?? getTimeOfDay() ?? initialSkyMode;
-    applyAmbientForMode(effectiveMode, true);
-    return effectiveMode;
+    const appliedMode = await applyTimeMode(mode, lightingContext);
+    activeTimeMode = appliedMode ?? getCurrentTimeMode() ?? activeTimeMode;
+    applyAmbientForMode(activeTimeMode, true);
+    return activeTimeMode;
   };
 
   const handleVolume = (value: number) => {
@@ -778,6 +788,23 @@ export async function runAthens(options: RunOptions = {}) {
       }
 
       keyboard.update?.();
+
+      if (keyboard.wasPressed?.('KeyT')) {
+        shiftTimeForward(lightingContext)
+          .then((mode) => {
+            activeTimeMode = mode ?? activeTimeMode;
+            applyAmbientForMode(activeTimeMode, true);
+          })
+          .catch(() => {});
+      }
+      if (keyboard.wasPressed?.('KeyY')) {
+        shiftTimeBackward(lightingContext)
+          .then((mode) => {
+            activeTimeMode = mode ?? activeTimeMode;
+            applyAmbientForMode(activeTimeMode, true);
+          })
+          .catch(() => {});
+      }
 
       previousPlayerPosition.copy(playerObject.position);
       try {

--- a/src/input/keyboard.js
+++ b/src/input/keyboard.js
@@ -16,7 +16,20 @@ const LOOK_KEYS = [
 
 const MODIFIER_KEYS = ['ShiftLeft', 'ShiftRight'];
 
-const EXTRA_KEYS = ['Space', 'KeyX', 'KeyC', 'KeyE', 'KeyQ', 'KeyZ', 'KeyF', 'ControlLeft', 'ControlRight'];
+const EXTRA_KEYS = [
+  'Space',
+  'KeyX',
+  'KeyC',
+  'KeyE',
+  'KeyQ',
+  'KeyZ',
+  'KeyF',
+  'ControlLeft',
+  'ControlRight',
+  'KeyT',
+  'KeyY',
+  'KeyP'
+];
 
 const RELEVANT_KEYS = new Set([...MOVEMENT_KEYS, ...LOOK_KEYS, ...MODIFIER_KEYS, ...EXTRA_KEYS]);
 
@@ -38,6 +51,9 @@ const KEY_FALLBACK_MAP = new Map([
   ['f', 'KeyF'],
   ['c', 'KeyC'],
   ['e', 'KeyE'],
+  ['t', 'KeyT'],
+  ['y', 'KeyY'],
+  ['p', 'KeyP'],
   ['shift', 'ShiftLeft'],
   ['control', 'ControlLeft']
 ]);
@@ -63,6 +79,7 @@ const normalizeCode = (event) => {
 
 export function createKeyboard(target = typeof window !== 'undefined' ? window : null) {
   const pressed = new Set();
+  const justPressed = new Set();
   const listeners = new Map();
   const axisState = {
     x: 0,
@@ -88,6 +105,9 @@ export function createKeyboard(target = typeof window !== 'undefined' ? window :
 
     if (!RELEVANT_KEYS.has(code)) {
       return;
+    }
+    if (!pressed.has(code)) {
+      justPressed.add(code);
     }
     pressed.add(code);
     updateState();
@@ -149,6 +169,8 @@ export function createKeyboard(target = typeof window !== 'undefined' ? window :
 
   updateState();
 
+  let frameJustPressed = new Set();
+
   const axis = {};
   Object.defineProperties(axis, {
     x: {
@@ -207,7 +229,18 @@ export function createKeyboard(target = typeof window !== 'undefined' ? window :
 
   const update = () => {
     updateState();
+    frameJustPressed = new Set(justPressed);
+    justPressed.clear();
     return axisState;
+  };
+
+  const wasPressed = (code) => {
+    if (!code) return false;
+    if (frameJustPressed.has(code)) {
+      frameJustPressed.delete(code);
+      return true;
+    }
+    return false;
   };
 
   const dispose = () => {
@@ -219,6 +252,8 @@ export function createKeyboard(target = typeof window !== 'undefined' ? window :
     });
     listeners.clear();
     pressed.clear();
+    justPressed.clear();
+    frameJustPressed.clear();
     updateState();
   };
 
@@ -227,6 +262,7 @@ export function createKeyboard(target = typeof window !== 'undefined' ? window :
     update,
     axis,
     look,
+    wasPressed,
     dispose
   };
 }

--- a/src/time/timeController.ts
+++ b/src/time/timeController.ts
@@ -1,0 +1,127 @@
+import * as THREE from 'three';
+import { setTimeOfDay, getTimeOfDay } from '../sky/timeSky.js';
+
+export const TIME_MODES = ['dawn', 'day', 'dusk', 'night'] as const;
+export type TimeMode = (typeof TIME_MODES)[number];
+
+type LightingContext = {
+  scene?: THREE.Scene | null;
+  renderer?: THREE.WebGLRenderer | null;
+  sun?: THREE.DirectionalLight | null;
+  ambient?: THREE.Light | null;
+};
+
+let current: TimeMode = 'day';
+let paused = false;
+
+const MODE_EXPOSURE: Record<TimeMode, number> = {
+  dawn: 0.9,
+  day: 1.05,
+  dusk: 0.9,
+  night: 0.7
+};
+
+const MODE_SUN_INTENSITY: Record<TimeMode, number> = {
+  dawn: 1.6,
+  day: 3.0,
+  dusk: 1.6,
+  night: 0.5
+};
+
+const MODE_AMBIENT_INTENSITY: Record<TimeMode, number> = {
+  dawn: 0.55,
+  day: 0.8,
+  dusk: 0.55,
+  night: 0.35
+};
+
+const SUN_DIRECTIONS: Record<TimeMode, THREE.Vector3> = {
+  dawn: new THREE.Vector3(-0.35, 0.55, 0.25),
+  day: new THREE.Vector3(-0.25, 0.95, 0.3),
+  dusk: new THREE.Vector3(0.3, 0.55, -0.25),
+  night: new THREE.Vector3(0.1, 0.2, -0.4)
+};
+
+const DEFAULT_MODE: TimeMode = 'day';
+
+function normalizeMode(mode: string | null | undefined): TimeMode {
+  if (!mode) {
+    return current ?? DEFAULT_MODE;
+  }
+  const normalized = `${mode}`.toLowerCase();
+  const found = TIME_MODES.find((value) => value === normalized);
+  if (found) {
+    return found;
+  }
+  return current ?? DEFAULT_MODE;
+}
+
+function applyLighting(mode: TimeMode, ctx: LightingContext = {}) {
+  const { renderer, sun, ambient } = ctx;
+  if (renderer) {
+    const targetExposure = MODE_EXPOSURE[mode] ?? renderer.toneMappingExposure;
+    renderer.toneMappingExposure = targetExposure;
+  }
+  if (sun) {
+    const intensity = MODE_SUN_INTENSITY[mode] ?? sun.intensity;
+    sun.intensity = intensity;
+    const direction = SUN_DIRECTIONS[mode];
+    if (direction) {
+      sun.position.set(direction.x * 400, Math.max(direction.y * 400, 30), direction.z * 400);
+    }
+  }
+  if (ambient) {
+    const target = MODE_AMBIENT_INTENSITY[mode] ?? ambient.intensity;
+    ambient.intensity = target;
+  }
+}
+
+export function getTimeMode(): TimeMode {
+  return current;
+}
+
+export function isTimePaused(): boolean {
+  return paused;
+}
+
+export function setTimePaused(value: boolean): boolean {
+  paused = Boolean(value);
+  return paused;
+}
+
+export async function setTimeMode(
+  mode: TimeMode | string,
+  ctx: LightingContext = {}
+): Promise<TimeMode> {
+  const next = typeof mode === 'string' ? mode : mode ?? current;
+  const requested = next ?? current;
+  const applied = await setTimeOfDay(requested);
+  const normalized = normalizeMode(applied ?? requested ?? current);
+  current = normalized;
+  applyLighting(normalized, ctx);
+  return current;
+}
+
+export async function initializeTimeMode(
+  mode: TimeMode | string | null | undefined,
+  ctx: LightingContext = {}
+): Promise<TimeMode> {
+  const fallback = (getTimeOfDay?.() as TimeMode | null | undefined) ?? current;
+  const requested = typeof mode === 'string' ? mode : fallback;
+  const normalized = normalizeMode(requested ?? fallback ?? current);
+  current = normalized;
+  return setTimeMode(normalized, ctx);
+}
+
+export async function shiftTimeForward(ctx: LightingContext = {}): Promise<TimeMode> {
+  const index = TIME_MODES.indexOf(current);
+  const next = TIME_MODES[(index + 1) % TIME_MODES.length];
+  return setTimeMode(next, ctx);
+}
+
+export async function shiftTimeBackward(ctx: LightingContext = {}): Promise<TimeMode> {
+  const index = TIME_MODES.indexOf(current);
+  const nextIndex = (index - 1 + TIME_MODES.length) % TIME_MODES.length;
+  const previous = TIME_MODES[nextIndex];
+  return setTimeMode(previous, ctx);
+}


### PR DESCRIPTION
## Summary
- add a shared time controller that updates sky assets, tone-mapping exposure, and key lights for dawn/day/dusk/night
- extend the keyboard helper to expose per-frame key presses for new time travel hotkeys
- hook the boot flow to initialise the requested sky mode and react to T/Y presses while keeping ambient audio aligned

## Testing
- `npm test`

## Audit
- time-of-day modes and sky loading live in `src/sky/timeSky.js`
- the primary sun/ambient lights are created in `src/entry/boot.ts`
- keyboard input state is centralised in `src/input/keyboard.js`


------
https://chatgpt.com/codex/tasks/task_b_68db5db5362883279b7b97509c959ee3