### PR TITLE
Refactor landmark layout configuration into shared module

### DIFF
--- a/src/buildings/createCity.js
+++ b/src/buildings/createCity.js
@@ -13,125 +13,7 @@ import { createCityWalls as createExtendedWalls, createGate } from './gatesWalls
 import { createTholos } from './tholos.js';
 import { createStadium } from './stadium.js';
 import { createPort } from './port.js';
-
-const ATHENS_PLAN_PRESET = {
-  Agora: { x: -40, y: 'ground', z: 30 },
-  Stoa_of_Attalos: { x: -20, y: 'ground', z: 20 },
-  Tholos: { x: -48, y: 'ground', z: 18 },
-  Theater_of_Dionysus: { x: 35, y: 'ground', z: 15 },
-  Stadium: { x: 80, y: 'ground', z: 10 },
-  CityGate_South: { x: 10, y: 'ground', z: 110 },
-  Port_Quay_A: { x: 10, y: 'ground', z: 160 },
-  Houses_NW: { x: -90, y: 'ground', z: -60 },
-  Houses_NE: { x: 40, y: 'ground', z: -80 },
-  Temple_of_Hephaestus: { x: -60, y: 'ground', z: 45 },
-  Parthenon: { x: 6, y: 'acropolis', z: -4 }
-};
-
-function applyConfigOverride(current, override) {
-  if (!override) return current;
-
-  if (override instanceof THREE.Vector3) {
-    return { x: override.x, y: override.y, z: override.z };
-  }
-
-  if (Array.isArray(override)) {
-    const [ox, oy, oz] = override;
-    return {
-      x: Number.isFinite(ox) ? ox : current.x,
-      y: Number.isFinite(oy) ? oy : current.y,
-      z: Number.isFinite(oz) ? oz : current.z
-    };
-  }
-
-  if (typeof override === 'number') {
-    return { ...current, y: override };
-  }
-
-  if (typeof override === 'object') {
-    const next = { ...current };
-    if ('x' in override && override.x !== undefined) {
-      const parsed = Number(override.x);
-      next.x = Number.isFinite(parsed) ? parsed : override.x;
-    }
-    if ('y' in override && override.y !== undefined) {
-      const parsed = Number(override.y);
-      next.y = Number.isFinite(parsed) ? parsed : override.y;
-    }
-    if ('z' in override && override.z !== undefined) {
-      const parsed = Number(override.z);
-      next.z = Number.isFinite(parsed) ? parsed : override.z;
-    }
-    return next;
-  }
-
-  return current;
-}
-
-function createLayoutResolver({ layout, layoutConfig, plateauHeight, sampleGround }) {
-  const normalizedLayout = typeof layout === 'string' && layout ? layout : 'classic';
-  const normalizedConfig = layoutConfig && typeof layoutConfig === 'object' ? layoutConfig : {};
-  const positionOverrides =
-    normalizedConfig.positions && typeof normalizedConfig.positions === 'object'
-      ? normalizedConfig.positions
-      : null;
-
-  return (key, fallback = new THREE.Vector3()) => {
-    const fallbackVec = fallback instanceof THREE.Vector3
-      ? fallback.clone()
-      : new THREE.Vector3(fallback?.x ?? 0, fallback?.y ?? 0, fallback?.z ?? 0);
-
-    let resolved = fallbackVec.clone();
-
-    if (normalizedLayout === 'athensPlan' && ATHENS_PLAN_PRESET[key]) {
-      const preset = ATHENS_PLAN_PRESET[key];
-      resolved.set(
-        Number.isFinite(preset.x) ? preset.x : fallbackVec.x,
-        preset.y ?? fallbackVec.y,
-        Number.isFinite(preset.z) ? preset.z : fallbackVec.z
-      );
-    }
-
-    const layers = [];
-    if (normalizedConfig[key] !== undefined) layers.push(normalizedConfig[key]);
-    if (positionOverrides?.[key] !== undefined) layers.push(positionOverrides[key]);
-
-    let config = { x: resolved.x, y: resolved.y, z: resolved.z };
-    for (const layer of layers) {
-      config = applyConfigOverride(config, layer);
-    }
-
-    const finalX = Number.isFinite(config.x) ? config.x : fallbackVec.x;
-    const finalZ = Number.isFinite(config.z) ? config.z : fallbackVec.z;
-
-    let finalY = config.y;
-    let snapToGround = false;
-
-    if (finalY === 'ground') {
-      const sample = sampleGround ? sampleGround(finalX, finalZ) : null;
-      if (typeof sample === 'number' && Number.isFinite(sample)) {
-        finalY = sample;
-      } else {
-        finalY = fallbackVec.y;
-      }
-      snapToGround = true;
-    } else if (finalY === 'acropolis') {
-      finalY = typeof plateauHeight === 'number' ? plateauHeight : fallbackVec.y;
-    } else if (!Number.isFinite(finalY)) {
-      finalY = fallbackVec.y;
-    } else {
-      snapToGround = false;
-    }
-
-    const position = new THREE.Vector3(
-      Number.isFinite(finalX) ? finalX : fallbackVec.x,
-      Number.isFinite(finalY) ? finalY : fallbackVec.y,
-      Number.isFinite(finalZ) ? finalZ : fallbackVec.z
-    );
-
-    return { position, snapToGround };
-  };
-}
+import { createLandmarkLayoutResolver } from '../config/landmarkLayout.ts';
 
 export async function createCity(options = {}) {
   const { renderer, scene, ground: groundOverrides, layout, layoutConfig } = options ?? {};
@@ -282,13 +164,14 @@ export async function createCity(options = {}) {
   })();
   // ACROPOLIS_END
 
