### PR TITLE
Avoid handling non-GET requests in service worker

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -38,9 +38,12 @@ self.addEventListener('fetch', (event) => {
   const url = new URL(req.url);
   const isSameOrigin = url.origin === self.location.origin;
 
-  // Only cache same-origin GET requests. Pass others straight through (safely).
+  // Only handle same-origin GET requests. Others should be left to the
+  // browser's default network handling. Responding to cross-origin or
+  // non-GET requests can trigger "Failed to convert value to 'Response'"
+  // errors in some browsers because the response must comply with stricter
+  // mode/type requirements (e.g. opaque responses for no-cors fetches).
   if (req.method !== 'GET' || !isSameOrigin) {
-    event.respondWith(safeNetwork(req));
     return;
   }
 


### PR DESCRIPTION
## Summary
- update the service worker fetch handler to only intercept same-origin GET requests
- avoid responding to cross-origin or non-GET fetches which triggered Response conversion errors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68dc9d2151388327b5a1c667e00ad132