### PR TITLE
Add runtime animation controller for player movement

### DIFF
--- a/src/entry/boot.ts
+++ b/src/entry/boot.ts
@@ -6,6 +6,7 @@ import boot from '../core/bootstrap.js';
 import createKeyboard from '../input/keyboard.js';
 import { createPlayerController } from '../player/playerController.js';
 import { loadPlayerAvatar, PlayerAvatar } from '../player/playerAvatar.ts';
+import { AnimationController } from '../player/animationController';
 import { createFollowCamera } from '../camera/followCamera.js';
 import { seedCameraBehindPlayer } from '../camera/seedCameraBehindPlayer.js';
 import { installRenderGuard } from '../safety/hardenPositions';
@@ -524,6 +525,7 @@ export async function runAthens(options: RunOptions = {}) {
   const colliders = buildAABBs(colliderMeshes);
 
   let playerAvatar: PlayerAvatar | null = null;
+  let animController: AnimationController | null = null;
   const existingPlayer =
     scene.getObjectByName('MainCharacter') || scene.getObjectByName('Player');
 
@@ -545,6 +547,16 @@ export async function runAthens(options: RunOptions = {}) {
     scene.add(playerObject);
   }
   ensureFeetAtLocalZero(playerObject);
+
+  if (playerAvatar) {
+    const clips = Object.values(playerAvatar.clips).filter(
+      (clip): clip is THREE.AnimationClip => clip instanceof THREE.AnimationClip
+    );
+    (playerObject as THREE.Object3D & { animations?: THREE.AnimationClip[] }).animations = clips;
+    animController = new AnimationController(
+      playerObject as THREE.Object3D & { animations?: THREE.AnimationClip[] }
+    );
+  }
 
   const resolveSavedState = (): SavedState | null => {
     if (options?.savedState) {
@@ -689,6 +701,11 @@ export async function runAthens(options: RunOptions = {}) {
   });
   playerController.setGroundMeshes?.(groundMeshes);
   playerController.setColliders?.(colliders);
+
+  const state = (playerController as { state?: { anim?: AnimationController | null } }).state;
+  if (state && animController) {
+    state.anim = animController;
+  }
 
   const footsteps = createFootsteps(audio);
 

--- a/src/player/animationController.ts
+++ b/src/player/animationController.ts
@@ -1,0 +1,43 @@
+import * as THREE from 'three';
+
+export type AnimSet = { idle?: THREE.AnimationAction; walk?: THREE.AnimationAction; run?: THREE.AnimationAction; };
+
+export class AnimationController {
+  mixer: THREE.AnimationMixer;
+  actions: AnimSet;
+
+  constructor(root: THREE.Object3D & { animations?: THREE.AnimationClip[] }) {
+    const clips = root.animations ?? [];
+    const find = (keys: string[]) => clips.find(c => keys.some(k => (c.name||'').toLowerCase().includes(k)));
+    const idle = find(['idle']);
+    const walk = find(['walk']);
+    const run  = find(['run']);
+
+    this.mixer = new THREE.AnimationMixer(root);
+    this.actions = {
+      idle: idle ? this.mixer.clipAction(idle) : undefined,
+      walk: walk ? this.mixer.clipAction(walk) : undefined,
+      run:  run  ? this.mixer.clipAction(run)  : undefined,
+    };
+    Object.values(this.actions).forEach(a => a && a.play());
+    this.set('idle');
+  }
+
+  set(name: 'idle'|'walk'|'run') {
+    (['idle','walk','run'] as const).forEach(k => {
+      if (this.actions[k]) this.actions[k]!.setEffectiveWeight(k===name ? 1 : 0);
+    });
+    if (this.actions[name]) this.actions[name]!.time = 0;
+  }
+
+  cross(from: keyof AnimSet, to: keyof AnimSet, dur: number = 0.4) {
+    const a = this.actions[from], b = this.actions[to];
+    if (!a || !b) return;
+    b.enabled = true; b.setEffectiveWeight(1); b.time = 0;
+    a.crossFadeTo(b, dur, true);
+  }
+
+  update(dt: number) {
+    this.mixer.update(dt);
+  }
+}

--- a/src/player/playerController.js
+++ b/src/player/playerController.js
@@ -120,6 +120,11 @@ export function createPlayerController(
 
   let groundSnapSkip = typeof groundSnapSkipRef === 'object' ? groundSnapSkipRef : null;
 
+  const state = {
+    velocity: new THREE.Vector3(),
+    anim: null
+  };
+
   const physicsState = {
     vy: 0,
     lastGoodY: Number.isFinite(controlledObject?.position?.y)
@@ -375,6 +380,17 @@ export function createPlayerController(
       velocity.y = 0;
     }
     sanitizeVec3(velocity, ZERO_VECTOR);
+    state.velocity.copy(velocity);
+
+    // ANIM_START
+    if (state.anim) {
+      const speed = Math.sqrt(state.velocity.x ** 2 + state.velocity.z ** 2);
+      if (speed < 0.1) state.anim.set('idle');
+      else if (speed < 2.5) state.anim.set('walk');
+      else state.anim.set('run');
+      state.anim.update(dt);
+    }
+    // ANIM_END
 
     // Integrate motion with collisions
     sanitizePosition(position);
@@ -466,7 +482,8 @@ export function createPlayerController(
     },
     isFlying() {
       return isFlying;
-    }
+    },
+    state
   };
 }
 


### PR DESCRIPTION
## Summary
- add an AnimationController utility that finds idle/walk/run clips on the player model and drives a Three.js mixer
- expose a player controller state object so per-frame updates can choose animations based on horizontal speed
- initialize the animation controller when the GLB avatar loads and hook it up to the player controller state

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68db6a4531448327bf324736b7cde2dd