### PR TITLE
Guard debug console output behind dev flag

### DIFF
--- a/src/utils/disposable.ts
+++ b/src/utils/disposable.ts
@@ -75,10 +75,8 @@ function disposeMaterial(material: THREE.Material, seen: SeenSet): void {
   try {
     material.dispose();
   } catch (error) {
-    if (typeof process !== 'undefined' && process?.env?.NODE_ENV !== 'production') {
-      // eslint-disable-next-line no-console
-      console.warn('[disposeAll] Failed to dispose material', material, error);
-    }
+    // eslint-disable-next-line no-console
+    if (import.meta.env.DEV) console.warn('[disposeAll] Failed to dispose material', material, error);
   }
 }
 
@@ -130,10 +128,8 @@ function disposeUnknown(item: DisposableItem | any, seen: SeenSet): void {
     try {
       item.dispose();
     } catch (error) {
-      if (typeof process !== 'undefined' && process?.env?.NODE_ENV !== 'production') {
-        // eslint-disable-next-line no-console
-        console.warn('[disposeAll] Failed to dispose texture', item, error);
-      }
+      // eslint-disable-next-line no-console
+      if (import.meta.env.DEV) console.warn('[disposeAll] Failed to dispose texture', item, error);
     }
     return;
   }
@@ -143,10 +139,8 @@ function disposeUnknown(item: DisposableItem | any, seen: SeenSet): void {
     try {
       item.dispose();
     } catch (error) {
-      if (typeof process !== 'undefined' && process?.env?.NODE_ENV !== 'production') {
-        // eslint-disable-next-line no-console
-        console.warn('[disposeAll] Failed to dispose geometry', item, error);
-      }
+      // eslint-disable-next-line no-console
+      if (import.meta.env.DEV) console.warn('[disposeAll] Failed to dispose geometry', item, error);
     }
     return;
   }
@@ -156,10 +150,8 @@ function disposeUnknown(item: DisposableItem | any, seen: SeenSet): void {
     try {
       item.dispose();
     } catch (error) {
-      if (typeof process !== 'undefined' && process?.env?.NODE_ENV !== 'production') {
-        // eslint-disable-next-line no-console
-        console.warn('[disposeAll] Failed to dispose resource', item, error);
-      }
+      // eslint-disable-next-line no-console
+      if (import.meta.env.DEV) console.warn('[disposeAll] Failed to dispose resource', item, error);
     }
     return;
   }

--- a/src/utils/fail-soft-loaders.js
+++ b/src/utils/fail-soft-loaders.js
@@ -69,14 +69,7 @@ export function applyLoadedTexture(
     try {
       fallbackTex.dispose?.();
     } catch (error) {
-      if (
-        typeof process !== 'undefined' &&
-        process?.env?.NODE_ENV !== 'production' &&
-        typeof console !== 'undefined' &&
-        typeof console.debug === 'function'
-      ) {
-        console.debug('[asset-loader] dispose fallback failed', error);
-      }
+      if (import.meta.env.DEV) console.debug?.('[asset-loader] dispose fallback failed', error);
     }
   }
 }
@@ -156,14 +149,7 @@ function loadTextureWithFallback(url, options = {}) {
             fallbackTexture: texture
           });
         }
-        if (
-          typeof process !== 'undefined' &&
-          process?.env?.NODE_ENV !== 'production' &&
-          typeof console !== 'undefined' &&
-          typeof console.debug === 'function'
-        ) {
-          console.debug(`[asset-loader] applied texture ${label}`);
-        }
+        if (import.meta.env.DEV) console.debug?.(`[asset-loader] applied texture ${label}`);
       } catch (error) {
         logger.warn(
           `[asset-loader] Texture post-processing failed for ${label} at ${url}; retaining fallback.`,


### PR DESCRIPTION
## Summary
- gate disposable cleanup warnings behind import.meta.env.DEV to keep production console quiet
- guard asset-loader debug messages with the same dev flag while retaining optional chaining safety

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68dcaa649e088327a9d365e987ed3f40