### PR TITLE
chore: remove legacy boot references

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,4 +22,4 @@ Development builds now launch straight into the main experience at `/`. For trou
 
 ## Entry points
 
-The legacy bootstrap at `src/entry/boot.ts` has been removed. Use `src/entry/initializeAthens.js` as the runtime entry point for embedding Athens into other experiences.
+Use `src/entry/initializeAthens.js` as the runtime entry point for embedding Athens into other experiences.


### PR DESCRIPTION
## Summary
- update the entry point documentation to reference initializeAthens directly

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68db87ac30508327a0c5fb0c431efc15