### PR TITLE
Add disposal utility and track scene teardown

### DIFF
--- a/src/entry/initializeAthens.js
+++ b/src/entry/initializeAthens.js
@@ -4,6 +4,7 @@ if (typeof window !== 'undefined') window.THREE = THREE; // for console/puppetee
 import { createStats } from '../debug/statsShim.js';
 import { logger } from '../utils/logger.ts';
 import { setupGround, updateTrees } from '../main.js';
+import { disposeAll } from '../utils/disposable.ts';
 import { loadLandmarks } from '../landmarks-loader.js';
 import { createLandmarkOverlay } from '../map/landmarks.js';
 // PLACER_START
@@ -504,6 +505,32 @@ export async function initializeAthens(options = {}) {
 
   const environmentManager = new EnvironmentController(scene, renderer);
 
+  const trackedDisposables = new Set();
+  const registerDisposables = (...items) => {
+    for (const item of items) {
+      if (!item) continue;
+      if (typeof item.dispose === 'function') {
+        trackedDisposables.add(item);
+        continue;
+      }
+      if (
+        item instanceof THREE.Object3D ||
+        item instanceof THREE.Material ||
+        item instanceof THREE.Texture ||
+        item instanceof THREE.BufferGeometry
+      ) {
+        trackedDisposables.add(item);
+      }
+    }
+  };
+  const disposeTracked = () => {
+    if (!trackedDisposables.size) return;
+    disposeAll(...trackedDisposables);
+  };
+  let beforeUnloadCleanup = null;
+
+  registerDisposables(renderer, environmentManager);
+
   if (typeof window !== 'undefined') {
     window.scene = window.scene || scene;
     window.renderer = window.renderer || renderer;
@@ -639,6 +666,7 @@ export async function initializeAthens(options = {}) {
       environmentManager.dispose();
     }
   };
+  registerDisposables(environmentController);
 
   if (!ambientOverrideSelected) {
     setEnvironmentMode(environmentController.mode, { allowAmbient: true });
@@ -646,11 +674,13 @@ export async function initializeAthens(options = {}) {
 
 
   // CITYPLAN_START
-  await setupGround(scene, renderer, { layout, layoutConfig });
+  const ground = await setupGround(scene, renderer, { layout, layoutConfig });
+  registerDisposables(ground);
   // CITYPLAN_END
 
   // CITYPLAN_START
   const city = await createCity({ renderer, scene, layout, layoutConfig });
+  registerDisposables(city);
   // CITYPLAN_END
 
   // LANDMARK_SPREAD_START
@@ -711,6 +741,7 @@ export async function initializeAthens(options = {}) {
   const extendedRes = await createCityExtended({ renderer, scene, layout, layoutConfig });
   // CITYPLAN_END
   const extendedCity = extendedRes?.root ?? null;
+  registerDisposables(extendedCity);
   const sharedMaterials = extendedRes?.materials ?? null;
 
   // LANDMARK_OVERRIDE_START
@@ -801,6 +832,7 @@ export async function initializeAthens(options = {}) {
       groundSampler,
       onSave: handleSave
     });
+    registerDisposables(landmarkPlacer);
     if (typeof landmarkPlacer?.setList === 'function') {
       landmarkPlacer.setList(activeList);
     }
@@ -936,6 +968,7 @@ export async function initializeAthens(options = {}) {
     layoutConfig
     // CITYPLAN_END
   });
+  registerDisposables(landmarks);
 
   const overlayCanvasId = options.overlayCanvasId ?? DEFAULT_OVERLAY_ID;
   const overlayCanvas = ensureOverlayCanvas(container, overlayCanvasId);
@@ -946,6 +979,7 @@ export async function initializeAthens(options = {}) {
 
   const ui = createOriginalUi({ container, overlayCanvas, environmentController });
   ui?.setTimeLabel?.(formatEnvironmentLabel(environmentController?.mode) || 'High Noon');
+  registerDisposables(ui);
 
   // Roads built from collected points (use extended/shared materials if available)
   let roadNetwork = null;
@@ -963,6 +997,7 @@ export async function initializeAthens(options = {}) {
       roadGroup.name = 'RoadNetwork';
       scene.add(roadGroup);
       roadNetwork = roadGroup;
+      registerDisposables(roadNetwork);
     }
   }
 
@@ -982,6 +1017,7 @@ export async function initializeAthens(options = {}) {
       navMesh = buildNavMeshFromMeshes(navSources);
       if (navMesh) {
         navPathfinder = createNavMeshPathfinder(navMesh);
+        registerDisposables(navMesh, navPathfinder);
       }
     } catch (error) {
       logger.warn('[Athens][NavMesh] Failed to build navmesh.', error);
@@ -1000,6 +1036,7 @@ export async function initializeAthens(options = {}) {
       npcConfigs: options.npcConfigs
     });
     npcSystem.initializeNpcs(scene, { navMesh, pathfinder: navPathfinder });
+    registerDisposables(npcSystem);
   }
 
   // Main character
@@ -1009,6 +1046,7 @@ export async function initializeAthens(options = {}) {
         ...(mainCharacterOptions || {}),
         initialPosition: playerSpawn
       });
