### PR TITLE
Ensure debug globals only initialized once

### DIFF
--- a/src/audio/ambient.ts
+++ b/src/audio/ambient.ts
@@ -171,10 +171,10 @@ export async function initAmbient(camera: THREE.Camera) {
   if (!camera) return;
   attachAudioListenerTo(camera);
   if (typeof window !== 'undefined') {
-    (window as any).__athensDebug = {
-      ...(window as any).__athensDebug,
-      audio: { AMBIENT_TRACKS }
-    };
+    const debug = (window as any).__athensDebug;
+    if (debug && typeof debug === 'object') {
+      debug.audio = { AMBIENT_TRACKS };
+    }
   }
 
   if (!AMBIENT_TRACKS.length) {

--- a/src/entry/initializeAthens.js
+++ b/src/entry/initializeAthens.js
@@ -1,6 +1,5 @@
 import * as THREE from 'three';
 import { installRenderGuard } from '../safety/hardenPositions';
-if (typeof window !== 'undefined') window.THREE = THREE; // for console/puppeteer debug only
 import { createStats } from '../debug/statsShim.js';
 import { logger } from '../utils/logger.ts';
 import { setupGround, updateTrees } from '../main.js';
@@ -646,25 +645,21 @@ export async function initializeAthens(options = {}) {
   let searchParams = null;
   if (typeof window !== 'undefined') {
     globalWindow = window;
-    globalWindow.THREE = THREE;
-    const existingDebug =
-      globalWindow.__athensDebug && typeof globalWindow.__athensDebug === 'object'
-        ? globalWindow.__athensDebug
-        : {};
-    globalWindow.__athensDebug = { ...existingDebug, scene, camera, renderer };
     searchParams = new URLSearchParams(globalWindow.location.search);
-    if (searchParams.get('headlessSmoke') === '1') {
-      globalWindow.__athensDebug = { scene, camera, renderer };
-    }
   }
 
   await initAmbient(camera);
 
   if (globalWindow) {
-    globalWindow.__athensDebug = {
-      ...(globalWindow.__athensDebug || {}),
-      audioAPI: AmbientAPI
-    };
+    const existingDebug =
+      globalWindow.__athensDebug && typeof globalWindow.__athensDebug === 'object'
+        ? globalWindow.__athensDebug
+        : {};
+    const headlessSmoke = searchParams?.get('headlessSmoke') === '1';
+    globalWindow.THREE = THREE;
+    globalWindow.__athensDebug = headlessSmoke
+      ? { scene, camera, renderer }
+      : { ...existingDebug, scene, camera, renderer, audioAPI: AmbientAPI };
   }
 
   try {

--- a/src/scene/sky.ts
+++ b/src/scene/sky.ts
@@ -189,10 +189,10 @@ export async function applySky(
       pmrem.dispose();
 
       if (typeof window !== 'undefined') {
-        (window as typeof window & { __athensDebug?: any }).__athensDebug = {
-          ...(window as typeof window & { __athensDebug?: any }).__athensDebug,
-          sky: { type: 'cube', id: pick.id, files: order }
-        };
+        const debug = (window as typeof window & { __athensDebug?: any }).__athensDebug;
+        if (debug && typeof debug === 'object') {
+          debug.sky = { type: 'cube', id: pick.id, files: order };
+        }
       }
     } else if (pick.type === 'equirect' && pick.file) {
       const loader = new THREE.TextureLoader();
@@ -214,10 +214,10 @@ export async function applySky(
       pmrem.dispose();
 
       if (typeof window !== 'undefined') {
-        (window as typeof window & { __athensDebug?: any }).__athensDebug = {
-          ...(window as typeof window & { __athensDebug?: any }).__athensDebug,
-          sky: { type: 'equirect', id: pick.id, file: url }
-        };
+        const debug = (window as typeof window & { __athensDebug?: any }).__athensDebug;
+        if (debug && typeof debug === 'object') {
+          debug.sky = { type: 'equirect', id: pick.id, file: url };
+        }
       }
     } else {
       logger.warn(


### PR DESCRIPTION
## Summary
- initialize Athens globals once after ambient setup, preserving audio API exposure
- adjust sky and ambient modules to annotate debug data without reassigning the debug object

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68dca3bc5fd08327b13802234ec39702