-  const sampleGround = (x, z) => {
+  const sampleGround = (x, z, fallbackY) => {
     const grounds = ensureGroundMeshes();
-    if (!grounds.length) return null;
-    return sampleGroundY(x, z, grounds, { fromY: 400 });
+    if (!grounds.length) return fallbackY;
+    const sample = sampleGroundY(x, z, grounds, { fromY: 400 });
+    return sample == null ? fallbackY : sample;
   };
 
-  const resolveLayout = createLayoutResolver({
+  const resolveLayout = createLandmarkLayoutResolver({
     layout,
     layoutConfig,
     plateauHeight: acropolisMeta.plateauHeight,

--- a/src/buildings/createCityExtended.js
+++ b/src/buildings/createCityExtended.js
@@ -1,2 +1,9 @@
 export { createCity as createCityExtended } from './createCity.js';
+export {
+  LANDMARK_ALIASES,
+  LANDMARK_LAYOUTS,
+  KNOWN_LANDMARK_KEYS,
+  createLandmarkLayoutResolver,
+  getLandmarkKeysForLayout
+} from '../config/landmarkLayout.ts';
 export { createCity as default } from './createCity.js';

--- a/src/config/landmarkLayout.ts
+++ b/src/config/landmarkLayout.ts
@@ -1,0 +1,261 @@
+import * as THREE from 'three';
+
+export type LandmarkHeightMode = number | 'ground' | 'acropolis';
+
+export interface LandmarkPositionSpec {
+  x?: number;
+  y?: LandmarkHeightMode;
+  z?: number;
+}
+
+export type LandmarkLayoutPreset = Record<string, LandmarkPositionSpec>;
+
+export const LANDMARK_ALIASES: Record<string, string[]> = {
+  Agora: ['Agora', 'AgoraGroup'],
+  Stoa_of_Attalos: ['Stoa_of_Attalos', 'Stoa', 'StoaAttalos'],
+  Tholos: ['Tholos'],
+  Theater_of_Dionysus: ['Theater_of_Dionysus', 'Theatre_of_Dionysus', 'Theater', 'Theatre'],
+  Stadium: ['Stadium', 'Stadion'],
+  CityGate_South: ['CityGate_South', 'CityGate', 'SouthGate', 'Gate_South'],
+  Port_Quay_A: ['Port_Quay_A', 'Port', 'Harbor', 'Harbour', 'Quay']
+};
+
+export const LANDMARK_LAYOUTS: Record<string, LandmarkLayoutPreset> = {
+  athensPlan: {
+    Agora: { x: -40, y: 'ground', z: 30 },
+    Stoa_of_Attalos: { x: -20, y: 'ground', z: 20 },
+    Tholos: { x: -48, y: 'ground', z: 18 },
+    Theater_of_Dionysus: { x: 35, y: 'ground', z: 15 },
+    Stadium: { x: 80, y: 'ground', z: 10 },
+    CityGate_South: { x: 10, y: 'ground', z: 110 },
+    Port_Quay_A: { x: 10, y: 'ground', z: 160 },
+    Houses_NW: { x: -90, y: 'ground', z: -60 },
+    Houses_NE: { x: 40, y: 'ground', z: -80 },
+    Temple_of_Hephaestus: { x: -60, y: 'ground', z: 45 },
+    Parthenon: { x: 6, y: 'acropolis', z: -4 }
+  }
+};
+
+const STATIC_LANDMARK_KEYS = new Set<string>([
+  ...Object.keys(LANDMARK_ALIASES),
+  ...Object.values(LANDMARK_LAYOUTS).flatMap((preset) => Object.keys(preset))
+]);
+
+export const KNOWN_LANDMARK_KEYS: readonly string[] = Object.freeze(Array.from(STATIC_LANDMARK_KEYS));
+
+function toFiniteNumber(value: unknown): number | undefined {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === 'string' && value.trim() !== '') {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+  return undefined;
+}
+
+function normalizeOverride(override: unknown): LandmarkPositionSpec | null {
+  if (override == null) {
+    return null;
+  }
+
+  if (override instanceof THREE.Vector3 || (override && (override as THREE.Vector3).isVector3)) {
+    const vec = override as THREE.Vector3;
+    return { x: vec.x, y: vec.y, z: vec.z };
+  }
+
+  if (Array.isArray(override)) {
+    const [x, y, z] = override;
+    const result: LandmarkPositionSpec = {};
+    const nx = toFiniteNumber(x);
+    if (nx !== undefined) result.x = nx;
+    if (y === 'ground' || y === 'acropolis') {
+      result.y = y;
+    } else {
+      const ny = toFiniteNumber(y);
+      if (ny !== undefined) result.y = ny;
+    }
+    const nz = toFiniteNumber(z);
+    if (nz !== undefined) result.z = nz;
+    return Object.keys(result).length ? result : null;
+  }
+
+  if (typeof override === 'number' && Number.isFinite(override)) {
+    return { y: override };
+  }
+
+  if (typeof override === 'object') {
+    const result: LandmarkPositionSpec = {};
+    const source = override as Record<string, unknown>;
+
+    if ('x' in source) {
+      const nx = toFiniteNumber(source.x);
+      if (nx !== undefined) {
+        result.x = nx;
+      }
+    }
+
+    if ('y' in source) {
+      const raw = source.y;
+      if (raw === 'ground' || raw === 'acropolis') {
+        result.y = raw;
+      } else {
+        const ny = toFiniteNumber(raw);
+        if (ny !== undefined) {
+          result.y = ny;
+        }
+      }
+    }
+
+    if ('z' in source) {
+      const nz = toFiniteNumber(source.z);
+      if (nz !== undefined) {
+        result.z = nz;
+      }
+    }
+
+    return Object.keys(result).length ? result : null;
+  }
+
+  return null;
+}
+
+function mergeSpec(base: LandmarkPositionSpec, override: unknown): LandmarkPositionSpec {
+  const normalized = normalizeOverride(override);
+  if (!normalized) {
+    return { ...base };
+  }
+  const next: LandmarkPositionSpec = { ...base };
+  if (normalized.x !== undefined) next.x = normalized.x;
+  if (normalized.y !== undefined) next.y = normalized.y;
+  if (normalized.z !== undefined) next.z = normalized.z;
+  return next;
+}
+
+function resolveSpec(
+  spec: LandmarkPositionSpec,
+  fallback: THREE.Vector3,
+  {
+    sampleGround,
+    plateauHeight
+  }: {
+    sampleGround?: GroundSampler | null;
+    plateauHeight?: number | null | undefined;
+  }
+): { position: THREE.Vector3; snapToGround: boolean } {
+  const x = toFiniteNumber(spec.x) ?? fallback.x;
+  const z = toFiniteNumber(spec.z) ?? fallback.z;
+
+  let snapToGround = false;
+  let desiredY: LandmarkHeightMode | undefined = spec.y;
+
+  if (desiredY === 'ground') {
+    const sampled = sampleGround ? sampleGround(x, z, fallback.y) : undefined;
+    const finalY = toFiniteNumber(sampled) ?? fallback.y;
+    return {
+      position: new THREE.Vector3(x, finalY, z),
+      snapToGround: true
+    };
+  }
+
+  if (desiredY === 'acropolis') {
+    const plateau = toFiniteNumber(plateauHeight);
+    const finalY = plateau ?? fallback.y;
+    return {
+      position: new THREE.Vector3(x, finalY, z),
+      snapToGround: false
+    };
+  }
+
+  const numericY = toFiniteNumber(desiredY);
+  const finalY = numericY ?? fallback.y;
+
+  return {
+    position: new THREE.Vector3(x, finalY, z),
+    snapToGround
+  };
+}
+
+export type GroundSampler = (x: number, z: number, fallbackY: number) => number | null | undefined;
+
+export interface LandmarkLayoutResolverOptions {
+  layout?: string | null;
+  layoutConfig?: Record<string, unknown> | null;
+  plateauHeight?: number | null | undefined;
+  sampleGround?: GroundSampler | null;
+}
+
+export interface LandmarkResolution {
+  position: THREE.Vector3;
+  snapToGround: boolean;
+  layoutUsed: boolean;
+  overrideUsed: boolean;
+}
+
+export type LandmarkLayoutResolver = (
+  key: string,
+  fallback?: THREE.Vector3 | { x?: number; y?: number; z?: number } | null
+) => LandmarkResolution;
+
+export function createLandmarkLayoutResolver(options: LandmarkLayoutResolverOptions = {}): LandmarkLayoutResolver {
+  const layoutKey = typeof options.layout === 'string' && options.layout ? options.layout : 'classic';
+  const layoutPreset = LANDMARK_LAYOUTS[layoutKey] ?? null;
+  const layoutConfig = options.layoutConfig && typeof options.layoutConfig === 'object' ? options.layoutConfig : {};
+  const positionOverrides =
+    layoutConfig && typeof layoutConfig === 'object' && layoutConfig.positions && typeof (layoutConfig as any).positions === 'object'
+      ? (layoutConfig as { positions: Record<string, unknown> }).positions
+      : null;
+
+  return (key, fallback) => {
+    const fallbackVec = fallback instanceof THREE.Vector3
+      ? fallback.clone()
+      : new THREE.Vector3(
+          toFiniteNumber((fallback as any)?.x) ?? 0,
+          toFiniteNumber((fallback as any)?.y) ?? 0,
+          toFiniteNumber((fallback as any)?.z) ?? 0
+        );
+
+    let spec: LandmarkPositionSpec = { x: fallbackVec.x, y: fallbackVec.y, z: fallbackVec.z };
+    let layoutUsed = false;
+    let overrideUsed = false;
+
+    if (layoutPreset && layoutPreset[key]) {
+      spec = mergeSpec(spec, layoutPreset[key]);
+      layoutUsed = true;
+    }
+
+    if (layoutConfig && Object.prototype.hasOwnProperty.call(layoutConfig, key)) {
+      const direct = (layoutConfig as Record<string, unknown>)[key];
+      spec = mergeSpec(spec, direct);
+      overrideUsed = true;
+    }
+
+    if (positionOverrides && Object.prototype.hasOwnProperty.call(positionOverrides, key)) {
+      const override = positionOverrides[key];
+      spec = mergeSpec(spec, override);
+      overrideUsed = true;
+    }
+
+    const resolved = resolveSpec(spec, fallbackVec, {
+      sampleGround: options.sampleGround,
+      plateauHeight: options.plateauHeight
+    });
+
+    return {
+      ...resolved,
+      layoutUsed,
+      overrideUsed
+    };
+  };
+}
+
+export function getLandmarkKeysForLayout(layout?: string | null): string[] {
+  const layoutKey = typeof layout === 'string' && layout ? layout : 'classic';
+  const preset = LANDMARK_LAYOUTS[layoutKey];
+  if (!preset) {
+    return [];
+  }
+  return Object.keys(preset);
+}

--- a/src/dev/landmarkPlacer.js
+++ b/src/dev/landmarkPlacer.js
@@ -1,15 +1,8 @@
 // PLACER_START
 import * as THREE from 'three';
+import { KNOWN_LANDMARK_KEYS } from '../config/landmarkLayout.ts';
 
-const DEFAULT_LANDMARKS = [
-  'Agora',
-  'Stoa_of_Attalos',
-  'Tholos',
-  'Theater_of_Dionysus',
-  'Stadium',
-  'CityGate_South',
-  'Port_Quay_A'
-];
+const DEFAULT_LANDMARKS = [...KNOWN_LANDMARK_KEYS];
 
 const KEY_BINDINGS = {
   next: { key: ']', code: 'BracketRight' },

--- a/src/entry/initializeAthens.js
+++ b/src/entry/initializeAthens.js
@@ -30,6 +30,12 @@ import { loadGrassMaterial } from '../materials/groundGrass.js';
 import { buildNavMeshFromMeshes } from '../navmesh/buildNavMesh.js';
 import { createNavMeshPathfinder } from '../navmesh/pathfinder.js';
 import {
+  LANDMARK_ALIASES,
+  KNOWN_LANDMARK_KEYS,
+  createLandmarkLayoutResolver,
+  getLandmarkKeysForLayout
+} from '../config/landmarkLayout.ts';
+import {
   DEFAULT_CAMERA,
   DEFAULT_PLAYER,
   finiteNumber,
@@ -133,81 +139,103 @@ function __enforceMainCharacterHeight(scene, options) {
 // CHAR_MAIN_HEIGHT_END
 
 // LANDMARK_SPREAD_START
-const _LANDMARK_MATCH = {
-  Agora:            ['Agora','AgoraGroup'],
-  Stoa_of_Attalos:  ['Stoa_of_Attalos','Stoa','StoaAttalos'],
-  Tholos:           ['Tholos'],
-  Theater_of_Dionysus: ['Theater_of_Dionysus','Theatre_of_Dionysus','Theater','Theatre'],
-  Stadium:          ['Stadium','Stadion'],
-  CityGate_South:   ['CityGate_South','CityGate','SouthGate','Gate_South'],
-  Port_Quay_A:      ['Port_Quay_A','Port','Harbor','Harbour','Quay']
-};
+const _TMP_WORLD = new THREE.Vector3();
+const _TMP_LOCAL = new THREE.Vector3();
+const _TMP_GROUND = new THREE.Vector3();
 
-const _SPREAD_DEFAULTS = {
-  // spread with clear separation, tweak freely later
-  Agora:                 { x:    0, y: 'ground', z:    0 },
-  Stoa_of_Attalos:       { x:  220, y: 'ground', z:   40 },
-  Tholos:                { x: -220, y: 'ground', z:  -20 },
-  Theater_of_Dionysus:   { x:  180, y: 'ground', z:  260 },
-  Stadium:               { x: -180, y: 'ground', z: -260 },
-  CityGate_South:        { x:   40, y: 'ground', z: -520 },
-  Port_Quay_A:           { x:   80, y: 'ground', z: -900 }
-};
-
-function _findByNames(scene, names) {
-  // try exact first
-  for (const n of names) {
-    const hit = scene.getObjectByName(n);
-    if (hit) return hit;
+function _setWorldPosition(object, x, y, z) {
+  if (!object?.isObject3D) return false;
+  object.updateMatrixWorld(true);
+  const parent = object.parent;
+  if (parent?.isObject3D) {
+    parent.updateMatrixWorld(true);
+    _TMP_LOCAL.set(x, y, z);
+    object.position.copy(parent.worldToLocal(_TMP_LOCAL));
+  } else {
+    object.position.set(x, y, z);
   }
-  // then case-insensitive / fuzzy
-  const lowers = names.map(n => n.toLowerCase());
-  let best = null;
-  scene.traverse(o => {
-    if (!o || !o.name) return;
-    const nm = o.name.toLowerCase();
-    for (const needle of lowers) {
-      if (nm === needle || nm.includes(needle)) { best = best || o; break; }
-    }
-  });
-  return best;
+  object.updateMatrixWorld(true);
+  return true;
 }
 
-function _groundYAt(pos, fallbackY) {
+function _findLandmarkObject(scene, key) {
+  if (!scene) return null;
+  const aliases = LANDMARK_ALIASES[key] || [key];
+  for (const name of aliases) {
+    const exact = scene.getObjectByName(name);
+    if (exact) return exact;
+  }
+  const lowered = aliases.map((name) => String(name).toLowerCase());
+  let fallback = null;
+  scene.traverse((obj) => {
+    if (fallback || !obj?.name) return;
+    const candidate = obj.name.toLowerCase();
+    for (const needle of lowered) {
+      if (candidate === needle || candidate.includes(needle)) {
+        fallback = obj;
+        break;
+      }
+    }
+  });
+  return fallback;
+}
+
+function _sampleSceneGround(x, z, fallbackY) {
+  const baseY = Number.isFinite(fallbackY) ? fallbackY : 0;
   try {
     if (typeof raycastGroundY === 'function') {
-      const gy = raycastGroundY(pos);
-      if (Number.isFinite(gy)) return gy;
+      _TMP_GROUND.set(x, baseY, z);
+      const gy = raycastGroundY(_TMP_GROUND);
+      if (Number.isFinite(gy)) {
+        return gy;
+      }
     }
   } catch {}
   return fallbackY;
 }
 
-function _applyLandmarkSpread(scene, options, {force=false} = {}) {
-  // Only act when explicitly requested, or when options.layout === 'athensPlan'
-  const shouldRun = force || options?.layout === 'athensPlan';
-  if (!shouldRun) return;
+function _applyLandmarkLayout(scene, options, keys, { label = 'Landmarks' } = {}) {
+  if (!scene || !Array.isArray(keys) || keys.length === 0) {
+    return {};
+  }
 
-  const overrides = options?.layoutConfig?.positions || {};
+  const resolver = createLandmarkLayoutResolver({
+    layout: options?.layout,
+    layoutConfig: options?.layoutConfig,
+    plateauHeight: options?.layoutConfig?.plateauHeight,
+    sampleGround: _sampleSceneGround
+  });
+
   const results = {};
-
-  for (const key of Object.keys(_LANDMARK_MATCH)) {
-    const target = _findByNames(scene, _LANDMARK_MATCH[key]);
-    if (!target) { results[key] = 'not-found'; continue; }
-
-    const src = overrides[key] ?? _SPREAD_DEFAULTS[key];
-    if (!src) { results[key] = 'no-default'; continue; }
-
-    // determine desired y
-    const wp = target.getWorldPosition(new THREE.Vector3());
-    let y = (src.y === 'ground') ? _groundYAt(new THREE.Vector3(src.x ?? wp.x, wp.y, src.z ?? wp.z), wp.y)
-                                 : (Number.isFinite(src.y) ? src.y : wp.y);
-
-    const ok = _setWorldPosition(target, src.x ?? wp.x, y, src.z ?? wp.z);
+  for (const key of keys) {
+    const target = _findLandmarkObject(scene, key);
+    if (!target) {
+      results[key] = 'not-found';
+      continue;
+    }
+    const fallback = target.getWorldPosition(_TMP_WORLD.set(0, 0, 0));
+    const { position } = resolver(key, fallback);
+    const ok = _setWorldPosition(target, position.x, position.y, position.z);
     results[key] = ok ? 'moved' : 'failed';
   }
 
-  try { logger.info('[LandmarkSpread]', results); } catch {}
+  try { logger.info(`[${label}]`, results); } catch {}
+  return results;
+}
+
+function _applyLandmarkSpread(scene, options, { force = false } = {}) {
+  const shouldRun = force || options?.layout === 'athensPlan';
+  if (!shouldRun) return;
+
+  const keys = new Set();
+  getLandmarkKeysForLayout(options?.layout).forEach((key) => keys.add(key));
+  const overrides = options?.layoutConfig?.positions;
+  if (overrides && typeof overrides === 'object') {
+    Object.keys(overrides).forEach((key) => keys.add(key));
+  }
+  KNOWN_LANDMARK_KEYS.forEach((key) => keys.add(key));
+
+  _applyLandmarkLayout(scene, options, [...keys], { label: 'LandmarkSpread' });
 }
 
 function _installLandmarkDev(scene, options) {
@@ -770,37 +798,6 @@ export async function initializeAthens(options = {}) {
   _installLandmarkDev(scene, options);
   // LANDMARK_SPREAD_END
 
-  // LANDMARK_OVERRIDE_START
-  (function applyAgoraOverride(scene, options) {
-    const p = options?.layoutConfig?.positions?.Agora;
-    if (!p) return;
-    function get(name) {
-      return scene.getObjectByName(name);
-    }
-    function setWorldPosition(obj, x, y, z) {
-      if (!obj) return false;
-      obj.updateMatrixWorld(true);
-      const parent = obj.parent;
-      if (parent) {
-        parent.updateMatrixWorld(true);
-        const v = new THREE.Vector3(x, y, z);
-        obj.position.copy(parent.worldToLocal(v));
-      } else {
-        obj.position.set(x, y, z);
-      }
-      obj.updateMatrixWorld(true);
-      return true;
-    }
-    const agora = get('AgoraGroup') || get('Agora');
-    if (agora) {
-      setWorldPosition(agora, p.x, p.y, p.z);
-      logger.info('[LandmarkOverride] Agora ->', p);
-    } else {
-      logger.warn('[LandmarkOverride] Agora object not found');
-    }
-  })(scene, options);
-  // LANDMARK_OVERRIDE_END
-
   // Grass material application for main ground
   if (!hasLayeredGround) {
     const mainGround = city?.root?.getObjectByName?.('Ground:MainGrass');
@@ -843,15 +840,7 @@ export async function initializeAthens(options = {}) {
     logger.warn('[npc] no ground meshes');
   }
   // PLACER_START
-  const landmarkSequence = [
-    'Agora',
-    'Stoa_of_Attalos',
-    'Tholos',
-    'Theater_of_Dionysus',
-    'Stadium',
-    'CityGate_South',
-    'Port_Quay_A'
-  ];
+  const landmarkSequence = [...KNOWN_LANDMARK_KEYS];
   const devLandmarkOptions = options?.dev?.landmarkPlacer;
   const shouldAttachLandmarkPlacer = devLandmarkOptions !== false;
   let landmarkPlacer = null;
@@ -1602,36 +1591,14 @@ export async function initializeAthens(options = {}) {
 }
 
 // LANDMARK_OVERRIDE_START
-function _findByNameCI(scene, name){
-  const target = name.toLowerCase();
-  let hit = scene.getObjectByName(name);
-  if (hit) return hit;
-  let fallback = null;
-  scene.traverse(obj => {
-    if (!obj || !obj.name) return;
-    const n = obj.name.toLowerCase();
-    if (n === target) { hit = obj; }
-    else if (!fallback && n.includes(target)) { fallback = obj; }
-  });
-  return hit || fallback;
-}
-
 function _applyLandmarkOverrides(scene, options){
-  const pos = options?.layoutConfig?.positions;
-  if (!pos) return;
+  const overrides = options?.layoutConfig?.positions;
+  if (!overrides || typeof overrides !== 'object') return;
 
-  const log = (...args)=>{ try{ logger.info('[LandmarkOverride]', ...args); }catch{} }
+  const keys = Object.keys(overrides);
+  if (!keys.length) return;
 
-  // AGORA override only (expand later)
-  if (pos.Agora && Number.isFinite(pos.Agora.x) && Number.isFinite(pos.Agora.y) && Number.isFinite(pos.Agora.z)) {
-    const agora = _findByNameCI(scene, 'Agora');
-    if (!agora) {
-      log('Agora not found in scene graph; available top-level children:', scene.children.map(c=>c.name).filter(Boolean));
-    } else {
-      const ok = _setWorldPosition(agora, pos.Agora.x, pos.Agora.y, pos.Agora.z);
-      log('Applied Agora override to', agora.name, '->', pos.Agora, 'success:', ok);
-    }
-  }
+  _applyLandmarkLayout(scene, options, keys, { label: 'LandmarkOverride' });
 }
 // LANDMARK_OVERRIDE_END
 


### PR DESCRIPTION
## Summary
- extract a shared landmark layout configuration module with alias metadata and layout resolver helpers
- update city construction, runtime landmark adjustments, and dev tooling to rely on the shared resolver for consistent overrides
- re-export the shared layout utilities from the extended city module for downstream consumers

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68dc9a5f639883279a3c8ec8d2c5a620