### PR TITLE
Defer main character height scaling until model ready

### DIFF
--- a/src/entry/initializeAthens.js
+++ b/src/entry/initializeAthens.js
@@ -1142,7 +1142,20 @@ export async function initializeAthens(options = {}) {
   }
 
   // CHAR_MAIN_HEIGHT_START
-  __enforceMainCharacterHeight(scene, options);
+  const enforceMainCharacterHeight = () => __enforceMainCharacterHeight(scene, options);
+  const readyPromise = mainCharacter?.ready;
+  if (readyPromise && typeof readyPromise.then === 'function') {
+    readyPromise
+      .then(() => {
+        enforceMainCharacterHeight();
+      })
+      .catch((error) => {
+        logger.warn('[Athens][MainCharacter] Failed to load character before enforcing height.', error);
+        enforceMainCharacterHeight();
+      });
+  } else {
+    enforceMainCharacterHeight();
+  }
   // CHAR_MAIN_HEIGHT_END
 
   const flyBypassFallbackPosition = new THREE.Vector3();


### PR DESCRIPTION
## Summary
- defer applying the main character height adjustments until after the character model finishes loading
- log a warning and fall back to the previous behaviour if the model fails to load

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68dca11f7aac832785b054690708acb2