### PR TITLE
Remove stale tree initialization comment

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -80,13 +80,6 @@ async function ensureTrees(scene, renderer) {
 export async function setupGround(scene, renderer) {
   const ground = await loadGround(scene, renderer, groundOptions);
 
-  // Optionally integrate tree initialization here (if present on main):
-  // if (!treesInitialized) {
-  //   const { initTrees } = await import('./trees/init.js');
-  //   ({ treeLibraryState, groveGroup } = await initTrees(scene, ground));
-  //   treesInitialized = true;
-  // }
-
   await ensureTrees(scene, renderer);
   return ground;
 }


### PR DESCRIPTION
## Summary
- remove obsolete commented-out tree initialization block from `setupGround`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68dbd72a3abc8327b26f560aa5e71f81