### PR TITLE
Normalize player height and drive animation mixer from main loop

### DIFF
--- a/src/entry/boot.ts
+++ b/src/entry/boot.ts
@@ -6,7 +6,7 @@ import boot from '../core/bootstrap.js';
 import createKeyboard from '../input/keyboard.js';
 import { createPlayerController } from '../player/playerController.js';
 import { loadPlayerAvatar, PlayerAvatar } from '../player/playerAvatar.ts';
-import { AnimationController } from '../player/animationController';
+import { AnimationController, scaleObjectToHeight } from '../player/animationController';
 import { createFollowCamera } from '../camera/followCamera.js';
 import { seedCameraBehindPlayer } from '../camera/seedCameraBehindPlayer.js';
 import { installRenderGuard } from '../safety/hardenPositions';
@@ -546,6 +546,7 @@ export async function runAthens(options: RunOptions = {}) {
   if (!scene.getObjectByName(playerObject.name)) {
     scene.add(playerObject);
   }
+  scaleObjectToHeight(playerObject, 1.8);
   ensureFeetAtLocalZero(playerObject);
 
   if (playerAvatar) {
@@ -553,9 +554,16 @@ export async function runAthens(options: RunOptions = {}) {
       (clip): clip is THREE.AnimationClip => clip instanceof THREE.AnimationClip
     );
     (playerObject as THREE.Object3D & { animations?: THREE.AnimationClip[] }).animations = clips;
-    animController = new AnimationController(
-      playerObject as THREE.Object3D & { animations?: THREE.AnimationClip[] }
-    );
+  }
+
+  if (!animController) {
+    const playerWithAnimations = playerObject as THREE.Object3D & { animations?: THREE.AnimationClip[] };
+    const animations = playerWithAnimations.animations;
+    if (Array.isArray(animations) && animations.length > 0) {
+      animController = new AnimationController(playerWithAnimations);
+      animController.autoUpdate = false;
+      animController.update(0, { immediate: true });
+    }
   }
 
   const resolveSavedState = (): SavedState | null => {
@@ -702,7 +710,9 @@ export async function runAthens(options: RunOptions = {}) {
   playerController.setGroundMeshes?.(groundMeshes);
   playerController.setColliders?.(colliders);
 
-  const state = (playerController as { state?: { anim?: AnimationController | null } }).state;
+  const state = (
+    playerController as { state?: { anim?: AnimationController | null; velocity?: THREE.Vector3 | null } }
+  ).state;
   if (state && animController) {
     state.anim = animController;
   }
@@ -866,6 +876,29 @@ export async function runAthens(options: RunOptions = {}) {
         } catch (error) {
           console.warn('[Athens][Boot] player avatar update failed', error);
         }
+      }
+
+      if (animController) {
+        const usesControllerState = Boolean(state && state.anim === animController);
+        const velocityVec = (state?.velocity ?? null) as THREE.Vector3 | null;
+        let planarSpeed = Number.NaN;
+        if (velocityVec && Number.isFinite(velocityVec.x) && Number.isFinite(velocityVec.z)) {
+          planarSpeed = Math.hypot(velocityVec.x, velocityVec.z);
+        }
+        if (!Number.isFinite(planarSpeed)) {
+          const safeDelta = delta > 1e-6 ? delta : 1 / 60;
+          const denom = Math.max(safeDelta, 1e-6);
+          planarSpeed = denom > 0 ? Math.hypot(playerDelta.x, playerDelta.z) / denom : 0;
+        }
+        if (!usesControllerState) {
+          let desired: 'idle' | 'walk' | 'run' = 'idle';
+          if (planarSpeed >= 2.5) desired = 'run';
+          else if (planarSpeed >= 0.1) desired = 'walk';
+          if (animController.current !== desired) {
+            animController.set(desired);
+          }
+        }
+        animController.update(usesControllerState ? 0 : delta, { immediate: true });
       }
 
       footstepInterval = footsteps.setIntervalBySpeed(currentSpeed);

--- a/src/player/animationController.ts
+++ b/src/player/animationController.ts
@@ -1,43 +1,111 @@
 import * as THREE from 'three';
 
-export type AnimSet = { idle?: THREE.AnimationAction; walk?: THREE.AnimationAction; run?: THREE.AnimationAction; };
+export type AnimSet = { idle?: THREE.AnimationAction; walk?: THREE.AnimationAction; run?: THREE.AnimationAction };
+
+const ACTION_NAMES = ['idle', 'walk', 'run'] as const;
+
+type ClipName = (typeof ACTION_NAMES)[number];
 
 export class AnimationController {
   mixer: THREE.AnimationMixer;
   actions: AnimSet;
+  autoUpdate = true;
+  private currentState: ClipName | null = null;
+  private pendingTime = 0;
 
   constructor(root: THREE.Object3D & { animations?: THREE.AnimationClip[] }) {
     const clips = root.animations ?? [];
-    const find = (keys: string[]) => clips.find(c => keys.some(k => (c.name||'').toLowerCase().includes(k)));
+    const find = (keys: string[]) => clips.find((clip) => keys.some((key) => (clip.name || '').toLowerCase().includes(key)));
     const idle = find(['idle']);
     const walk = find(['walk']);
-    const run  = find(['run']);
+    const run = find(['run']);
 
     this.mixer = new THREE.AnimationMixer(root);
-    this.actions = {
-      idle: idle ? this.mixer.clipAction(idle) : undefined,
-      walk: walk ? this.mixer.clipAction(walk) : undefined,
-      run:  run  ? this.mixer.clipAction(run)  : undefined,
+    const prepare = (clip?: THREE.AnimationClip) => {
+      if (!clip) return undefined;
+      const action = this.mixer.clipAction(clip);
+      action.enabled = true;
+      action.setEffectiveWeight(0);
+      action.play();
+      return action;
     };
-    Object.values(this.actions).forEach(a => a && a.play());
+
+    this.actions = {
+      idle: prepare(idle),
+      walk: prepare(walk),
+      run: prepare(run)
+    };
+
     this.set('idle');
   }
 
-  set(name: 'idle'|'walk'|'run') {
-    (['idle','walk','run'] as const).forEach(k => {
-      if (this.actions[k]) this.actions[k]!.setEffectiveWeight(k===name ? 1 : 0);
+  get current(): ClipName | null {
+    return this.currentState;
+  }
+
+  set(name: ClipName) {
+    if (this.currentState === name) return;
+    const target = this.actions[name];
+    if (!target) return;
+    ACTION_NAMES.forEach((key) => {
+      const action = this.actions[key];
+      if (!action) return;
+      if (key === name) {
+        action.reset();
+        action.enabled = true;
+        action.setEffectiveWeight(1);
+      } else {
+        action.setEffectiveWeight(0);
+      }
     });
-    if (this.actions[name]) this.actions[name]!.time = 0;
+    target.play();
+    this.currentState = name;
   }
 
-  cross(from: keyof AnimSet, to: keyof AnimSet, dur: number = 0.4) {
-    const a = this.actions[from], b = this.actions[to];
+  cross(from: keyof AnimSet, to: keyof AnimSet, dur = 0.4) {
+    const a = this.actions[from];
+    const b = this.actions[to];
     if (!a || !b) return;
-    b.enabled = true; b.setEffectiveWeight(1); b.time = 0;
+    b.enabled = true;
+    b.setEffectiveWeight(1);
+    b.reset();
     a.crossFadeTo(b, dur, true);
+    this.currentState = (to as ClipName) ?? this.currentState;
   }
 
-  update(dt: number) {
-    this.mixer.update(dt);
+  update(dt: number, options?: { immediate?: boolean }) {
+    if (!Number.isFinite(dt) || dt <= 0) {
+      if (options?.immediate && this.pendingTime > 0) {
+        this.mixer.update(this.pendingTime);
+        this.pendingTime = 0;
+      }
+      return;
+    }
+
+    if (options?.immediate) {
+      const total = this.pendingTime > 0 ? this.pendingTime : dt;
+      if (total > 0) {
+        this.mixer.update(total);
+      }
+      this.pendingTime = 0;
+      return;
+    }
+
+    if (this.autoUpdate) {
+      this.mixer.update(dt);
+    } else {
+      this.pendingTime += dt;
+    }
   }
+}
+
+export function scaleObjectToHeight(obj: THREE.Object3D, targetHeight = 1.8) {
+  if (!Number.isFinite(targetHeight) || targetHeight <= 0) return;
+  const box = new THREE.Box3().setFromObject(obj);
+  if (box.isEmpty()) return;
+  const height = box.max.y - box.min.y;
+  if (!Number.isFinite(height) || height <= 1e-4) return;
+  const scale = targetHeight / height;
+  obj.scale.setScalar(scale);
+  obj.updateMatrixWorld(true);
 }


### PR DESCRIPTION
## Summary
- scale the player object to a consistent 1.8 m and initialise an animation controller when clips are present
- extend the animation controller with clip discovery, deferred updates, and height-scaling helpers
- update the render loop to advance the mixer every frame with speed-based fallbacks when controller state is unavailable

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68db7e132c888327bbc35eddaae1a7fa