### PR TITLE
Fix tree and main character ground alignment

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,6 @@
 import { loadGround } from './scene/ground.js';
 import { loadTreeLibrary, scatterTrees, updateTrees as updateTreeAnimations } from './vegetation/trees.js';
+import { groundYAt } from './utils/spawn.ts';
 import { getAssetBase } from './utils/asset-paths.js';
 import { logger } from './utils/logger.ts';
 
@@ -49,7 +50,16 @@ let treesInitialized = false;
 
 // If your main branch had extra tree setup inside setupGround, you can merge it
 // below after the ground is created. For now we keep the original ground setup:
-async function ensureTrees(scene, renderer) {
+function collectGroundTargets(groundLayers) {
+  if (!groundLayers || typeof groundLayers !== 'object') {
+    return [];
+  }
+
+  const { root, dirt, grass, foundationBlend, tilesRoot } = groundLayers;
+  return [root, dirt, grass, foundationBlend, tilesRoot].filter(Boolean);
+}
+
+async function ensureTrees(scene, renderer, groundLayers = null) {
   if (treesInitialized) {
     if (scene && groveGroup && !scene.children.includes(groveGroup)) {
       scene.add(groveGroup);
@@ -59,11 +69,20 @@ async function ensureTrees(scene, renderer) {
 
   try {
     treeLibraryState = await loadTreeLibrary(renderer);
+    const groundTargets = collectGroundTargets(groundLayers);
+    const heightFn = groundTargets.length
+      ? (x, z) => {
+          const height = groundYAt(x, z, groundTargets);
+          return Number.isFinite(height) ? height : 0;
+        }
+      : undefined;
+
     groveGroup = scatterTrees({
       name: 'olive',
       area: { xMin: -500, xMax: 500, zMin: -500, zMax: 500 },
       count: 100,
-      minDist: 7
+      minDist: 7,
+      heightFn
     });
 
     if (scene && groveGroup && !scene.children.includes(groveGroup)) {
@@ -80,7 +99,7 @@ async function ensureTrees(scene, renderer) {
 export async function setupGround(scene, renderer) {
   const ground = await loadGround(scene, renderer, groundOptions);
 
-  await ensureTrees(scene, renderer);
+  await ensureTrees(scene, renderer, ground);
   return ground;
 }
 

--- a/src/npc/npcSystem.js
+++ b/src/npc/npcSystem.js
@@ -415,6 +415,17 @@ function attachModelToNpc(npc, model) {
     enableMeshShadows(model);
     fixModelTilt(model);
     object3d.add(model);
+
+    ensureFeetAtLocalZero(model);
+    object3d.updateMatrixWorld(true);
+
+    const groundTarget = npc.groundTarget || null;
+    if (groundTarget) {
+      placeOnGround(object3d, groundTarget, { clearance: GROUND_CLEARANCE, rayStart: SNAP_OPTIONS.rayStart });
+      if (npc.state && typeof npc.state === 'object') {
+        npc.state.lastGoodY = (object3d.position.y || 0) - GROUND_CLEARANCE;
+      }
+    }
   }
 }
 
@@ -556,7 +567,8 @@ function createNpcEntity(config = {}, { scene = null, navContext = null, groundM
     scheduleTarget: null,
     navContext: navContext || null,
     blockedTimer: 0,
-    lastProgress: object3d.position.clone()
+    lastProgress: object3d.position.clone(),
+    groundTarget
   };
 
   if (sanitizedWaypoints.length > 1) {


### PR DESCRIPTION
## Summary
- align scattered trees with the sampled ground height when planting groves
- re-snap NPC models, including the main character, so their feet sit on the ground after loading

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68dc9dc1b66883278bdf371a524fb1de