+  registerDisposables(mainCharacter);
 
   const findPlayerObject = () => scene.getObjectByName('Player') || scene.getObjectByName('Hero');
 
@@ -1053,6 +1091,7 @@ export async function initializeAthens(options = {}) {
   const cameraFollowConfig = cameraSettings?.follow ?? {};
   const cameraSeedConfig = cameraSettings?.seed ?? {};
   const keyboard = createKeyboard();
+  registerDisposables(keyboard);
   const controller = createPlayerController(playerObject, keyboard, {
     walkSpeed: Number.isFinite(movementConfig?.walkSpeed) ? movementConfig.walkSpeed : 4,
     runMultiplier: Number.isFinite(movementConfig?.runMultiplier) ? movementConfig.runMultiplier : 1.7,
@@ -1393,6 +1432,7 @@ export async function initializeAthens(options = {}) {
   };
 
   const gameLoop = createGameLoop(updateFrame, renderFrame);
+  registerDisposables(gameLoop);
 
   const flyBypassInput = {
     held(code) {
@@ -1448,28 +1488,30 @@ export async function initializeAthens(options = {}) {
     dispose() {
       if (disposed) return;
       disposed = true;
-      gameLoop?.dispose?.();
       window.removeEventListener('resize', resizeHandler);
+      beforeUnloadCleanup?.();
       overlay?.destroy?.();
       if (overlayCanvas.parentNode) {
         overlayCanvas.parentNode.removeChild(overlayCanvas);
       }
-      mainCharacter?.dispose?.();
-      npcSystem?.dispose?.();
-      roadNetwork?.dispose?.();
-      landmarks?.dispose?.();
-      environmentController?.dispose?.();
-      ui?.dispose?.();
+      disposeTracked();
+      trackedDisposables.clear();
       if (stats?.dom && stats.dom.parentNode === container) {
         container.removeChild(stats.dom);
       }
-      renderer.dispose();
-      keyboard?.dispose?.();
-      city?.dispose?.();
-      extendedCity?.dispose?.();
       followCamera.setPointerLockElement?.(null);
     }
   };
+
+  if (typeof window !== 'undefined' && import.meta?.env?.DEV) {
+    const beforeUnloadHandler = () => {
+      disposeTracked();
+    };
+    window.addEventListener('beforeunload', beforeUnloadHandler);
+    beforeUnloadCleanup = () => {
+      window.removeEventListener('beforeunload', beforeUnloadHandler);
+    };
+  }
 
   if (typeof window !== 'undefined') {
     window.__athens = window.__athens || {};

--- a/src/environment/EnvironmentController.ts
+++ b/src/environment/EnvironmentController.ts
@@ -1,5 +1,6 @@
 import * as THREE from 'three';
 import { applySky } from '../scene/sky.ts';
+import { disposeAll } from '../utils/disposable.ts';
 
 export type SkyMode = 'procedural';
 
@@ -33,6 +34,16 @@ export class EnvironmentController {
   }
 
   dispose(): void {
+    if (this.disposed) return;
     this.disposed = true;
+    const environment = this.scene.environment as THREE.Texture | null;
+    const background = this.scene.background;
+    const backgroundTexture =
+      background instanceof THREE.Texture || background instanceof THREE.CubeTexture
+        ? background
+        : null;
+    disposeAll(environment, backgroundTexture);
+    this.scene.environment = null;
+    this.scene.background = null;
   }
 }

--- a/src/ground/index.js
+++ b/src/ground/index.js
@@ -2,6 +2,7 @@
 import * as THREE from 'three';
 import { createDirtGround, createDirtMaterial } from './dirt.js';
 import { createGrassGround } from './grass.js';
+import { disposeAll } from '../utils/disposable.ts';
 
 /**
  * Enumerates available ground types.
@@ -736,6 +737,15 @@ export function createGroundLayered({
   root.userData.tileInstances = tileInstances;
   root.userData.groundConfig = config;
 
+  function dispose() {
+    if (root.parent) {
+      root.parent.remove(root);
+    }
+    disposeAll(root);
+    tileInstances.length = 0;
+    skirts.length = 0;
+  }
+
   return {
     root,
     dirt: dirtLayer,
@@ -744,5 +754,6 @@ export function createGroundLayered({
     tiles: tileInstances,
     skirts: skirtRecords,
     config,
+    dispose,
   };
 }

--- a/src/npc/npcSystem.js
+++ b/src/npc/npcSystem.js
@@ -7,6 +7,7 @@ import { loadGLTF } from '../loaders/safeGltf.js';
 import { logOnce } from '../utils/logOnce.js';
 import { ensureFeetAtLocalZero, placeOnGround } from '../utils/spawn.ts';
 import { logger } from '../utils/logger.ts';
+import { disposeAll } from '../utils/disposable.ts';
 
 const SNAP_OPTIONS = { gravity: 12, maxStepUp: 0.6, maxDrop: 4, hover: 0.03, rayStart: 1000 };
 const GROUND_CLEARANCE = typeof SNAP_OPTIONS.hover === 'number' ? SNAP_OPTIONS.hover : 0.03;
@@ -277,24 +278,6 @@ function fixModelTilt(object3d) {
   }
 }
 
-function disposeObject3D(object) {
-  if (!object) return;
-  object.traverse((child) => {
-    if (child.isMesh || child.isSkinnedMesh) {
-      child.geometry?.dispose?.();
-      if (Array.isArray(child.material)) {
-        child.material.forEach((mat) => mat?.dispose?.());
-      } else {
-        child.material?.dispose?.();
-      }
-    }
-    if (child.isSprite) {
-      child.material?.map?.dispose?.();
-      child.material?.dispose?.();
-    }
-  });
-}
-
 function normalizeModelUrl(input) {
   if (!input) return null;
   if (typeof input !== 'string') return resolveAssetUrl(input);
@@ -370,7 +353,7 @@ function attachModelToNpc(npc, model) {
     object3d.remove(npc.modelRoot);
   }
   if (npc.modelRoot && npc.modelRoot !== model) {
-    disposeObject3D(npc.modelRoot);
+    disposeAll(npc.modelRoot);
   }
   npc.modelRoot = model || null;
   if (model) {
@@ -435,13 +418,13 @@ function disposeNpcEntity(npc) {
   npc.mixer = null;
   if (npc.modelRoot) {
     if (npc.modelRoot.parent === npc.object3d) npc.object3d.remove(npc.modelRoot);
-    disposeObject3D(npc.modelRoot);
+    disposeAll(npc.modelRoot);
     npc.modelRoot = null;
   }
   if (npc.object3d?.parent) {
     npc.object3d.parent.remove(npc.object3d);
   }
-  disposeObject3D(npc.object3d);
+  disposeAll(npc.object3d);
 }
 
 function createNpcEntity(config = {}, { scene = null, navContext = null, groundMeshes = [] } = {}) {

--- a/src/scene/ground.js
+++ b/src/scene/ground.js
@@ -4,6 +4,13 @@ import { updateGroundDebugOverlay, clearGroundDebugOverlay } from '../ground/deb
 
 let __groundSingleton = null;
 
+export function disposeGround() {
+  if (__groundSingleton?.dispose) {
+    __groundSingleton.dispose();
+  }
+  __groundSingleton = null;
+}
+
 function hideLegacyGroundPlanes(scene, layeredGroundRoot) {
   if (!scene) return;
 
@@ -115,7 +122,15 @@ export async function loadGround(scene, renderer, options = {}) {
       layeredOptions.stabilizeTileOverlap = stabilizeTileOverlap;
     }
 
-    __groundSingleton = createGroundLayered(layeredOptions);
+    const layered = createGroundLayered(layeredOptions);
+    const originalDispose = layered?.dispose?.bind(layered);
+    layered.dispose = () => {
+      originalDispose?.();
+      if (__groundSingleton === layered) {
+        __groundSingleton = null;
+      }
+    };
+    __groundSingleton = layered;
 
     if (__groundSingleton?.root) {
       __groundSingleton.root.userData.layeredGround = true;

--- a/src/scene/sky.ts
+++ b/src/scene/sky.ts
@@ -1,5 +1,6 @@
 import * as THREE from 'three';
 import { logger } from '../utils/logger';
+import { disposeAll } from '../utils/disposable.ts';
 
 export type SkyChoice =
   | {
@@ -94,11 +95,7 @@ function baseURL(rel: string) {
 
 function disposeExistingEnvironment(scene: THREE.Scene) {
   const current = scene.environment as THREE.Texture | THREE.CubeTexture | null;
-  if (current && typeof (current as THREE.Texture).dispose === 'function') {
-    try {
-      (current as THREE.Texture).dispose();
-    } catch {}
-  }
+  disposeAll(current);
 }
 
 function setTextureColorSpace(tex: THREE.Texture | THREE.CubeTexture) {
@@ -214,14 +211,9 @@ export async function applySky(
     logger.warn('[sky] Failed to apply sky environment.', error);
   } finally {
     // Dispose the previous background texture if it was replaced
-    const backgroundDisposable = previousBackground as unknown as { dispose?: () => void };
-    if (
-      previousBackground &&
-      previousBackground !== scene.background &&
-      typeof backgroundDisposable?.dispose === 'function'
-    ) {
+    if (previousBackground && previousBackground !== scene.background) {
       try {
-        backgroundDisposable.dispose();
+        disposeAll(previousBackground as THREE.Texture | THREE.CubeTexture | null);
       } catch (e) {
         logger.warn('[sky] Failed to dispose previous background texture.', e);
       }

--- a/src/utils/disposable.ts
+++ b/src/utils/disposable.ts
@@ -1,0 +1,188 @@
+import * as THREE from 'three';
+
+export interface Disposable {
+  dispose(): void;
+}
+
+type DisposableItem =
+  | THREE.Object3D
+  | THREE.Material
+  | THREE.Texture
+  | THREE.BufferGeometry
+  | Disposable
+  | null
+  | undefined
+  | DisposableItem[];
+
+const materialTextureProps = [
+  'map',
+  'alphaMap',
+  'aoMap',
+  'bumpMap',
+  'clearcoatMap',
+  'clearcoatNormalMap',
+  'clearcoatRoughnessMap',
+  'displacementMap',
+  'emissiveMap',
+  'envMap',
+  'gradientMap',
+  'lightMap',
+  'matcap',
+  'metalnessMap',
+  'normalMap',
+  'roughnessMap',
+  'sheenColorMap',
+  'sheenRoughnessMap',
+  'specularColorMap',
+  'specularMap',
+  'specularIntensityMap',
+  'thicknessMap',
+  'transmissionMap'
+] as const;
+
+type SeenSet = Set<unknown>;
+
+function disposeMaterial(material: THREE.Material, seen: SeenSet): void {
+  if (seen.has(material)) return;
+  seen.add(material);
+
+  const uniforms = (material as { uniforms?: Record<string, any> }).uniforms;
+  if (uniforms && typeof uniforms === 'object') {
+    for (const uniform of Object.values(uniforms)) {
+      const value = uniform && typeof uniform === 'object' ? uniform.value ?? uniform.texture : uniform;
+      disposeUnknown(value, seen);
+    }
+  }
+
+  for (const key of materialTextureProps) {
+    const value = (material as any)[key];
+    if (value) {
+      disposeUnknown(value, seen);
+      if ((material as any)[key] === value) {
+        (material as any)[key] = null;
+      }
+    }
+  }
+
+  const keys = Object.keys(material as any);
+  for (const key of keys) {
+    const value = (material as any)[key];
+    if (value && (value instanceof THREE.Texture || Array.isArray(value))) {
+      disposeUnknown(value, seen);
+    }
+  }
+
+  try {
+    material.dispose();
+  } catch (error) {
+    if (typeof process !== 'undefined' && process?.env?.NODE_ENV !== 'production') {
+      // eslint-disable-next-line no-console
+      console.warn('[disposeAll] Failed to dispose material', material, error);
+    }
+  }
+}
+
+function disposeObject3D(object: THREE.Object3D, seen: SeenSet): void {
+  if (seen.has(object)) return;
+  seen.add(object);
+
+  object.traverse((child: any) => {
+    if (!child) return;
+    if (child.geometry) {
+      disposeUnknown(child.geometry, seen);
+    }
+    if (child.material) {
+      disposeUnknown(child.material, seen);
+    }
+    if (child instanceof THREE.Sprite && child.material) {
+      disposeUnknown((child.material as any).map, seen);
+    }
+    if (typeof child.dispose === 'function' && child !== object) {
+      disposeUnknown(child, seen);
+    }
+  });
+}
+
+function disposeUnknown(item: DisposableItem | any, seen: SeenSet): void {
+  if (!item || seen.has(item)) {
+    return;
+  }
+
+  if (Array.isArray(item)) {
+    for (const value of item) {
+      disposeUnknown(value, seen);
+    }
+    return;
+  }
+
+  if (item instanceof THREE.Object3D) {
+    disposeObject3D(item, seen);
+    return;
+  }
+
+  if (item instanceof THREE.Material) {
+    disposeMaterial(item, seen);
+    return;
+  }
+
+  if (item instanceof THREE.Texture || item instanceof THREE.CubeTexture) {
+    seen.add(item);
+    try {
+      item.dispose();
+    } catch (error) {
+      if (typeof process !== 'undefined' && process?.env?.NODE_ENV !== 'production') {
+        // eslint-disable-next-line no-console
+        console.warn('[disposeAll] Failed to dispose texture', item, error);
+      }
+    }
+    return;
+  }
+
+  if (item instanceof THREE.BufferGeometry) {
+    seen.add(item);
+    try {
+      item.dispose();
+    } catch (error) {
+      if (typeof process !== 'undefined' && process?.env?.NODE_ENV !== 'production') {
+        // eslint-disable-next-line no-console
+        console.warn('[disposeAll] Failed to dispose geometry', item, error);
+      }
+    }
+    return;
+  }
+
+  if (typeof item.dispose === 'function') {
+    seen.add(item);
+    try {
+      item.dispose();
+    } catch (error) {
+      if (typeof process !== 'undefined' && process?.env?.NODE_ENV !== 'production') {
+        // eslint-disable-next-line no-console
+        console.warn('[disposeAll] Failed to dispose resource', item, error);
+      }
+    }
+    return;
+  }
+
+  seen.add(item);
+}
+
+export function disposeAll(
+  ...items: (
+    | THREE.Object3D
+    | THREE.Material
+    | THREE.Texture
+    | THREE.BufferGeometry
+    | Disposable
+    | null
+    | undefined
+    | (THREE.Object3D | THREE.Material | THREE.Texture | THREE.BufferGeometry | Disposable | null | undefined)[]
+  )[]
+): void {
+  if (!items.length) return;
+  const seen: SeenSet = new Set();
+  for (const item of items) {
+    disposeUnknown(item, seen);
+  }
+}
+


### PR DESCRIPTION
## Summary
- add a shared `disposeAll` helper to dispose Three.js objects, materials, textures, and geometries consistently
- apply the helper across environment, sky, NPC, and ground modules and expose dispose hooks for layered ground
- track top-level disposables during initialization, clear them on teardown, and invoke disposal on `beforeunload` in development

## Testing
- `npm test` *(fails: TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".ts" for /workspace/Athens/src/utils/logger.ts)*

------
https://chatgpt.com/codex/tasks/task_b_68dbc1f50560832782cb499b03bae0a5