### PR TITLE
Add layout post-processing for Athens city landmarks

### DIFF
--- a/src/buildings/createCity.js
+++ b/src/buildings/createCity.js
@@ -7,6 +7,116 @@ import { createGround } from './ground.js';
 import { markGround, collectGround } from '../physics/groundRegistry.js';
 import { snapGroupToGround } from '../physics/groundProject.js';
 
+// LAYOUT_APPLY_START
+// Lightweight post-build layout applier: respects options.layoutConfig.positions and spacing
+const __LANDMARK_KEYS = [
+  'Agora', 'Stoa', 'Stoa_of_Attalos', 'Tholos', 'Theater', 'Theater_of_Dionysus', 'Stadium', 'CityGate', 'CityGate_South', 'Port', 'Port_Quay_A'
+];
+const __NAME_ALIASES = {
+  Agora: ['Agora', 'AgoraGroup'],
+  Stoa: ['Stoa', 'Stoa_of_Attalos', 'StoaAttalos'],
+  Stoa_of_Attalos: ['Stoa_of_Attalos', 'Stoa', 'StoaAttalos'],
+  Tholos: ['Tholos'],
+  Theater: ['Theater', 'Theatre', 'Theater_of_Dionysus', 'Theatre_of_Dionysus'],
+  Theater_of_Dionysus: ['Theater_of_Dionysus', 'Theatre_of_Dionysus', 'Theater', 'Theatre'],
+  Stadium: ['Stadium', 'Stadion'],
+  CityGate: ['CityGate', 'SouthGate', 'Gate_South', 'CityGate_South'],
+  CityGate_South: ['CityGate_South', 'CityGate', 'SouthGate', 'Gate_South'],
+  Port: ['Port', 'Harbor', 'Harbour', 'Quay', 'Port_Quay_A'],
+  Port_Quay_A: ['Port_Quay_A', 'Port', 'Harbor', 'Harbour', 'Quay']
+};
+
+function __findByNames(root, names) {
+  if (!root) return null;
+  // exact first
+  for (const n of names) {
+    const hit = root.getObjectByName?.(n);
+    if (hit) return hit;
+  }
+  // fuzzy
+  const lowers = names.map((n) => String(n).toLowerCase());
+  let best = null;
+  root.traverse?.((o) => {
+    if (!o?.name) return;
+    const nm = o.name.toLowerCase();
+    for (const needle of lowers) {
+      if (nm === needle || nm.includes(needle)) {
+        best = best || o;
+        break;
+      }
+    }
+  });
+  return best;
+}
+
+function __setWorldPositionSafe(obj, x, y, z) {
+  if (!obj) return false;
+  try {
+    const T = (typeof THREE !== 'undefined') ? THREE : (globalThis?.THREE);
+    if (obj.parent && obj.parent.worldToLocal && T?.Vector3) {
+      obj.parent.updateMatrixWorld?.(true);
+      const wp = new T.Vector3(x, y, z);
+      obj.position.copy(obj.parent.worldToLocal(wp));
+    } else {
+      // fallback: local set (may be off if parent is transformed, but safe)
+      obj.position.set(x, y, z);
+    }
+    obj.updateMatrixWorld?.(true);
+    return true;
+  } catch {
+    obj.position.set(x, y, z);
+    return true;
+  }
+}
+
+function __applyAthensLayout(root, options) {
+  const cfg = options?.layoutConfig || {};
+  const spacingMul = Number.isFinite(cfg.spacing) ? cfg.spacing : 1.0;
+  const overrides = cfg.positions || {};
+  // very simple spread defaults (scaled by spacing)
+  const defaults = {
+    Agora: { x: 0, y: 80, z: 0 },
+    Stoa: { x: 200, y: 82, z: 50 },
+    Stoa_of_Attalos: { x: 200, y: 82, z: 50 },
+    Tholos: { x: -150, y: 82, z: 80 },
+    Theater: { x: 300, y: 78, z: -200 },
+    Theater_of_Dionysus: { x: 300, y: 78, z: -200 },
+    Stadium: { x: -300, y: 85, z: 250 },
+    CityGate: { x: 0, y: 80, z: -400 },
+    CityGate_South: { x: 0, y: 80, z: -420 },
+    Port: { x: 0, y: 75, z: 500 },
+    Port_Quay_A: { x: 80, y: 75, z: 520 }
+  };
+  // apply spacing multiplier
+  for (const k of Object.keys(defaults)) {
+    defaults[k] = { x: defaults[k].x * spacingMul, y: defaults[k].y, z: defaults[k].z * spacingMul };
+  }
+
+  const results = {};
+  for (const key of __LANDMARK_KEYS) {
+    const aliases = __NAME_ALIASES[key] || [key];
+    const obj = __findByNames(root, aliases);
+    if (!obj) {
+      results[key] = 'not-found';
+      continue;
+    }
+    const src = overrides[key] || defaults[key];
+    if (!src) {
+      results[key] = 'no-pos';
+      continue;
+    }
+    const x = Number.isFinite(src.x) ? src.x : obj.position.x;
+    const y = Number.isFinite(src.y) ? src.y : obj.position.y;
+    const z = Number.isFinite(src.z) ? src.z : obj.position.z;
+    const ok = __setWorldPositionSafe(obj, x, y, z);
+    results[key] = ok ? `moved (${x.toFixed?.(2) || x}, ${y.toFixed?.(2) || y}, ${z.toFixed?.(2) || z})` : 'failed';
+  }
+  try {
+    console.info('[Athens/Layout]', results);
+  } catch {}
+}
+// LAYOUT_APPLY_END
+
 export async function createCity({ renderer, scene, ground: groundOverrides } = {}) {
   const options = arguments[0] ?? {};
   const materials = await loadMaterials(renderer);
@@ -131,12 +241,6 @@ export async function createCity({ renderer, scene, ground: groundOverrides } = 
 
   const agoraPosition = new THREE.Vector3(80, 0, -40);
   const agora = createAgora(materials, { position: agoraPosition });
-  // AGORA_OVERRIDE_START
-  if (options?.layoutConfig?.positions?.Agora) {
-    const p = options.layoutConfig.positions.Agora;
-    agora.position.set(p.x, p.y, p.z);
-  }
-  // AGORA_OVERRIDE_END
   addAndSnap(agora);
 
   const wallsPath = [
@@ -150,6 +254,16 @@ export async function createCity({ renderer, scene, ground: groundOverrides } = 
   addAndSnap(walls);
 
   updateWorldMatrices();
+
+  // LAYOUT_APPLY_START
+  // If using athensPlan, apply layout overrides/spread after build so nothing is squashed.
+  if (options?.layout === 'athensPlan') {
+    __applyAthensLayout(scene ?? root, options);
+  } else if (options?.layoutConfig?.positions) {
+    // even without athensPlan flag, respect explicit positions when provided
+    __applyAthensLayout(scene ?? root, options);
+  }
+  // LAYOUT_APPLY_END
 
   return { root, materials };
 }


### PR DESCRIPTION
## Summary
- add lightweight post-build layout helper that can reposition known landmarks by alias
- allow layout spacing multiplier and explicit overrides via options.layoutConfig
- automatically apply the layout when athensPlan layout is requested or explicit positions are provided

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68dbdaf555988327a635ebae09a9bfa5