### PR TITLE
Adjust character height handling

### DIFF
--- a/src/entry/initializeAthens.js
+++ b/src/entry/initializeAthens.js
@@ -46,6 +46,139 @@ import { installSkyDev } from '../dev/skyDebugHooks.js';
 import { EnvironmentController } from '../environment/EnvironmentController.ts';
 // SKYSYS_END
 
+// CHAR_HEIGHT_START
+function _boxHeightOf(obj) {
+  if (!obj) return 0;
+  const box = new THREE.Box3().setFromObject(obj);
+  const size = new THREE.Vector3();
+  box.getSize(size);
+  return size.y;
+}
+
+function _findMainCharacter(scene) {
+  // Try common globals (if exposed)
+  if (typeof window !== 'undefined') {
+    if (window.mainCharacter) return window.mainCharacter;
+    if (window.player) return window.player;
+    if (window.state?.character) return window.state.character;
+  }
+  // Try by name
+  const candidates = ['mainCharacter', 'MainCharacter', 'Player', 'Character', 'Avatar', 'Hero'];
+  for (const n of candidates) {
+    const hit = scene.getObjectByName(n);
+    if (hit) return hit;
+  }
+  // Fallback: first object that looks like a skinned character
+  let pick = null;
+  scene.traverse((o) => {
+    if (pick) return;
+    if (o?.isSkinnedMesh || /character|player|avatar|hero/i.test(o?.name || '')) {
+      pick = o.isSkinnedMesh ? (o.parent || o) : o;
+    }
+  });
+  return pick;
+}
+
+function _setWorldPosition(object, x, y, z) {
+  if (!object) return false;
+  object.updateMatrixWorld(true);
+  const parent = object.parent;
+  if (parent) {
+    parent.updateMatrixWorld(true);
+    const wp = new THREE.Vector3(x, y, z);
+    object.position.copy(parent.worldToLocal(wp));
+  } else {
+    object.position.set(x, y, z);
+  }
+  object.updateMatrixWorld(true);
+  return true;
+}
+
+function _raycastGroundYSafe(pos) {
+  try {
+    if (typeof window.raycastGroundY === 'function') {
+      const gy = window.raycastGroundY(pos);
+      if (Number.isFinite(gy)) return gy;
+    }
+  } catch {}
+  return null;
+}
+
+/**
+ * Ensure character visual + collider match a desired height (meters).
+ * - Measures baseline (unscaled) height once, caches it on userData.
+ * - Applies uniform mesh scale.
+ * - Scales capsule and navAgent metrics if present.
+ */
+function _applyCharacterHeight(scene, options, desiredMeters = 1.8) {
+  const char = _findMainCharacter(scene);
+  if (!char) { try { console.warn('[CharHeight] character not found'); } catch {} return; }
+
+  // Cache original scale & baseline height once
+  char.userData._origScale ??= char.scale.clone();
+  if (!char.userData._baselineHeight) {
+    const s = char.scale.clone();
+    char.scale.set(1, 1, 1);
+    char.updateMatrixWorld(true);
+    char.userData._baselineHeight = _boxHeightOf(char) || 1;
+    char.scale.copy(s);
+    char.updateMatrixWorld(true);
+  }
+  const baseline = char.userData._baselineHeight || 1;
+  const factor = desiredMeters / baseline;
+
+  // Apply visual scale idempotently (relative to original)
+  char.scale.set(
+    char.userData._origScale.x * factor,
+    char.userData._origScale.y * factor,
+    char.userData._origScale.z * factor
+  );
+  char.updateMatrixWorld(true);
+
+  // Collider/controller alignment if state is global
+  const st = (typeof window !== 'undefined' ? window.state : undefined) || {};
+  if (typeof st.capsuleHalfHeight === 'number') {
+    st._origCapsuleHalfHeight ??= st.capsuleHalfHeight;
+    st.capsuleHalfHeight = st._origCapsuleHalfHeight * factor;
+  }
+  if (typeof st.radius === 'number') {
+    st._origRadius ??= st.radius;
+    st.radius = st._origRadius * factor;
+  }
+  if (st.navAgent) {
+    if (typeof st.navAgent.height === 'number') {
+      st._origAgentHeight ??= st.navAgent.height;
+      st.navAgent.height = st._origAgentHeight * factor;
+    }
+    if (typeof st.navAgent.radius === 'number') {
+      st._origAgentRadius ??= st.navAgent.radius;
+      st.navAgent.radius = st._origAgentRadius * factor;
+    }
+  }
+
+  // Optional snap-to-ground if available
+  const wp = char.getWorldPosition(new THREE.Vector3());
+  const gy = _raycastGroundYSafe(wp);
+  if (gy !== null) _setWorldPosition(char, wp.x, gy + 0.02, wp.z);
+
+  try { console.info('[CharHeight] applied', { desiredMeters, factor }); } catch {}
+}
+
+function _installCharHeightDev(scene, options) {
+  if (typeof window === 'undefined') return;
+  window.dev = window.dev || {};
+  window.dev.character = window.dev.character || {};
+  window.dev.character.setHeight = (m = 1.8) => _applyCharacterHeight(scene, options, m);
+  // convenience alias
+  window.dev.character.status = () => {
+    const char = _findMainCharacter(scene);
+    if (!char) return console.log('[CharHeight] no character found');
+    const h = _boxHeightOf(char);
+    console.log('[CharHeight] measuredHeight≈', h.toFixed(2), 'scale=', char.scale);
+  };
+}
+// CHAR_HEIGHT_END
+
 // LANDMARK_SPREAD_START
 const _LANDMARK_MATCH = {
   Agora:            ['Agora','AgoraGroup'],
@@ -85,21 +218,6 @@ function _findByNames(scene, names) {
     }
   });
   return best;
-}
-
-function _setWorldPosition(obj, x, y, z) {
-  if (!obj) return false;
-  obj.updateMatrixWorld(true);
-  const parent = obj.parent;
-  if (parent) {
-    parent.updateMatrixWorld(true);
-    const wp = new THREE.Vector3(x, y, z);
-    obj.position.copy(parent.worldToLocal(wp));
-  } else {
-    obj.position.set(x, y, z);
-  }
-  obj.updateMatrixWorld(true);
-  return true;
 }
 
 function _groundYAt(pos, fallbackY) {
@@ -1078,6 +1196,18 @@ export async function initializeAthens(options = {}) {
   if (playerObject?.position) {
     sanitizeVec3(playerObject.position, SAFE_PLAYER_FALLBACK);
   }
+
+  // CHAR_HEIGHT_START
+  // Determine desired height (meters): options.movementConfig.character.height OR default 1.8
+  const desiredCharHeight =
+    options?.movementConfig?.character?.height ??
+    options?.character?.height ??
+    1.8;
+
+  // Apply height once everything is constructed
+  _applyCharacterHeight(scene, options, desiredCharHeight);
+  _installCharHeightDev(scene, options);
+  // CHAR_HEIGHT_END
 
   const flyBypassFallbackPosition = new THREE.Vector3();
   const flyBypassVelocity = { y: 0 };


### PR DESCRIPTION
## Summary
- add character height utility helpers to keep visuals, collider, and nav agent in sync
- allow configurable height with a default of 1.8m and expose a dev hook for runtime adjustments

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68dbc7452e308327a9102645ec80508c