### PR TITLE
Remove global Node preload configuration

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-node-options=--require=./scripts/register-require.cjs

--- a/scripts/register-require.cjs
+++ b/scripts/register-require.cjs
@@ -1,4 +1,0 @@
-const { createRequire } = require('module');
-if (typeof globalThis.require !== 'function') {
-  globalThis.require = createRequire(process.cwd() + '/scripts/generate-sky-ground-assets.js');
-}


### PR DESCRIPTION
## Summary
- delete the obsolete scripts/register-require.cjs preload hook
- remove the corresponding .npmrc NODE_OPTIONS configuration to stop forcing --require

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68dcbf2bd1248327bb4d82d98368c990