### PR TITLE
refactor: route logging through shared utility

### DIFF
--- a/src/audio/AudioManager.js
+++ b/src/audio/AudioManager.js
@@ -1,4 +1,5 @@
 import * as THREE from 'three';
+import { logger } from '../utils/logger.ts';
 
 export function assetUrl(rel) {
   const base = (typeof import.meta !== 'undefined' && import.meta.env && typeof import.meta.env.BASE_URL === 'string')
@@ -72,7 +73,7 @@ export class AudioManager {
         () => {
           this._loading.delete(key);
           if (!this._missing.has(relativePath)) {
-            console.warn(`[audio] missing ${relativePath}, skipping`);
+            logger.warn(`[audio] missing ${relativePath}, skipping`);
             this._missing.add(relativePath);
           }
           resolve(null);

--- a/src/audio/ambient-zones.js
+++ b/src/audio/ambient-zones.js
@@ -1,4 +1,5 @@
 import * as THREE from 'three';
+import { logger } from '../utils/logger.ts';
 
 function clamp(value, min, max) {
   return Math.min(max, Math.max(min, value));
@@ -326,7 +327,7 @@ export class AmbientZoneManager {
 
     zone.loading = loadBuffer()
       .catch((error) => {
-        console.warn(`[ambient-zones] Unable to create buffer for ${zone.id}`, error);
+        logger.warn(`[ambient-zones] Unable to create buffer for ${zone.id}`, error);
         if (zone.audio) {
           zone.audio.removeFromParent();
         }

--- a/src/audio/ambient.ts
+++ b/src/audio/ambient.ts
@@ -1,5 +1,6 @@
 import * as THREE from 'three';
 import { assetUrl } from '../utils/assetUrl.js';
+import { logger } from '../utils/logger';
 
 export type AmbEntry = {
   id: string;
@@ -74,7 +75,7 @@ function nowMs() {
 
 export async function playAmbient(id: string, fadeSeconds = 1.0) {
   if (!AMBIENT_TRACKS.length) {
-    console.warn('[ambient] No tracks configured');
+    logger.warn('[ambient] No tracks configured');
     return;
   }
 
@@ -86,7 +87,7 @@ export async function playAmbient(id: string, fadeSeconds = 1.0) {
   try {
     buffer = await loadBuffer(srcUrl);
   } catch (error) {
-    console.warn(`[ambient] Failed to load ${srcUrl}`, error);
+    logger.warn(`[ambient] Failed to load ${srcUrl}`, error);
     return;
   }
 
@@ -97,7 +98,7 @@ export async function playAmbient(id: string, fadeSeconds = 1.0) {
   try {
     next.play();
   } catch (error) {
-    console.warn('[ambient] Unable to start playback', error);
+    logger.warn('[ambient] Unable to start playback', error);
   }
 
   const targetVol = typeof entry.volume === 'number' ? THREE.MathUtils.clamp(entry.volume, 0, 1) : 0.3;
@@ -130,7 +131,7 @@ export async function playAmbient(id: string, fadeSeconds = 1.0) {
     try {
       prev.stop();
     } catch (error) {
-      console.warn('[ambient] Failed to stop previous track', error);
+      logger.warn('[ambient] Failed to stop previous track', error);
     }
   }
   R.fading = true;
@@ -153,7 +154,7 @@ export async function playAmbient(id: string, fadeSeconds = 1.0) {
       try {
         prev.stop();
       } catch (error) {
-        console.warn('[ambient] Failed to stop old track', error);
+        logger.warn('[ambient] Failed to stop old track', error);
       }
       R.fading = false;
     }

--- a/src/building-kit.js
+++ b/src/building-kit.js
@@ -1,6 +1,7 @@
 import * as THREE from 'three';
 import { getAssetBase, resolveAssetUrl } from './utils/asset-paths.js';
 import { loadTextureWithFallback } from './utils/fail-soft-loaders.js';
+import { logger } from './utils/logger.ts';
 
 /** Lightweight materials (one-time) */
 const MAT = {
@@ -64,7 +65,7 @@ const isDevBuild =
   import.meta.env.DEV;
 
 if (isDevBuild) {
-  console.log('[Athens][assets]', {
+  logger.info('[Athens][assets]', {
     base: getAssetBase(),
     cityWallTexture: wallURL
   });
@@ -105,7 +106,7 @@ loadTextureWithFallback(wallURL, {
   },
   onFallback: (error) => {
     if (error) {
-      console.warn('Wall texture failed to load, using fallback material:', error);
+      logger.warn('Wall texture failed to load, using fallback material:', error);
     }
     applyWallTextureFallback();
   }

--- a/src/buildings-from-geojson.js
+++ b/src/buildings-from-geojson.js
@@ -8,6 +8,7 @@ import { getDistrictAt, getDistricts } from './scene/districts.js';
 import { defaultPlacementOptions } from './scene/placement-options.js';
 import { estimateAABB, GridIndex } from './scene/placement-grid.js';
 import { applyCompressionToVector3 } from './world/scale.js';
+import { logger } from './utils/logger.ts';
 
 const deg = (d)=> THREE.MathUtils.degToRad(d);
 
@@ -838,11 +839,11 @@ export async function buildFromGeoJSON({ scene, geoJsonUrl, projector, placement
     const skippedInfo = report.skippedOverlap ?? 0;
     const alignedInfo = report.pathAligned ?? 0;
     const exceededCount = report.exceededAdjustRadius?.length ?? 0;
-    console.info(
+    logger.info(
       `[placement] placed ${report.placed}/${report.total}; moved ${movedInfo}; skipped ${skippedInfo}; aligned ${alignedInfo}; exceeded radius ${exceededCount}.`
     );
     if (exceededCount > 0) {
-      console.info('[placement] adjustment radius exceeded for:', report.exceededAdjustRadius.join(', '));
+      logger.info('[placement] adjustment radius exceeded for:', report.exceededAdjustRadius.join(', '));
     }
   }
 

--- a/src/buildings/ground.js
+++ b/src/buildings/ground.js
@@ -1,5 +1,6 @@
 import * as THREE from 'three';
 import { loadGrassMaterial } from '../materials/groundGrass.js';
+import { logger } from '../utils/logger.ts';
 
 function cloneMaterial(source, fallbackColor = 0xffffff) {
   if (source && typeof source.clone === 'function') {
@@ -255,7 +256,7 @@ export async function createGround(sceneOrMaterials = {}, materialsOrOptions = {
       }
       return groundPlane.material;
     } catch (error) {
-      console.warn('[Ground] Failed to apply grass material.', error);
+      logger.warn('[Ground] Failed to apply grass material.', error);
       return groundPlane.material;
     }
   };
@@ -263,7 +264,7 @@ export async function createGround(sceneOrMaterials = {}, materialsOrOptions = {
 
   if (options.renderer) {
     groundPlane.userData.applyGrassMaterial(options.renderer, { repeat }).catch((error) => {
-      console.warn('[Ground] Grass material application deferred.', error);
+      logger.warn('[Ground] Grass material application deferred.', error);
     });
   }
 

--- a/src/core/bootstrap.js
+++ b/src/core/bootstrap.js
@@ -1,4 +1,5 @@
 import { main } from '../main.js';
+import { logger } from '../utils/logger.ts';
 
 let bootReadyResolve;
 let bootReadyReject;
@@ -71,14 +72,14 @@ export default async function boot(opts = {}) {
     options.preset = 'High Noon';
   }
 
-  console.info('[Athens][Bootstrap] Booting', {
+  logger.info('[Athens][Bootstrap] Booting', {
     entrypoint: describeBootstrapEntrypoint(main),
     options
   });
 
   try {
     await main(options);
-    console.info('[Athens][Bootstrap] Boot complete', {
+    logger.info('[Athens][Bootstrap] Boot complete', {
       elapsedMs: Date.now() - startedAt
     });
     bootReadyResolve?.(true);

--- a/src/core/nameResolver.js
+++ b/src/core/nameResolver.js
@@ -1,3 +1,5 @@
+import { logger } from '../utils/logger.ts';
+
 const KNOWN_NAMES = [
   'High Noon',
   'Golden Dawn',
@@ -38,7 +40,7 @@ export function resolveName(input) {
   }
 
   if (!warnedUnknownName) {
-    console.warn('[Athens] Unknown preset name provided:', input, '→ using', defaultName);
+    logger.warn('[Athens] Unknown preset name provided:', input, '→ using', defaultName);
     warnedUnknownName = true;
   }
 

--- a/src/core/presetResolver.js
+++ b/src/core/presetResolver.js
@@ -1,3 +1,5 @@
+import { logger } from '../utils/logger.ts';
+
 const KNOWN_PRESETS = ['High Noon', 'Golden Dawn', 'Golden Dusk', 'Blue Hour', 'Night Sky'];
 
 const CANONICAL_PRESETS = new Map([
@@ -32,7 +34,7 @@ export function resolvePreset(name) {
   }
 
   if (!warnedUnknownPreset) {
-    console.warn('[Athens] Unknown preset name:', name, '→ defaulting');
+    logger.warn('[Athens] Unknown preset name:', name, '→ defaulting');
     warnedUnknownPreset = true;
   }
 

--- a/src/dev/skyDebugHooks.js
+++ b/src/dev/skyDebugHooks.js
@@ -1,3 +1,5 @@
+import { logger } from '../utils/logger.ts';
+
 // SKYSYS_START
 export function installSkyDev({ scene, renderer, camera }) {
   if (typeof window === 'undefined') return;
@@ -5,7 +7,7 @@ export function installSkyDev({ scene, renderer, camera }) {
   window.dev.sky = window.dev.sky || {};
 
   window.dev.sky.status = () => {
-    console.info('[sky] status', {
+    logger.info('[sky] status', {
       hasBackground: !!scene.background,
       hasEnvironment: !!scene.environment,
       clearAlpha: renderer.getClearAlpha?.(),

--- a/src/engine/safeEntry.js
+++ b/src/engine/safeEntry.js
@@ -1,5 +1,6 @@
 import * as THREE from 'three';
 import { applySky } from '../scene/sky.ts';
+import { logger } from '../utils/logger.ts';
 
 export async function createSafeScene(canvasSelector = 'canvas') {
   const canvas = typeof document !== 'undefined' ? document.querySelector(canvasSelector) : null;
@@ -22,7 +23,7 @@ export async function createSafeScene(canvasSelector = 'canvas') {
   try {
     await applySky(scene, renderer, 'day');
   } catch (error) {
-    console.warn('[safeEntry] applySky failed.', error);
+    logger.warn('[safeEntry] applySky failed.', error);
     renderer.setClearColor(0x202834, 1);
   }
 

--- a/src/entry/block-remote-guard.js
+++ b/src/entry/block-remote-guard.js
@@ -1,4 +1,5 @@
 import { USE_REMOTE } from '../config/flags';
+import { logger } from '../utils/logger.ts';
 
 if (typeof window !== 'undefined' && !USE_REMOTE) {
   (function () {
@@ -14,7 +15,7 @@ if (typeof window !== 'undefined' && !USE_REMOTE) {
     window.fetch = async function (input, init) {
       const url = String(input instanceof Request ? input.url : input);
       if (blocked.some((p) => url.includes(p))) {
-        console.warn('[remote blocked]', url);
+        logger.warn('[remote blocked]', url);
         return new Response(JSON.stringify({ ok: false, blocked: true }), {
           status: 499,
           headers: { 'Content-Type': 'application/json' }

--- a/src/entry/initializeAthens.js
+++ b/src/entry/initializeAthens.js
@@ -2,6 +2,7 @@ import * as THREE from 'three';
 import { installRenderGuard } from '../safety/hardenPositions';
 if (typeof window !== 'undefined') window.THREE = THREE; // for console/puppeteer debug only
 import { createStats } from '../debug/statsShim.js';
+import { logger } from '../utils/logger.ts';
 import { setupGround, updateTrees } from '../main.js';
 import { loadLandmarks } from '../landmarks-loader.js';
 import { createLandmarkOverlay } from '../map/landmarks.js';
@@ -134,7 +135,7 @@ function _applyLandmarkSpread(scene, options, {force=false} = {}) {
     results[key] = ok ? 'moved' : 'failed';
   }
 
-  try { console.info('[LandmarkSpread]', results); } catch {}
+  try { logger.info('[LandmarkSpread]', results); } catch {}
 }
 
 function _installLandmarkDev(scene, options) {
@@ -150,7 +151,7 @@ function _installLandmarkDev(scene, options) {
     token = String(token).toLowerCase();
     const hits = [];
     scene.traverse(o => { if (o?.name && o.name.toLowerCase().includes(token)) hits.push(o.name); });
-    console.log('[find]', token, hits);
+    logger.info('[find]', token, hits);
     return hits;
   };
 }
@@ -548,7 +549,7 @@ export async function initializeAthens(options = {}) {
     await environmentManager.applySky('day');
     environmentManager.setMode('procedural');
   } catch (error) {
-    console.warn('[Athens] applySky failed during initializeAthens.', error);
+    logger.warn('[Athens] applySky failed during initializeAthens.', error);
     renderer.setClearColor(DEFAULT_BACKGROUND_HEX, 1);
   }
 
@@ -681,9 +682,9 @@ export async function initializeAthens(options = {}) {
     const agora = get('AgoraGroup') || get('Agora');
     if (agora) {
       setWorldPosition(agora, p.x, p.y, p.z);
-      console.info('[LandmarkOverride] Agora ->', p);
+      logger.info('[LandmarkOverride] Agora ->', p);
     } else {
-      console.warn('[LandmarkOverride] Agora object not found');
+      logger.warn('[LandmarkOverride] Agora object not found');
     }
   })(scene, options);
   // LANDMARK_OVERRIDE_END
@@ -701,7 +702,7 @@ export async function initializeAthens(options = {}) {
         }
       }
     } catch (error) {
-      console.warn('[Athens] Unable to apply grass material to main ground plane.', error);
+      logger.warn('[Athens] Unable to apply grass material to main ground plane.', error);
     }
   }
 
@@ -724,7 +725,7 @@ export async function initializeAthens(options = {}) {
       const opts = { layoutConfig: { positions } };
       _applyLandmarkOverrides(scene, opts);
     };
-    console.info('[LandmarkOverride] dev.landmarks.applyPositions({ Agora:{x,y,z} }) is available');
+    logger.info('[LandmarkOverride] dev.landmarks.applyPositions({ Agora:{x,y,z} }) is available');
   }
   // LANDMARK_OVERRIDE_END
 
@@ -732,7 +733,7 @@ export async function initializeAthens(options = {}) {
   markGround(scene);
   const groundMeshes = collectGround(scene);
   if (!groundMeshes.length) {
-    console.warn('[npc] no ground meshes');
+    logger.warn('[npc] no ground meshes');
   }
   // PLACER_START
   const landmarkSequence = [
@@ -783,12 +784,12 @@ export async function initializeAthens(options = {}) {
       devApi.lastExport = exportString;
       devApi.lastPayload = payload;
       // eslint-disable-next-line no-console
-      console.log('[Athens][Landmarks] Exported landmark positions:', exportString);
+      logger.info('[Athens][Landmarks] Exported landmark positions:', exportString);
       if (typeof devApi.onSave === 'function') {
         try {
           devApi.onSave(payload);
         } catch (error) {
-          console.warn('[Athens][Landmarks] onSave handler error.', error);
+          logger.warn('[Athens][Landmarks] onSave handler error.', error);
         }
       }
     };
@@ -852,7 +853,7 @@ export async function initializeAthens(options = {}) {
     devApi.lastPayload = devApi.lastPayload ?? null;
     if (typeof devApi.saveToFile !== 'function') {
       devApi.saveToFile = () => {
-        console.info('[Athens][Landmarks] saveToFile hook not implemented.');
+        logger.info('[Athens][Landmarks] saveToFile hook not implemented.');
       };
     }
 
@@ -983,7 +984,7 @@ export async function initializeAthens(options = {}) {
         navPathfinder = createNavMeshPathfinder(navMesh);
       }
     } catch (error) {
-      console.warn('[Athens][NavMesh] Failed to build navmesh.', error);
+      logger.warn('[Athens][NavMesh] Failed to build navmesh.', error);
       navMesh = null;
       navPathfinder = null;
     }
@@ -1290,7 +1291,7 @@ export async function initializeAthens(options = {}) {
       try {
         updateTrees?.(delta);
       } catch (error) {
-        console.warn('[Athens] Tree animation update failed.', error);
+        logger.warn('[Athens] Tree animation update failed.', error);
       }
 
       if (playerObject?.position && !isFiniteVec3(playerObject.position)) {
@@ -1359,7 +1360,7 @@ export async function initializeAthens(options = {}) {
       sanitizeVec3(lookTarget, SAFE_PLAYER_FALLBACK);
       camera.lookAt(lookTarget);
     } catch (error) {
-      console.warn('[Athens] Frame update failed.', error);
+      logger.warn('[Athens] Frame update failed.', error);
     }
   };
 
@@ -1502,7 +1503,7 @@ function _applyLandmarkOverrides(scene, options){
   const pos = options?.layoutConfig?.positions;
   if (!pos) return;
 
-  const log = (...args)=>{ try{ console.info('[LandmarkOverride]', ...args); }catch{} }
+  const log = (...args)=>{ try{ logger.info('[LandmarkOverride]', ...args); }catch{} }
 
   // AGORA override only (expand later)
   if (pos.Agora && Number.isFinite(pos.Agora.x) && Number.isFinite(pos.Agora.y) && Number.isFinite(pos.Agora.z)) {

--- a/src/entry/landing.js
+++ b/src/entry/landing.js
@@ -6,6 +6,7 @@ import { startGameLoop, setLoopWatchdog } from '../engine/loop.js';
 import { createSafeScene } from '../engine/safeEntry.js';
 import { attachWatchdog } from '../ui/watchdog.js';
 import { maybeRemoteInit } from '../services/remote.js';
+import { logger } from '../utils/logger.ts';
 
 /**
  * @typedef {ReturnType<typeof initializeAthens> extends Promise<infer T> ? T : never} AthensContext
@@ -49,7 +50,7 @@ const ensureFallback = () => {
     try {
       fallbackScene = await createSafeScene();
     } catch (error) {
-      console.warn('[Athens] Failed to initialize fallback scene.', error);
+      logger.warn('[Athens] Failed to initialize fallback scene.', error);
       fallbackActive = false;
       if (fallbackRoot?.parentNode) {
         fallbackRoot.parentNode.removeChild(fallbackRoot);
@@ -76,7 +77,7 @@ const ensureFallback = () => {
     });
   })()
     .catch((error) => {
-      console.warn('[Athens] Fallback initialization failed.', error);
+      logger.warn('[Athens] Fallback initialization failed.', error);
     })
     .finally(() => {
       fallbackInitTask = null;
@@ -139,7 +140,7 @@ function ensureBootStarted() {
   if (!bootPromise) {
     started = true;
     if (!bootLogEmitted) {
-      console.log('[Athens] boot starting');
+      logger.info('[Athens] boot starting');
       bootLogEmitted = true;
     }
     bootPromise = Promise.resolve()
@@ -205,7 +206,7 @@ async function runAthens(options = {}) {
       try {
         context.scene.background = new THREE.Color(0x202834);
       } catch (error) {
-        console.warn('[Athens] Unable to set scene background color.', error);
+        logger.warn('[Athens] Unable to set scene background color.', error);
       }
     }
 
@@ -247,7 +248,7 @@ window.dispatchEvent(
     detail: { initializer: runAthens, source: 'landing.js' }
   })
 );
-console.log('[Athens] initializer ready');
+logger.info('[Athens] initializer ready');
 
 try {
   await runAthens();

--- a/src/landmarks-loader.js
+++ b/src/landmarks-loader.js
@@ -3,6 +3,7 @@ import { applyFeatureOffset } from './geo/featureOffsets.js';
 import { createFeatureLines } from './scene/feature-lines.js';
 import { applyCompressionToVector3 } from './world/scale.js';
 import { resolveAssetUrl } from './utils/asset-paths.js';
+import { logger } from './utils/logger.ts';
 import { snapObjectToGround } from './physics/groundProject.js';
 
 /**
@@ -172,7 +173,7 @@ export async function loadLandmarks({
       try {
         featureLines.root.userData.onDisposeFeatureLines();
       } catch (error) {
-        console.warn('[landmarks] Failed to dispose feature line listeners.', error);
+        logger.warn('[landmarks] Failed to dispose feature line listeners.', error);
       }
     }
     if (featureLines?.root) {

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,7 @@
 import { loadGround } from './scene/ground.js';
 import { loadTreeLibrary, scatterTrees, updateTrees as updateTreeAnimations } from './vegetation/trees.js';
 import { getAssetBase } from './utils/asset-paths.js';
+import { logger } from './utils/logger.ts';
 
 const ATHENS_MAIN_SENTINEL = Symbol.for('athens.main.entrypoint');
 const isAthensMainEntrypoint = (fn) => typeof fn === 'function' && fn[ATHENS_MAIN_SENTINEL];
@@ -69,7 +70,7 @@ async function ensureTrees(scene, renderer) {
       scene.add(groveGroup);
     }
   } catch (error) {
-    console.warn('[trees] Unable to initialize tree library.', error);
+    logger.warn('[trees] Unable to initialize tree library.', error);
   }
 
   treesInitialized = true;
@@ -168,7 +169,7 @@ async function waitForAthensInitializer({ timeoutMs, pollIntervalMs = 50, warnAf
 
       if (!hasWarned && normalizedWarnAfter !== null && Date.now() - start >= normalizedWarnAfter) {
         hasWarned = true;
-        console.warn('[Athens] Waiting for initializer to become available…');
+        logger.warn('[Athens] Waiting for initializer to become available…');
       }
 
       if (hasTimeout && Date.now() - start >= normalizedTimeout) {
@@ -221,11 +222,11 @@ export async function main(opts = {}) {
       ? opts
       : {};
 
-  console.info('[Athens][Main] Resolving entry point');
+  logger.info('[Athens][Main] Resolving entry point');
   reportDevLog('Resolving entry point…');
 
   const assetBase = getAssetBase();
-  console.info(`[Athens][Main] Assets base: ${assetBase}`);
+  logger.info(`[Athens][Main] Assets base: ${assetBase}`);
 
   const initializerResult = await waitForAthensInitializer({
     timeoutMs: typeof waitForInitializerMs === 'number' ? waitForInitializerMs : undefined,
@@ -263,7 +264,7 @@ export async function main(opts = {}) {
     }
   }
 
-  console.info('[Athens][Main] Invoking initializer…', {
+  logger.info('[Athens][Main] Invoking initializer…', {
     initializer: describeInitializer(initializer),
     source: initializerSource
   });
@@ -291,11 +292,11 @@ if (typeof window !== 'undefined') {
   try {
     if (typeof window.initializeAthens !== 'function') {
       window.initializeAthens = main;
-      console.info('[Athens][Main] Exposed module main() as window.initializeAthens');
+      logger.info('[Athens][Main] Exposed module main() as window.initializeAthens');
     } else {
-      console.info('[Athens][Main] Detected existing window.initializeAthens');
+      logger.info('[Athens][Main] Detected existing window.initializeAthens');
     }
   } catch (error) {
-    console.warn('[Athens][Main] Unable to coordinate window.initializeAthens', error);
+    logger.warn('[Athens][Main] Unable to coordinate window.initializeAthens', error);
   }
 }

--- a/src/map/landmarks.js
+++ b/src/map/landmarks.js
@@ -2,6 +2,7 @@ import { loadGeoJson, DEFAULT_GEOJSON_PATH } from '../geo/geoLoader.js';
 import { LocalEquirectangularProjection } from '../geo/projection.js';
 import { applyFeatureOffset } from '../geo/featureOffsets.js';
 import { AgoraLayer } from './agoraLayer.js';
+import { logger } from '../utils/logger.ts';
 
 const LANDMARK_LABELS = {
     'Acropolis of Athens': 'Acropolis',
@@ -262,7 +263,7 @@ export class LandmarkOverlay {
             try {
                 await this.agoraLayer.load();
             } catch (error) {
-                console.warn('Failed to load Agora plan overlay data:', error);
+                logger.warn('Failed to load Agora plan overlay data:', error);
             }
         }
         this._fitView(this.options.fitPadding ?? CITY_PADDING_PX);

--- a/src/materials/groundGrass.js
+++ b/src/materials/groundGrass.js
@@ -1,5 +1,6 @@
 import * as THREE from 'three';
 import { assetUrl } from '../utils/assetUrl.js';
+import { logger } from '../utils/logger.ts';
 
 const FALLBACK_COLOR = 0x5a8f3a;
 const GRASS_URL = 'assets/textures/grass.jpg';
@@ -23,7 +24,7 @@ function computeAnisotropy(renderer) {
       return renderer.capabilities.getMaxAnisotropy() || 1;
     }
   } catch (error) {
-    console.warn('[groundGrass] Failed to determine renderer anisotropy.', error);
+    logger.warn('[groundGrass] Failed to determine renderer anisotropy.', error);
   }
   return 1;
 }
@@ -52,7 +53,7 @@ async function loadGrassTexture() {
       }
     );
   }).catch((error) => {
-    console.warn('[groundGrass] Failed to load grass texture.', error);
+    logger.warn('[groundGrass] Failed to load grass texture.', error);
     return null;
   });
   return cachedPromise;

--- a/src/npc/npcSystem.js
+++ b/src/npc/npcSystem.js
@@ -6,6 +6,7 @@ import { keepUpright } from '../physics/upright.js';
 import { loadGLTF } from '../loaders/safeGltf.js';
 import { logOnce } from '../utils/logOnce.js';
 import { ensureFeetAtLocalZero, placeOnGround } from '../utils/spawn.ts';
+import { logger } from '../utils/logger.ts';
 
 const SNAP_OPTIONS = { gravity: 12, maxStepUp: 0.6, maxDrop: 4, hover: 0.03, rayStart: 1000 };
 const GROUND_CLEARANCE = typeof SNAP_OPTIONS.hover === 'number' ? SNAP_OPTIONS.hover : 0.03;
@@ -652,7 +653,7 @@ function createNpcManager(scene, groundMeshes, options = {}) {
     if (dt === 0) return;
 
     if (!warnedGround && surfaces.length === 0) {
-      console.warn('[npc] no ground meshes');
+      logger.warn('[npc] no ground meshes');
       warnedGround = true;
     }
 
@@ -723,7 +724,7 @@ export function createNpcSystem(options = {}) {
 
   function spawnNpcAt(position, { patrol = null, ...config } = {}) {
     if (!manager) {
-      console.warn('[npc] Attempted to spawn NPC before initialization.');
+      logger.warn('[npc] Attempted to spawn NPC before initialization.');
       return null;
     }
 
@@ -781,7 +782,7 @@ export function createNpcSystem(options = {}) {
 
   function initializeNpcs(scene, navmesh) {
     if (!scene) {
-      console.warn('[npc] Cannot initialize NPCs without a scene.');
+      logger.warn('[npc] Cannot initialize NPCs without a scene.');
       return;
     }
 

--- a/src/player/playerController.js
+++ b/src/player/playerController.js
@@ -4,6 +4,7 @@ import { keepUpright } from '../physics/upright.js';
 import { Capsule, resolveCapsuleVsAABBs } from '../physics/collision.js';
 import { movementConfig, FLIGHT as FLIGHT_DEFAULTS } from '../config/movement.ts';
 import { sanitizeVec3, DEFAULT_PLAYER } from '../utils/sanitize.ts';
+import { logger } from '../utils/logger.ts';
 
 const moveDirection = new THREE.Vector3();
 
@@ -290,9 +291,7 @@ export function createPlayerController(
       } else {
         enterFlight();
       }
-      if (typeof console !== 'undefined' && typeof console.info === 'function') {
-        console.info(`[playerController] Fly ${isFlying ? 'ON' : 'OFF'}`);
-      }
+      logger.info(`[playerController] Fly ${isFlying ? 'ON' : 'OFF'}`);
     }
     prevToggleDown = toggleDown;
 
@@ -479,7 +478,7 @@ export function createPlayerController(
     if (debugControlsEnabled && dtSafe > 0 && debugLogTime <= 2) {
       debugLogTime += dtSafe;
       if (debugLogTime <= 2) {
-        console.log('[controls]', {
+        logger.info('[controls]', {
           x: axisX,
           z: axisZ,
           yaw

--- a/src/roads/hybridroads.js
+++ b/src/roads/hybridroads.js
@@ -6,6 +6,7 @@ import {
   loadGltfWithFallback,
   applyLoadedTexture
 } from '../utils/fail-soft-loaders.js';
+import { logger } from '../utils/logger.ts';
 
 // Load a texture and create a road mesh
 export function createRoadSegment(texturePath, start, end, width = 6) {
@@ -123,5 +124,5 @@ window.scatterTest = async function () {
   };
 
   await scatterPropsAlongRoad(window.scene, start, end, config);
-  console.log('Scatter test complete!');
+  logger.info('Scatter test complete!');
 };

--- a/src/scene/districts.js
+++ b/src/scene/districts.js
@@ -2,6 +2,7 @@ import * as THREE from 'three';
 import { Line2 } from 'three/examples/jsm/lines/Line2.js';
 import { LineMaterial } from 'three/examples/jsm/lines/LineMaterial.js';
 import { LineGeometry } from 'three/examples/jsm/lines/LineGeometry.js';
+import { logger } from '../utils/logger.ts';
 
 let districtsGroup = null;
 let districtFillGroup = null;
@@ -172,7 +173,7 @@ function notifyDistrictsChanged() {
     try {
       handler(snapshot);
     } catch (error) {
-      console.warn('[districts] change handler error', error);
+      logger.warn('[districts] change handler error', error);
     }
   });
 }
@@ -320,7 +321,7 @@ export function onDistrictsChanged(handler) {
     try {
       handler(currentDistricts.map((district) => ({ ...district })));
     } catch (error) {
-      console.warn('[districts] change handler error', error);
+      logger.warn('[districts] change handler error', error);
     }
   }
 

--- a/src/scene/sky.ts
+++ b/src/scene/sky.ts
@@ -1,4 +1,5 @@
 import * as THREE from 'three';
+import { logger } from '../utils/logger';
 
 export type SkyChoice =
   | {
@@ -142,7 +143,7 @@ export async function applySky(
     }) || SKY_CHOICES[0];
 
   if (!pick) {
-    console.warn('[sky] No sky choices found.');
+    logger.warn('[sky] No sky choices found.');
     return;
   }
 
@@ -204,13 +205,13 @@ export async function applySky(
         };
       }
     } else {
-      console.warn(
+      logger.warn(
         `[sky] Choice "${pick.id}" is missing required properties for type "${pick.type}".`
       );
       return;
     }
   } catch (error) {
-    console.warn('[sky] Failed to apply sky environment.', error);
+    logger.warn('[sky] Failed to apply sky environment.', error);
   } finally {
     // Dispose the previous background texture if it was replaced
     const backgroundDisposable = previousBackground as unknown as { dispose?: () => void };
@@ -222,7 +223,7 @@ export async function applySky(
       try {
         backgroundDisposable.dispose();
       } catch (e) {
-        console.warn('[sky] Failed to dispose previous background texture.', e);
+        logger.warn('[sky] Failed to dispose previous background texture.', e);
       }
     }
   }

--- a/src/services/remote.js
+++ b/src/services/remote.js
@@ -1,4 +1,5 @@
 import { USE_REMOTE } from '../config/flags.ts';
+import { logger } from '../utils/logger.ts';
 
 /**
  * Initialize optional remote integrations without blocking rendering.
@@ -12,6 +13,6 @@ export async function maybeRemoteInit(context) {
     void context;
     // Remote integrations are currently disabled. Add guarded logic here when needed.
   } catch (error) {
-    console.warn('[remote disabled]', error);
+    logger.warn('[remote disabled]', error);
   }
 }

--- a/src/sky/moon.js
+++ b/src/sky/moon.js
@@ -1,4 +1,5 @@
 import * as THREE from 'three';
+import { logger } from '../utils/logger.ts';
 
 const ORIGIN = new THREE.Vector3();
 
@@ -49,7 +50,7 @@ export function createMoon({
       material.map = texture;
       material.needsUpdate = true;
     }, undefined, (error) => {
-      console.warn('[moon] Failed to load moon texture.', error);
+      logger.warn('[moon] Failed to load moon texture.', error);
     });
   }
 

--- a/src/sky/photoSkydome.js
+++ b/src/sky/photoSkydome.js
@@ -1,6 +1,7 @@
 // src/sky/photoSkydome.js
 import * as THREE from 'three';
 import { loadTextureAsyncWithFallback } from '../utils/fail-soft-loaders.js';
+import { logger } from '../utils/logger.ts';
 
 const sharedTextureLoader = new THREE.TextureLoader();
 const textureCache = new Map();
@@ -80,7 +81,7 @@ async function loadTextureSequence(sources, loader, options = {}) {
 
       if (texture?.userData?.isFallbackTexture) {
         fallbackResult = fallbackResult ?? { texture, source };
-        console.warn(
+        logger.warn(
           `PhotoSkydome: ${label} unavailable at ${source.url}; using fallback placeholder.`
         );
         continue;
@@ -89,7 +90,7 @@ async function loadTextureSequence(sources, loader, options = {}) {
       return { texture, source };
     } catch (error) {
       lastError = error;
-      console.warn(`PhotoSkydome: failed to load ${label} from ${source.url}`, error);
+      logger.warn(`PhotoSkydome: failed to load ${label} from ${source.url}`, error);
     }
   }
 

--- a/src/sky/presets.js
+++ b/src/sky/presets.js
@@ -1,4 +1,5 @@
 import { resolvePreset as resolvePresetSafe, getDefaultPreset as getDefaultPresetSafe } from '../core/presetResolver.js';
+import { logger } from '../utils/logger.ts';
 
 export const KNOWN_PRESETS = [
   'Golden Dawn',
@@ -41,7 +42,7 @@ export function resolvePreset(inputName) {
   }
   const fallback = getDefaultPresetSafe();
   if (inputName && !warnedUnknownPreset) {
-    console.warn('[Athens] Unknown sky preset:', inputName, '→ using', fallback);
+    logger.warn('[Athens] Unknown sky preset:', inputName, '→ using', fallback);
     warnedUnknownPreset = true;
   }
   return fallback;

--- a/src/ui/originalUi.js
+++ b/src/ui/originalUi.js
@@ -1,3 +1,5 @@
+import { logger } from '../utils/logger.ts';
+
 const ENVIRONMENT_LABELS = {
   high_noon: 'High Noon',
   day: 'High Noon',
@@ -447,7 +449,7 @@ export function createOriginalUi({
         try {
           fn();
         } catch (error) {
-          console.warn('[Athens][UI] Failed to run cleanup handler.', error);
+          logger.warn('[Athens][UI] Failed to run cleanup handler.', error);
         }
       });
       cleanupFns.length = 0;

--- a/src/utils/asset-paths.js
+++ b/src/utils/asset-paths.js
@@ -1,4 +1,5 @@
 import { assetUrl } from './assetUrl.js';
+import { logger } from './logger.ts';
 
 function ensureTrailingSlash(value) {
   if (typeof value !== 'string' || value.length === 0) {
@@ -24,7 +25,7 @@ function normalizeBaseCandidate(candidate) {
       const absolute = new URL(trimmed);
       return ensureTrailingSlash(absolute.pathname || '/');
     } catch (error) {
-      console.warn('[asset-paths] Invalid absolute BASE_URL candidate.', error);
+      logger.warn('[asset-paths] Invalid absolute BASE_URL candidate.', error);
       return null;
     }
   }
@@ -36,7 +37,7 @@ function normalizeBaseCandidate(candidate) {
         const relative = new URL(trimmed, location.href);
         return ensureTrailingSlash(relative.pathname || '/');
       } catch (error) {
-        console.warn('[asset-paths] Unable to resolve relative BASE_URL candidate.', error);
+        logger.warn('[asset-paths] Unable to resolve relative BASE_URL candidate.', error);
       }
     }
     const sanitized = trimmed.replace(/^\.\//, '/');
@@ -103,7 +104,7 @@ function computeFromModuleUrl() {
       return ensureTrailingSlash(pathname.slice(0, lastSlash + 1) || '/');
     }
   } catch (error) {
-    console.warn('[asset-paths] Unable to infer base from module URL.', error);
+    logger.warn('[asset-paths] Unable to infer base from module URL.', error);
   }
 
   return null;

--- a/src/utils/fail-soft-loaders.js
+++ b/src/utils/fail-soft-loaders.js
@@ -1,4 +1,5 @@
 import * as THREE from 'three';
+import { logger } from './logger.ts';
 
 const DEFAULT_TEXTURE_FALLBACK_COLOR = 0x999999;
 const DEFAULT_MODEL_FALLBACK_COLOR = 0xff4477;
@@ -110,7 +111,7 @@ function loadTextureWithFallback(url, options = {}) {
       try {
         onFallback(texture, error ?? null);
       } catch (callbackError) {
-        console.warn('[asset-loader] onFallback callback threw an error.', callbackError);
+        logger.warn('[asset-loader] onFallback callback threw an error.', callbackError);
       }
     }
     if (typeof onLoad === 'function') {
@@ -122,13 +123,13 @@ function loadTextureWithFallback(url, options = {}) {
           fallbackTexture: texture
         });
       } catch (callbackError) {
-        console.warn('[asset-loader] onLoad callback threw an error.', callbackError);
+        logger.warn('[asset-loader] onLoad callback threw an error.', callbackError);
       }
     }
   };
 
   if (!url) {
-    console.warn(
+    logger.warn(
       `[asset-loader] ${label} 404/failed: ${url ?? '<missing>'}; using fallback #${formatHex(
         fallbackColor
       )}`
@@ -164,7 +165,7 @@ function loadTextureWithFallback(url, options = {}) {
           console.debug(`[asset-loader] applied texture ${label}`);
         }
       } catch (error) {
-        console.warn(
+        logger.warn(
           `[asset-loader] Texture post-processing failed for ${label} at ${url}; retaining fallback.`,
           error
         );
@@ -179,7 +180,7 @@ function loadTextureWithFallback(url, options = {}) {
         sourceUrl: url,
         isFallbackTexture: true
       };
-      console.warn(
+      logger.warn(
         `[asset-loader] ${label} 404/failed: ${url}; using fallback #${formatHex(fallbackColor)}`
       );
       notifyFallback(error);
@@ -197,7 +198,7 @@ async function loadTextureAsyncWithFallback(url, options = {}) {
   } = options;
 
   if (!url) {
-    console.warn(
+    logger.warn(
       `[asset-loader] ${label} 404/failed: ${url ?? '<missing>'}; using fallback #${formatHex(
         fallbackColor
       )}`
@@ -216,7 +217,7 @@ async function loadTextureAsyncWithFallback(url, options = {}) {
     texture.needsUpdate = true;
     return texture;
   } catch (error) {
-    console.warn(
+    logger.warn(
       `[asset-loader] ${label} 404/failed: ${url}; using fallback #${formatHex(fallbackColor)}`
     );
     const fallback = createSolidColorTexture({ color: fallbackColor, name: `${label}::fallback` });
@@ -269,7 +270,7 @@ async function loadGltfWithFallback(loader, url, options = {}) {
   }
 
   if (!url) {
-    console.warn(
+    logger.warn(
       `[asset-loader] Missing URL for ${label}; substituting fallback primitive #${formatHex(
         fallbackColor
       )}.`
@@ -293,7 +294,7 @@ async function loadGltfWithFallback(loader, url, options = {}) {
     }
     return gltf;
   } catch (error) {
-    console.warn(
+    logger.warn(
       `[asset-loader] Failed to load ${label} at ${url}; substituting fallback primitive #${formatHex(
         fallbackColor
       )}.`,

--- a/src/utils/logOnce.js
+++ b/src/utils/logOnce.js
@@ -1,16 +1,14 @@
+import { logger } from './logger.ts';
+
 export function logOnce(key, ...args) {
   if (typeof key !== 'string' || !key) {
-    if (typeof console !== 'undefined' && typeof console.warn === 'function') {
-      console.warn(...args);
-    }
+    logger.warn(...args);
     return;
   }
 
   const globalObject = typeof window !== 'undefined' ? window : typeof globalThis !== 'undefined' ? globalThis : null;
   if (!globalObject) {
-    if (typeof console !== 'undefined' && typeof console.warn === 'function') {
-      console.warn(...args);
-    }
+    logger.warn(...args);
     return;
   }
 
@@ -24,9 +22,7 @@ export function logOnce(key, ...args) {
 
   globalObject.__LOG_ONCE.add(key);
 
-  if (typeof console !== 'undefined' && typeof console.warn === 'function') {
-    console.warn(...args);
-  }
+  logger.warn(...args);
 }
 
 export default logOnce;

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,5 @@
+export const logger = {
+  info: (...a: any[]) => (import.meta.env.DEV ? console.info(...a) : void 0),
+  warn: (...a: any[]) => (import.meta.env.DEV ? console.warn(...a) : void 0),
+  error: (...a: any[]) => console.error(...a), // keep errors
+};

--- a/src/vegetation/trees.js
+++ b/src/vegetation/trees.js
@@ -4,6 +4,7 @@ import { assetUrl } from '../utils/assetUrl.js';
 import { applyCompressionToVector3 } from '../world/scale.js';
 import { loadGLTF } from '../loaders/safeGltf.js';
 import { logOnce } from '../utils/logOnce.js';
+import { logger } from '../utils/logger.ts';
 
 const TREE_MODEL_FILES = {
   olive: 'olive.glb',
@@ -550,7 +551,7 @@ export function scatterTrees({
   maxLod = 32
 } = {}) {
   if (!treeLibrary.size) {
-    console.warn('[trees] Tree library not loaded before scatterTrees call');
+    logger.warn('[trees] Tree library not loaded before scatterTrees call');
   }
 
   const definition = getTreeDefinition(name);


### PR DESCRIPTION
## Summary
- add a shared logger utility that hides info/warn output in production
- replace console log/info/warn usage across the src tree with the new logger

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68dbbd23c2808327b832c121603e7287