### PR TITLE
Increase player movement speeds

### DIFF
--- a/src/config/movement.ts
+++ b/src/config/movement.ts
@@ -64,8 +64,8 @@ export const FLIGHT = {
 } as const;
 
 export const movementConfig: MovementConfig = {
-  walkSpeed: 4,
-  runMultiplier: 1.7,
+  walkSpeed: 8,
+  runMultiplier: 2,
   acceleration: 10,
   safePosition: { x: 0, y: 1, z: 0 },
   character: {


### PR DESCRIPTION
## Summary
- double the default walking speed to make traversal faster
- raise the running multiplier so the sprint key provides a more noticeable boost

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68dce4fba2ec832792030cc6b46d4a7c