### PR TITLE
Scale main character via movement config

### DIFF
--- a/src/config/movement.ts
+++ b/src/config/movement.ts
@@ -30,6 +30,14 @@ export interface MovementCameraConfig {
   seed?: CameraSeedConfig;
 }
 
+export interface CharacterConfig {
+  /**
+   * Uniform scale applied to the controllable character.
+   * The value is a dimensionless multiplier where `1` keeps the default asset size.
+   */
+  scale?: number;
+}
+
 export interface MovementConfig {
   walkSpeed?: number;
   runMultiplier?: number;
@@ -37,6 +45,7 @@ export interface MovementConfig {
   safePosition?: { x: number; y: number; z: number };
   flight?: FlightConfig;
   camera?: MovementCameraConfig;
+  character?: CharacterConfig;
 }
 
 export const FLIGHT = {
@@ -44,11 +53,24 @@ export const FLIGHT = {
   horizontalSpeed: 8
 } as const;
 
+export const DEFAULT_CHARACTER_SCALE = 1;
+
+export function resolveCharacterScale(config: MovementConfig = movementConfig): number {
+  const value = config?.character?.scale;
+  const numericScale = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(numericScale) && numericScale > 0
+    ? numericScale
+    : DEFAULT_CHARACTER_SCALE;
+}
+
 export const movementConfig: MovementConfig = {
   walkSpeed: 4,
   runMultiplier: 1.7,
   acceleration: 10,
   safePosition: { x: 0, y: 1, z: 0 },
+  character: {
+    scale: DEFAULT_CHARACTER_SCALE
+  },
   flight: {
     toggleKey: 'KeyF',
     toggleKeys: ['KeyF', 'KeyX'],

--- a/src/entry/initializeAthens.js
+++ b/src/entry/initializeAthens.js
@@ -20,7 +20,7 @@ import { installFlyBypass } from '../dev/flyBypass.js';
 import { assetUrl } from '../utils/assetUrl.js';
 import { createGameLoop } from '../engine/loop.js';
 import { initSky, setSky, reapplySky } from '../sky/SkyManager.ts';
-import { movementConfig } from '../config/movement.ts';
+import { movementConfig, resolveCharacterScale } from '../config/movement.ts';
 import { markGround, collectGround } from '../physics/groundRegistry.js';
 import { markColliders, collectColliders, buildAABBs } from '../physics/colliderRegistry.js';
 import { sampleGroundY, snapGroupToGround, snapObjectToGround, snapChildrenToGround } from '../physics/groundProject.js';
@@ -253,10 +253,17 @@ function createDefaultNpcConfigs(modelUrls = DEFAULT_NPC_MODEL_URLS) {
   });
 }
 
+const CHARACTER_SCALE = resolveCharacterScale();
 const DEFAULT_PLAYER_START = new THREE.Vector3(6, 0, -12);
 const PLAYER_SEARCH_STEP = 4;
 const PLAYER_SEARCH_RINGS = 10;
-const PLAYER_COLLIDER_MARGIN = 1.5;
+const PLAYER_COLLIDER_MARGIN = 1.5 * CHARACTER_SCALE;
+const PLAYER_SPAWN_HOVER = 0.05 * CHARACTER_SCALE;
+const PLAYER_SAFE_FALLBACK = {
+  x: DEFAULT_PLAYER.x,
+  y: DEFAULT_PLAYER.y * CHARACTER_SCALE,
+  z: DEFAULT_PLAYER.z
+};
 
 const _spawnCandidate = new THREE.Vector3();
 
@@ -304,7 +311,7 @@ function findSafePlayerSpawn({
   hint,
   groundMeshes,
   colliders,
-  hover = 0.05,
+  hover = PLAYER_SPAWN_HOVER,
   fromY = 400
 } = {}) {
   const base = toVector3(hint, DEFAULT_PLAYER_START);
@@ -918,10 +925,10 @@ export async function initializeAthens(options = {}) {
     hint: spawnHint,
     groundMeshes,
     colliders,
-    hover: 0.05,
+    hover: PLAYER_SPAWN_HOVER,
     fromY: 400
   });
-  sanitizeVec3(playerSpawn, DEFAULT_PLAYER);
+  sanitizeVec3(playerSpawn, PLAYER_SAFE_FALLBACK);
 
   // Landmarks & overlay
   const landmarks = await loadLandmarks({

--- a/src/npc/mainCharacter.js
+++ b/src/npc/mainCharacter.js
@@ -1,4 +1,5 @@
 import { createNpc } from './npcSystem.js';
+import { resolveCharacterScale } from '../config/movement.ts';
 
 function sanitizeVector(input) {
   if (!input) {
@@ -49,7 +50,7 @@ export function createMainCharacter(scene, options = {}) {
     modelUrl = 'models/character.glb',
     initialPosition = { x: 0, y: 0, z: 0 },
     headingRadians = 0,
-    scale = 1
+    scale = resolveCharacterScale()
   } = options;
 
   const start = sanitizeVector(initialPosition);

--- a/src/player/playerController.js
+++ b/src/player/playerController.js
@@ -2,7 +2,7 @@ import * as THREE from 'three';
 import { snapToGround } from '../physics/groundSnap.js';
 import { keepUpright } from '../physics/upright.js';
 import { Capsule, resolveCapsuleVsAABBs } from '../physics/collision.js';
-import { movementConfig, FLIGHT as FLIGHT_DEFAULTS } from '../config/movement.ts';
+import { movementConfig, FLIGHT as FLIGHT_DEFAULTS, resolveCharacterScale } from '../config/movement.ts';
 import { sanitizeVec3, DEFAULT_PLAYER } from '../utils/sanitize.ts';
 
 const moveDirection = new THREE.Vector3();
@@ -21,10 +21,22 @@ const verticalMoveDelta = new THREE.Vector3();
 
 const TURN_ACCEL = 12;
 
+const CHARACTER_SCALE = resolveCharacterScale();
+const DEFAULT_SAFE_POSITION = {
+  x: DEFAULT_PLAYER.x,
+  y: DEFAULT_PLAYER.y * CHARACTER_SCALE,
+  z: DEFAULT_PLAYER.z
+};
+
+const configuredSafe = movementConfig?.safePosition ?? {};
 const SAFE_POSITION = {
-  x: Number.isFinite(movementConfig?.safePosition?.x) ? movementConfig.safePosition.x : DEFAULT_PLAYER.x,
-  y: Number.isFinite(movementConfig?.safePosition?.y) ? movementConfig.safePosition.y : DEFAULT_PLAYER.y,
-  z: Number.isFinite(movementConfig?.safePosition?.z) ? movementConfig.safePosition.z : DEFAULT_PLAYER.z
+  x: Number.isFinite(configuredSafe?.x) ? configuredSafe.x : DEFAULT_SAFE_POSITION.x,
+  y: Number.isFinite(configuredSafe?.y)
+    ? configuredSafe.y === DEFAULT_PLAYER.y
+      ? DEFAULT_SAFE_POSITION.y
+      : configuredSafe.y
+    : DEFAULT_SAFE_POSITION.y,
+  z: Number.isFinite(configuredSafe?.z) ? configuredSafe.z : DEFAULT_SAFE_POSITION.z
 };
 const ZERO_VECTOR = { x: 0, y: 0, z: 0 };
 
@@ -116,7 +128,9 @@ export function createPlayerController(
   let groundMeshes = [];
   let colliderAabbs = Array.isArray(initialColliders) ? initialColliders : [];
 
-  const capsule = new Capsule(0.45, 1.6);
+  const capsuleRadius = 0.45 * CHARACTER_SCALE;
+  const capsuleHeight = 1.6 * CHARACTER_SCALE;
+  const capsule = new Capsule(capsuleRadius, capsuleHeight);
 
   let groundSnapSkip = typeof groundSnapSkipRef === 'object' ? groundSnapSkipRef : null;
 


### PR DESCRIPTION
## Summary
- add a documented character scale option to the movement configuration
- apply the configured scale to the main character mesh, player collider, and spawn hover defaults
- derive player-safe fallbacks from the configured scale to keep grounding sensible when resized

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_b_68db86fccb388327b794138240a1304d