### PR TITLE
fix: ensure auto sky override uses applied environment mode

### DIFF
--- a/src/entry/initializeAthens.js
+++ b/src/entry/initializeAthens.js
@@ -629,10 +629,10 @@ export async function initializeAthens(options = {}) {
   }
 
   try {
-    await environmentManager.applySky('day');
+    const appliedSkyMode = (await environmentManager.applySky('day')) || 'day';
     environmentManager.setMode('procedural');
     try {
-      const currentMode = environmentManager?.skyMode || 'day';
+      const currentMode = environmentManager?.skyMode || appliedSkyMode || 'day';
       const match = (SKY_JPGS || []).find((i) =>
         (i.tags || []).some((t) => t.toLowerCase() === String(currentMode).toLowerCase())
       );

--- a/src/environment/EnvironmentController.ts
+++ b/src/environment/EnvironmentController.ts
@@ -2,13 +2,14 @@ import * as THREE from 'three';
 import { applySky } from '../scene/sky.ts';
 import { disposeAll } from '../utils/disposable.ts';
 
-export type SkyMode = 'procedural';
+export type SkyMode = 'procedural' | string;
 
 export class EnvironmentController {
   private readonly scene: THREE.Scene;
   private readonly renderer: THREE.WebGLRenderer;
   private disposed = false;
   private currentSkyMode: SkyMode = 'procedural';
+  private lastAppliedSkyId: string | null = null;
 
   constructor(scene: THREE.Scene, renderer: THREE.WebGLRenderer) {
     this.scene = scene;
@@ -16,14 +17,18 @@ export class EnvironmentController {
   }
 
   get skyMode(): SkyMode {
-    return this.currentSkyMode;
+    return (this.lastAppliedSkyId ?? this.currentSkyMode) as SkyMode;
   }
 
-  async applySky(choice?: string) {
+  async applySky(choice?: string): Promise<string | null> {
     if (this.disposed) {
       return null;
     }
-    return applySky(this.scene, this.renderer, choice);
+    const appliedId = await applySky(this.scene, this.renderer, choice);
+    if (appliedId) {
+      this.lastAppliedSkyId = appliedId;
+    }
+    return appliedId;
   }
 
   setMode(mode: SkyMode): void {

--- a/src/environment/EnvironmentController.ts
+++ b/src/environment/EnvironmentController.ts
@@ -42,6 +42,8 @@ export class EnvironmentController {
   dispose(): void {
     if (this.disposed) return;
     this.disposed = true;
+    this.currentSkyMode = 'procedural';
+    this.lastAppliedSkyId = null;
     const environment = this.scene.environment as THREE.Texture | null;
     const background = this.scene.background;
     const backgroundTexture =

--- a/src/environment/EnvironmentController.ts
+++ b/src/environment/EnvironmentController.ts
@@ -25,9 +25,7 @@ export class EnvironmentController {
       return null;
     }
     const appliedId = await applySky(this.scene, this.renderer, choice);
-    if (appliedId) {
-      this.lastAppliedSkyId = appliedId;
-    }
+    this.lastAppliedSkyId = appliedId ?? null;
     return appliedId;
   }
 
@@ -36,6 +34,9 @@ export class EnvironmentController {
       return;
     }
     this.currentSkyMode = mode;
+    if (mode === 'procedural') {
+      this.lastAppliedSkyId = null;
+    }
   }
 
   dispose(): void {

--- a/src/scene/sky.ts
+++ b/src/scene/sky.ts
@@ -135,7 +135,7 @@ export async function applySky(
   scene: THREE.Scene,
   renderer: THREE.WebGLRenderer,
   choice?: string
-) {
+): Promise<string | null> {
   setRendererColorSpace(renderer);
 
   const previousBackground = scene.background as THREE.Texture | THREE.Color | null;
@@ -159,8 +159,10 @@ export async function applySky(
 
   if (!pick) {
     logger.warn('[sky] No sky choices found.');
-    return;
+    return null;
   }
+
+  let appliedId: string | null = null;
 
   try {
     if (pick.type === 'cube' && pick.dir && pick.faces) {
@@ -194,6 +196,7 @@ export async function applySky(
           debug.sky = { type: 'cube', id: pick.id, files: order };
         }
       }
+      appliedId = pick.id;
     } else if (pick.type === 'equirect' && pick.file) {
       const loader = new THREE.TextureLoader();
       const url = resolveSkyPath(pick.file);
@@ -219,14 +222,16 @@ export async function applySky(
           debug.sky = { type: 'equirect', id: pick.id, file: url };
         }
       }
+      appliedId = pick.id;
     } else {
       logger.warn(
         `[sky] Choice "${pick.id}" is missing required properties for type "${pick.type}".`
       );
-      return;
+      return null;
     }
   } catch (error) {
     logger.warn('[sky] Failed to apply sky environment.', error);
+    return null;
   } finally {
     // Dispose the previous background texture if it was replaced
     if (previousBackground && previousBackground !== scene.background) {
@@ -237,4 +242,6 @@ export async function applySky(
       }
     }
   }
+
+  return appliedId;
 }


### PR DESCRIPTION
## Summary
- record the applied sky identifier so overrides can inspect the latest environment selection
- return the applied sky id from the sky helper and use it when matching discovered JPG assets

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68dcbd97a2f083278763a6ee7ef0b4cd