### PR TITLE
Refactor entry bootstrapping into TypeScript app entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,4 +22,4 @@ Development builds now launch straight into the main experience at `/`. For trou
 
 ## Entry points
 
-Use `src/entry/initializeAthens.js` as the runtime entry point for embedding Athens into other experiences.
+Use `src/entry/app.ts` as the runtime entry point for embedding Athens into other experiences.

--- a/docs/audit/file-sizes.csv
+++ b/docs/audit/file-sizes.csv
@@ -11599,8 +11599,9 @@
 ./src/engine/loop.js,3893
 ./src/engine/safeEntry.js,2597
 ./src/entry/block-remote-guard.js,816
-./src/entry/initializeAthens.js,54322
-./src/entry/landing.js,6835
+./src/entry/app.ts,749
+./src/runtime/initializeAthens.ts,53949
+./src/runtime/runApp.ts,6419
 ./src/geo/__tests__/featureOffsets.test.js,1221
 ./src/geo/__tests__/projection.test.js,1902
 ./src/geo/featureOffsets.js,2043

--- a/docs/audit/repository-audit.md
+++ b/docs/audit/repository-audit.md
@@ -37,11 +37,11 @@
 - Two separate sky managers coexist (`src/scene/sky.js` vs `src/scene/sky.ts`) in addition to `src/sky/SkyManager.ts`, each duplicating loader/color-space logic.【F:src/scene/sky.js†L1-L120】【F:src/scene/sky.ts†L1-L200】【F:src/sky/SkyManager.ts†L1-L156】
 
 ### Debug / console noise
-- Production entrypoints log heavily (`console.info`, `console.warn`, `console.error`) within `src/main.js`, `src/entry/landing.js`, `src/entry/initializeAthens.js`, and `src/roads/hybridroads.js` debug helpers.【F:src/main.js†L224-L299】【F:src/entry/landing.js†L139-L209】【F:src/entry/initializeAthens.js†L139-L157】【F:src/roads/hybridroads.js†L95-L126】
+- Production entrypoints log heavily (`console.info`, `console.warn`, `console.error`) within `src/main.js`, `src/entry/app.ts`, `src/runtime/initializeAthens.ts`, and `src/roads/hybridroads.js` debug helpers.【F:src/main.js†L224-L299】【F:src/entry/app.ts†L13-L24】【F:src/runtime/initializeAthens.ts†L139-L759】【F:src/roads/hybridroads.js†L95-L126】
 
 ### Incomplete refactors & TODO hotspots
 - Footstep audio renaming was never reflected in code, leaving default clip names wrong.【F:src/audio/footsteps.js†L24-L56】【F:public/assets/audio/README.md†L12-L13】
-- `AmbientAPI` exposes track IDs that no longer exist, so mode-to-track mapping silently fails.【F:src/audio/ambient.ts†L11-L19】【F:src/entry/initializeAthens.js†L611-L647】
+- `AmbientAPI` exposes track IDs that no longer exist, so mode-to-track mapping silently fails.【F:src/audio/ambient.ts†L11-L19】【F:src/runtime/initializeAthens.ts†L601-L655】
 
 ### Unused dependencies
 - `depcheck` reports `cannon`, `tone`, `rimraf`, and `puppeteer` unused; no references exist in `src/` to those packages.【fd27ba†L1-L6】【F:package.json†L19-L29】
@@ -77,13 +77,13 @@
 - Replace ad-hoc BASE URL logic with a single helper (e.g., keep `asset-paths` and migrate consumers) to simplify GitHub Pages compatibility.【F:src/utils/assetUrl.js†L1-L34】【F:src/utils/asset-paths.js†L68-L107】
 - Normalize audio asset handling: rename files to match `footstep_*` expectations, supply the missing ambience tracks, or degrade gracefully by pruning IDs from `AMBIENT_TRACKS`.【F:src/audio/ambient.ts†L11-L19】【F:src/audio/footsteps.js†L24-L55】
 - Consolidate sky selection into one module (likely `SkyManager.ts`) and migrate all callers, removing `scene/sky.js` and `scene/sky.ts` duplication.【F:src/scene/sky.js†L1-L198】【F:src/scene/sky.ts†L1-L200】【F:src/sky/SkyManager.ts†L1-L156】
-- Strip or gate debug `console.*` calls behind environment checks to keep production logs clean.【F:src/main.js†L224-L299】【F:src/entry/landing.js†L139-L209】
+- Strip or gate debug `console.*` calls behind environment checks to keep production logs clean.【F:src/main.js†L224-L299】【F:src/entry/app.ts†L13-L24】
 
 ## Cleanup plan
 1. **Asset consolidation** – Decide on authoritative asset directories (e.g., keep `models/` as source, ignore generated output) and remove redundant trees from git. Update `.gitignore` to cover entire generated folders.【F:scripts/generate-static-assets.js†L12-L23】【F:.gitignore†L4-L23】
 2. **Audio alignment** – Rename or replace MP3 files to match code expectations, remove unused clips, and update README to reflect the tracked/ignored policy.【F:src/audio/ambient.ts†L11-L19】【F:src/audio/footsteps.js†L24-L55】【F:public/assets/audio/README.md†L7-L16】
 3. **Code pruning** – Delete obsolete modules (`ambience.js`, disabled ground files, duplicate sky modules) after verifying no imports remain, then update references to the canonical implementations.【F:src/audio/ambience.js†L1-L95】【F:src/scene/index1.js†L1-L28】【F:src/scene/sky.ts†L1-L200】
 4. **Memory management** – Add explicit `dispose()` routines for tree libraries and sky environments to prevent GPU leaks during hot reloads or scene swaps.【F:src/vegetation/trees.js†L327-L610】【F:src/sky/SkyManager.ts†L109-L156】
-5. **Logging hygiene** – Guard console usage with environment flags or remove verbose info/debug logs in production entry points.【F:src/main.js†L224-L299】【F:src/entry/initializeAthens.js†L139-L157】
+5. **Logging hygiene** – Guard console usage with environment flags or remove verbose info/debug logs in production entry points.【F:src/main.js†L224-L299】【F:src/runtime/initializeAthens.ts†L139-L759】
 6. **GitHub Pages prep** – Ensure all asset URL helpers use the same base resolution logic and audit `public/` so only necessary, non-generated assets ship to Pages.【F:vite.config.js†L1-L28】【F:src/utils/asset-paths.js†L68-L107】
 

--- a/index.html
+++ b/index.html
@@ -69,6 +69,6 @@
     </script>
 
     <!-- Vite will rewrite this to /Athens/assets/*.js in production -->
-    <script type="module" src="./src/entry/landing.js"></script>
+    <script type="module" src="./src/entry/app.ts"></script>
   </body>
 </html>

--- a/src/entry/app.ts
+++ b/src/entry/app.ts
@@ -1,0 +1,25 @@
+import './block-remote-guard.js';
+import runApp, { getAthensContext, getInitializationState, type AthensContext } from '../runtime/runApp.ts';
+
+export type { AthensContext };
+export { getAthensContext, getInitializationState, runApp };
+export default runApp;
+
+const globalWindow = window as Window & {
+  runAthens?: typeof runApp;
+  getAthensContext?: () => ReturnType<typeof getAthensContext>;
+};
+
+globalWindow.runAthens = runApp;
+globalWindow.getAthensContext = getAthensContext;
+
+window.dispatchEvent(
+  new CustomEvent('athens:initializer-ready', {
+    detail: { initializer: runApp, source: 'app.ts' }
+  })
+);
+console.log('[Athens] initializer ready');
+
+runApp().catch((error) => {
+  console.error('[Athens] Failed to initialize.', error);
+});

--- a/src/runtime/initializeAthens.ts
+++ b/src/runtime/initializeAthens.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import * as THREE from 'three';
 import { installRenderGuard } from '../safety/hardenPositions';
 if (typeof window !== 'undefined') window.THREE = THREE; // for console/puppeteer debug only

--- a/src/runtime/runApp.ts
+++ b/src/runtime/runApp.ts
@@ -1,15 +1,13 @@
-import './block-remote-guard.js';
+// @ts-nocheck
 import * as THREE from 'three';
-import initializeAthens from './initializeAthens.js';
+import initializeAthens from './initializeAthens.ts';
 import boot, { whenBootReady } from '../core/bootstrap.js';
 import { startGameLoop, setLoopWatchdog } from '../engine/loop.js';
 import { createSafeScene } from '../engine/safeEntry.js';
 import { attachWatchdog } from '../ui/watchdog.js';
 import { maybeRemoteInit } from '../services/remote.js';
 
-/**
- * @typedef {ReturnType<typeof initializeAthens> extends Promise<infer T> ? T : never} AthensContext
- */
+export type AthensContext = Awaited<ReturnType<typeof initializeAthens>>;
 
 let initializationTask = null;
 let initializedContext = null;
@@ -225,10 +223,9 @@ async function runAthens(options = {}) {
   }
 }
 
-const globalWindow = /** @type {Window & { runAthens?: typeof runAthens; getAthensContext?: () => Promise<AthensContext | undefined>; }} */ (window);
+export const getInitializationState = () => ({ initializationTask, initializedContext });
 
-globalWindow.runAthens = runAthens;
-globalWindow.getAthensContext = async () => {
+export async function getAthensContext() {
   if (initializedContext) {
     return initializedContext;
   }
@@ -240,17 +237,6 @@ globalWindow.getAthensContext = async () => {
     }
   }
   return undefined;
-};
-
-window.dispatchEvent(
-  new CustomEvent('athens:initializer-ready', {
-    detail: { initializer: runAthens, source: 'landing.js' }
-  })
-);
-console.log('[Athens] initializer ready');
-
-try {
-  await runAthens();
-} catch (error) {
-  console.error('[Athens] Failed to initialize.', error);
 }
+
+export default runAthens;


### PR DESCRIPTION
## Summary
- add a TypeScript entry point at src/entry/app.ts that wires runApp into the window and dispatch lifecycle events
- migrate the initializeAthens and landing boot logic into src/runtime modules and update documentation/index references
- refresh audit metadata for the relocated files and remove the deprecated JavaScript entry files

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68dbb84f04388327944258a84a3658d7