### PR TITLE
feat: add structured hotkey manifest and keyboard action helpers

### DIFF
--- a/src/config/hotkeys.ts
+++ b/src/config/hotkeys.ts
@@ -1,0 +1,306 @@
+const HotkeyCategoryId = {
+  Movement: 'movement',
+  Look: 'look',
+  Flight: 'flight',
+  Debug: 'debug',
+  DevTools: 'devTools'
+} as const;
+
+type HotkeyCategory = (typeof HotkeyCategoryId)[keyof typeof HotkeyCategoryId];
+
+type ContinuousAxisId = 'x' | 'z' | 'lookX' | 'lookY' | 'turn';
+
+type HotkeyFallbackEntry = string | [string, string];
+
+type HotkeyActionInit = {
+  id: string;
+  title: string;
+  default: string;
+  aliasCodes?: string[];
+  fallback?: HotkeyFallbackEntry[];
+};
+
+type HotkeyActionDefinition = {
+  id: string;
+  title: string;
+  default: string;
+  aliasCodes: string[];
+  codes: string[];
+  fallback: [string, string][];
+  category: HotkeyCategory;
+};
+
+type AxisBinding =
+  | {
+      type: 'paired';
+      axis: ContinuousAxisId;
+      positive: string;
+      negative: string;
+      normalizeWith?: ContinuousAxisId[];
+    }
+  | {
+      type: 'binary';
+      axis: 'running';
+      actions: string[];
+    };
+
+const actionRegistry = new Map<string, HotkeyActionDefinition>();
+const actionCodes = new Map<string, string[]>();
+
+function createAction(
+  category: HotkeyCategory,
+  init: HotkeyActionInit
+): HotkeyActionDefinition {
+  const aliasCodes = Array.isArray(init.aliasCodes)
+    ? init.aliasCodes.filter((code, index, array) => typeof code === 'string' && array.indexOf(code) === index)
+    : [];
+  const codes = [init.default, ...aliasCodes].filter(
+    (code, index, array) => typeof code === 'string' && array.indexOf(code) === index
+  );
+  const fallbackEntries: [string, string][] = [];
+  if (Array.isArray(init.fallback)) {
+    for (const entry of init.fallback) {
+      if (Array.isArray(entry) && entry.length >= 2) {
+        const key = String(entry[0]).toLowerCase();
+        const mappedCode = typeof entry[1] === 'string' ? entry[1] : init.default;
+        if (key) {
+          fallbackEntries.push([key, mappedCode]);
+        }
+      } else if (typeof entry === 'string') {
+        fallbackEntries.push([entry.toLowerCase(), init.default]);
+      }
+    }
+  }
+
+  const definition: HotkeyActionDefinition = {
+    id: init.id,
+    title: init.title,
+    default: init.default,
+    aliasCodes,
+    codes,
+    fallback: fallbackEntries,
+    category
+  };
+
+  actionRegistry.set(definition.id, definition);
+  actionCodes.set(definition.id, definition.codes);
+
+  return definition;
+}
+
+const movementActions = {
+  moveForward: createAction(HotkeyCategoryId.Movement, {
+    id: 'movement.moveForward',
+    title: 'Move Forward',
+    default: 'KeyW',
+    fallback: ['w', 'z']
+  }),
+  moveBackward: createAction(HotkeyCategoryId.Movement, {
+    id: 'movement.moveBackward',
+    title: 'Move Backward',
+    default: 'KeyS',
+    fallback: ['s']
+  }),
+  moveLeft: createAction(HotkeyCategoryId.Movement, {
+    id: 'movement.moveLeft',
+    title: 'Move Left',
+    default: 'KeyA',
+    fallback: ['a', 'q']
+  }),
+  moveRight: createAction(HotkeyCategoryId.Movement, {
+    id: 'movement.moveRight',
+    title: 'Move Right',
+    default: 'KeyD',
+    fallback: ['d']
+  }),
+  run: createAction(HotkeyCategoryId.Movement, {
+    id: 'movement.run',
+    title: 'Run Modifier',
+    default: 'ShiftLeft',
+    aliasCodes: ['ShiftRight'],
+    fallback: ['shift']
+  })
+} as const;
+
+const lookActions = {
+  lookLeft: createAction(HotkeyCategoryId.Look, {
+    id: 'look.left',
+    title: 'Look Left',
+    default: 'ArrowLeft',
+    fallback: ['arrowleft']
+  }),
+  lookRight: createAction(HotkeyCategoryId.Look, {
+    id: 'look.right',
+    title: 'Look Right',
+    default: 'ArrowRight',
+    fallback: ['arrowright']
+  }),
+  lookUp: createAction(HotkeyCategoryId.Look, {
+    id: 'look.up',
+    title: 'Look Up',
+    default: 'ArrowUp',
+    fallback: ['arrowup']
+  }),
+  lookDown: createAction(HotkeyCategoryId.Look, {
+    id: 'look.down',
+    title: 'Look Down',
+    default: 'ArrowDown',
+    fallback: ['arrowdown']
+  })
+} as const;
+
+const flightActions = {
+  ascend: createAction(HotkeyCategoryId.Flight, {
+    id: 'flight.ascend',
+    title: 'Ascend',
+    default: 'Space',
+    aliasCodes: ['KeyE'],
+    fallback: [' ', 'space', 'spacebar', ['e', 'KeyE']]
+  }),
+  descend: createAction(HotkeyCategoryId.Flight, {
+    id: 'flight.descend',
+    title: 'Descend',
+    default: 'KeyQ',
+    aliasCodes: ['KeyC', 'ControlLeft', 'ControlRight'],
+    fallback: ['q', ['c', 'KeyC'], 'control', 'ctrl']
+  }),
+  toggle: createAction(HotkeyCategoryId.Flight, {
+    id: 'flight.toggle',
+    title: 'Toggle Flight',
+    default: 'KeyF',
+    aliasCodes: ['KeyX'],
+    fallback: ['f', ['x', 'KeyX']]
+  }),
+  nudgeUp: createAction(HotkeyCategoryId.Flight, {
+    id: 'flight.nudgeUp',
+    title: 'Flight Nudge Up',
+    default: 'KeyZ',
+    fallback: ['z']
+  })
+} as const;
+
+const debugActions = {
+  toggleInspector: createAction(HotkeyCategoryId.Debug, {
+    id: 'debug.toggleInspector',
+    title: 'Toggle Inspector',
+    default: 'KeyT',
+    fallback: ['t']
+  }),
+  toggleStats: createAction(HotkeyCategoryId.Debug, {
+    id: 'debug.toggleStats',
+    title: 'Toggle Stats Overlay',
+    default: 'KeyY',
+    fallback: ['y']
+  })
+} as const;
+
+const devToolActions = {
+  captureScreenshot: createAction(HotkeyCategoryId.DevTools, {
+    id: 'dev.captureScreenshot',
+    title: 'Capture Screenshot',
+    default: 'KeyP',
+    fallback: ['p']
+  })
+} as const;
+
+export const HOTKEY_MANIFEST = {
+  movement: movementActions,
+  look: lookActions,
+  flight: flightActions,
+  debug: debugActions,
+  devTools: devToolActions
+} as const;
+
+const relevantKeys = new Set<string>();
+for (const def of actionRegistry.values()) {
+  for (const code of def.codes) {
+    relevantKeys.add(code);
+  }
+}
+
+export const RELEVANT_KEYS = relevantKeys;
+
+const fallbackPairs: [string, string][] = [];
+for (const def of actionRegistry.values()) {
+  for (const entry of def.fallback) {
+    fallbackPairs.push(entry);
+  }
+}
+
+export const KEY_FALLBACK_MAP = new Map(fallbackPairs);
+
+export const ACTION_CODES = actionCodes;
+export const ACTION_REGISTRY = actionRegistry;
+
+export const HOTKEY_AXIS_METADATA: AxisBinding[] = [
+  {
+    type: 'paired',
+    axis: 'x',
+    positive: movementActions.moveRight.id,
+    negative: movementActions.moveLeft.id,
+    normalizeWith: ['z']
+  },
+  {
+    type: 'paired',
+    axis: 'z',
+    positive: movementActions.moveBackward.id,
+    negative: movementActions.moveForward.id,
+    normalizeWith: ['x']
+  },
+  {
+    type: 'paired',
+    axis: 'lookX',
+    positive: lookActions.lookRight.id,
+    negative: lookActions.lookLeft.id
+  },
+  {
+    type: 'paired',
+    axis: 'lookY',
+    positive: lookActions.lookUp.id,
+    negative: lookActions.lookDown.id
+  },
+  {
+    type: 'binary',
+    axis: 'running',
+    actions: [movementActions.run.id]
+  }
+];
+
+export const HOTKEY_IDS = Object.freeze({
+  movement: {
+    forward: movementActions.moveForward.id,
+    backward: movementActions.moveBackward.id,
+    left: movementActions.moveLeft.id,
+    right: movementActions.moveRight.id,
+    run: movementActions.run.id
+  },
+  look: {
+    left: lookActions.lookLeft.id,
+    right: lookActions.lookRight.id,
+    up: lookActions.lookUp.id,
+    down: lookActions.lookDown.id
+  },
+  flight: {
+    ascend: flightActions.ascend.id,
+    descend: flightActions.descend.id,
+    toggle: flightActions.toggle.id,
+    nudgeUp: flightActions.nudgeUp.id
+  },
+  debug: {
+    toggleInspector: debugActions.toggleInspector.id,
+    toggleStats: debugActions.toggleStats.id
+  },
+  devTools: {
+    captureScreenshot: devToolActions.captureScreenshot.id
+  }
+});
+
+export function getActionCodes(actionId: string): string[] {
+  return actionCodes.get(actionId) ?? [];
+}
+
+export function getActionDefinition(actionId: string): HotkeyActionDefinition | undefined {
+  return actionRegistry.get(actionId);
+}
+
+export type { HotkeyActionDefinition };

--- a/src/dev/flyBypass.js
+++ b/src/dev/flyBypass.js
@@ -1,3 +1,8 @@
+import { HOTKEY_IDS } from '../config/hotkeys.ts';
+
+const ASCEND_ACTION = HOTKEY_IDS.flight.ascend;
+const DESCEND_ACTION = HOTKEY_IDS.flight.descend;
+
 export function installFlyBypass({ state, input }){
   if (typeof window==='undefined') return;
   window.dev = window.dev || {};
@@ -10,8 +15,17 @@ export function installFlyBypass({ state, input }){
   return {
     tick(dt){
       if (!on) return;
-      const up   = input?.held?.('flyUp')   || input?.held?.('Space');
-      const down = input?.held?.('flyDown') || input?.held?.('ShiftLeft') || input?.held?.('ShiftRight');
+      const up =
+        input?.held?.(ASCEND_ACTION) ||
+        input?.held?.('flyUp') ||
+        input?.held?.('Space');
+      const down =
+        input?.held?.(DESCEND_ACTION) ||
+        input?.held?.('flyDown') ||
+        input?.held?.('ShiftLeft') ||
+        input?.held?.('ShiftRight') ||
+        input?.held?.('ControlLeft') ||
+        input?.held?.('ControlRight');
       const speed = 6;
       if (up)   state.position.y += speed * dt;
       if (down) state.position.y -= speed * dt;

--- a/src/entry/initializeAthens.js
+++ b/src/entry/initializeAthens.js
@@ -14,6 +14,7 @@ import { collectRoadPoints } from '../roads/collectRoadPoints.js';
 import { createNpcSystem } from '../npc/npcSystem.js';
 import { createMainCharacter } from '../npc/mainCharacter.js';
 import { createKeyboard } from '../input/keyboard.js';
+import { HOTKEY_IDS } from '../config/hotkeys.ts';
 import { createFollowCamera } from '../camera/followCamera.js';
 import { seedCameraBehindPlayer } from '../camera/seedCameraBehindPlayer.js';
 import { createPlayerController } from '../player/playerController.js';
@@ -1534,26 +1535,59 @@ if (readyPromise && typeof readyPromise.then === 'function') {
   const gameLoop = createGameLoop(updateFrame, renderFrame);
   registerDisposables(gameLoop);
 
+  const flyBypassAscendAliases = new Set([
+    HOTKEY_IDS.flight.ascend,
+    'flyUp',
+    'Space',
+    'KeyE'
+  ]);
+  const flyBypassDescendAliases = new Set([
+    HOTKEY_IDS.flight.descend,
+    'flyDown',
+    'ShiftLeft',
+    'ShiftRight',
+    'ControlLeft',
+    'ControlRight',
+    'KeyQ',
+    'KeyC'
+  ]);
+
   const flyBypassInput = {
-    held(code) {
-      if (!keyboard || typeof keyboard.isDown !== 'function') {
+    held(identifier) {
+      if (!keyboard) {
         return false;
       }
-      switch (code) {
-        case 'flyUp':
-          return keyboard.isDown('Space') || keyboard.isDown('KeyE');
-        case 'flyDown':
-          return (
-            keyboard.isDown('ShiftLeft') ||
-            keyboard.isDown('ShiftRight') ||
-            keyboard.isDown('ControlLeft') ||
-            keyboard.isDown('ControlRight') ||
-            keyboard.isDown('KeyQ') ||
-            keyboard.isDown('KeyC')
-          );
-        default:
-          return keyboard.isDown(code);
+
+      if (flyBypassAscendAliases.has(identifier)) {
+        if (typeof keyboard.isActionDown === 'function' && keyboard.isActionDown(HOTKEY_IDS.flight.ascend)) {
+          return true;
+        }
+        return typeof keyboard.isDown === 'function'
+          ? keyboard.isDown('Space') || keyboard.isDown('KeyE')
+          : false;
       }
+
+      if (flyBypassDescendAliases.has(identifier)) {
+        if (typeof keyboard.isActionDown === 'function' && keyboard.isActionDown(HOTKEY_IDS.flight.descend)) {
+          return true;
+        }
+        return typeof keyboard.isDown === 'function'
+          ? (
+              keyboard.isDown('ShiftLeft') ||
+              keyboard.isDown('ShiftRight') ||
+              keyboard.isDown('ControlLeft') ||
+              keyboard.isDown('ControlRight') ||
+              keyboard.isDown('KeyQ') ||
+              keyboard.isDown('KeyC')
+            )
+          : false;
+      }
+
+      if (typeof identifier === 'string' && identifier.includes('.') && typeof keyboard.isActionDown === 'function') {
+        return keyboard.isActionDown(identifier);
+      }
+
+      return typeof keyboard.isDown === 'function' ? keyboard.isDown(identifier) : false;
     }
   };
 

--- a/src/input/keyboard.js
+++ b/src/input/keyboard.js
@@ -1,62 +1,23 @@
+import {
+  RELEVANT_KEYS,
+  KEY_FALLBACK_MAP,
+  HOTKEY_AXIS_METADATA,
+  getActionCodes
+} from '../config/hotkeys.ts';
+
 const INV_SQRT2 = 1 / Math.sqrt(2);
 
-const MOVEMENT_KEYS = [
-  'KeyW',
-  'KeyA',
-  'KeyS',
-  'KeyD'
-];
+const pairedAxisBindings = new Map();
+let runningBinding = null;
 
-const LOOK_KEYS = [
-  'ArrowUp',
-  'ArrowDown',
-  'ArrowLeft',
-  'ArrowRight'
-];
-
-const MODIFIER_KEYS = ['ShiftLeft', 'ShiftRight'];
-
-const EXTRA_KEYS = [
-  'Space',
-  'KeyX',
-  'KeyC',
-  'KeyE',
-  'KeyQ',
-  'KeyZ',
-  'KeyF',
-  'ControlLeft',
-  'ControlRight',
-  'KeyT',
-  'KeyY',
-  'KeyP'
-];
-
-const RELEVANT_KEYS = new Set([...MOVEMENT_KEYS, ...LOOK_KEYS, ...MODIFIER_KEYS, ...EXTRA_KEYS]);
-
-const KEY_FALLBACK_MAP = new Map([
-  ['w', 'KeyW'],
-  ['a', 'KeyA'],
-  ['s', 'KeyS'],
-  ['d', 'KeyD'],
-  ['z', 'KeyW'],
-  ['q', 'KeyA'],
-  ['arrowup', 'ArrowUp'],
-  ['arrowdown', 'ArrowDown'],
-  ['arrowleft', 'ArrowLeft'],
-  ['arrowright', 'ArrowRight'],
-  [' ', 'Space'],
-  ['space', 'Space'],
-  ['spacebar', 'Space'],
-  ['x', 'KeyX'],
-  ['f', 'KeyF'],
-  ['c', 'KeyC'],
-  ['e', 'KeyE'],
-  ['t', 'KeyT'],
-  ['y', 'KeyY'],
-  ['p', 'KeyP'],
-  ['shift', 'ShiftLeft'],
-  ['control', 'ControlLeft']
-]);
+for (const binding of HOTKEY_AXIS_METADATA) {
+  if (!binding) continue;
+  if (binding.type === 'paired') {
+    pairedAxisBindings.set(binding.axis, binding);
+  } else if (binding.type === 'binary' && binding.axis === 'running') {
+    runningBinding = binding;
+  }
+}
 
 const normalizeCode = (event) => {
   if (!event) {
@@ -65,11 +26,11 @@ const normalizeCode = (event) => {
 
   const { code, key } = event;
 
-  if (code && code !== '' && code !== 'Unidentified') {
+  if (typeof code === 'string' && code !== '' && code !== 'Unidentified') {
     return code;
   }
 
-  if (!key && key !== 0) {
+  if (key === undefined || key === null) {
     return undefined;
   }
 
@@ -90,6 +51,53 @@ export function createKeyboard(target = typeof window !== 'undefined' ? window :
     lookY: 0
   };
   const lookState = { x: 0, y: 0 };
+  let frameJustPressed = new Set();
+
+  const resolveActionCodes = (actionId) => getActionCodes(actionId);
+
+  const getActionState = (actionId) => {
+    const codes = resolveActionCodes(actionId);
+    if (!codes.length) {
+      return { id: actionId, isDown: false, justPressed: false, codes };
+    }
+    let isDown = false;
+    let wasJustPressed = false;
+    for (const code of codes) {
+      if (!isDown && pressed.has(code)) {
+        isDown = true;
+      }
+      if (!wasJustPressed && (frameJustPressed.has(code) || justPressed.has(code))) {
+        wasJustPressed = true;
+      }
+      if (isDown && wasJustPressed) {
+        break;
+      }
+    }
+    return { id: actionId, isDown, justPressed: wasJustPressed, codes };
+  };
+
+  const isActionDown = (actionId) => {
+    const codes = resolveActionCodes(actionId);
+    if (!codes.length) {
+      return false;
+    }
+    for (const code of codes) {
+      if (pressed.has(code)) {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  const updateAxisFromBinding = (axisId) => {
+    const binding = pairedAxisBindings.get(axisId);
+    if (!binding) {
+      return 0;
+    }
+    const positive = isActionDown(binding.positive) ? 1 : 0;
+    const negative = isActionDown(binding.negative) ? 1 : 0;
+    return positive - negative;
+  };
 
   const handleKeyDown = (event) => {
     const code = normalizeCode(event);
@@ -103,7 +111,7 @@ export function createKeyboard(target = typeof window !== 'undefined' ? window :
       }
     }
 
-    if (!RELEVANT_KEYS.has(code)) {
+    if (!code || !RELEVANT_KEYS.has(code)) {
       return;
     }
     if (!pressed.has(code)) {
@@ -116,7 +124,7 @@ export function createKeyboard(target = typeof window !== 'undefined' ? window :
   const handleKeyUp = (event) => {
     const code = normalizeCode(event);
 
-    if (!RELEVANT_KEYS.has(code)) {
+    if (!code || !RELEVANT_KEYS.has(code)) {
       return;
     }
     pressed.delete(code);
@@ -133,43 +141,28 @@ export function createKeyboard(target = typeof window !== 'undefined' ? window :
   const isDown = (code) => pressed.has(code);
 
   const updateState = () => {
-    let x = 0;
-    let z = 0;
+    axisState.x = updateAxisFromBinding('x');
+    axisState.z = updateAxisFromBinding('z');
 
-    if (isDown('KeyD')) {
-      x += 1;
-    }
-    if (isDown('KeyA')) {
-      x -= 1;
+    if (axisState.x !== 0 && axisState.z !== 0) {
+      axisState.x *= INV_SQRT2;
+      axisState.z *= INV_SQRT2;
     }
 
-    if (isDown('KeyS')) {
-      z += 1;
-    }
-    if (isDown('KeyW')) {
-      z -= 1;
-    }
-
-    if (x !== 0 && z !== 0) {
-      x *= INV_SQRT2;
-      z *= INV_SQRT2;
-    }
-
-    axisState.x = x;
-    axisState.z = z;
     axisState.turn = 0;
-    axisState.running = MODIFIER_KEYS.some((code) => isDown(code));
 
-    axisState.lookX = (isDown('ArrowRight') ? 1 : 0) - (isDown('ArrowLeft') ? 1 : 0);
-    axisState.lookY = (isDown('ArrowUp') ? 1 : 0) - (isDown('ArrowDown') ? 1 : 0);
+    axisState.lookX = updateAxisFromBinding('lookX');
+    axisState.lookY = updateAxisFromBinding('lookY');
+
+    axisState.running = Boolean(
+      runningBinding?.actions?.some((actionId) => isActionDown(actionId))
+    );
 
     lookState.x = axisState.lookX;
     lookState.y = axisState.lookY;
   };
 
   updateState();
-
-  let frameJustPressed = new Set();
 
   const axis = {};
   Object.defineProperties(axis, {
@@ -259,6 +252,8 @@ export function createKeyboard(target = typeof window !== 'undefined' ? window :
 
   return {
     isDown,
+    isActionDown,
+    getActionState,
     update,
     axis,
     look,

--- a/tests/keyboard-controls.test.js
+++ b/tests/keyboard-controls.test.js
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import createKeyboard from '../src/input/keyboard.js';
+import { HOTKEY_IDS } from '../src/config/hotkeys.ts';
 
 const createMockTarget = () => {
   const listeners = new Map();
@@ -27,10 +28,13 @@ test('keyboard respects event.code when provided', () => {
 
   keydown({ code: 'KeyW', key: 'w' });
   assert.strictEqual(keyboard.isDown('KeyW'), true);
+  assert.strictEqual(keyboard.isActionDown(HOTKEY_IDS.movement.forward), true);
+  assert.strictEqual(keyboard.getActionState(HOTKEY_IDS.movement.forward).isDown, true);
   assert.strictEqual(keyboard.axis.z, -1);
 
   keyup({ code: 'KeyW', key: 'w' });
   assert.strictEqual(keyboard.isDown('KeyW'), false);
+  assert.strictEqual(keyboard.isActionDown(HOTKEY_IDS.movement.forward), false);
   assert.strictEqual(keyboard.axis.z, 0);
 
   keyboard.dispose();
@@ -44,13 +48,17 @@ test('keyboard normalizes events without code to maintain controls', () => {
 
   keydown({ key: 'w', code: '' });
   assert.strictEqual(keyboard.isDown('KeyW'), true);
+  assert.strictEqual(keyboard.isActionDown(HOTKEY_IDS.movement.forward), true);
+  assert.strictEqual(keyboard.getActionState(HOTKEY_IDS.movement.forward).isDown, true);
   assert.strictEqual(keyboard.axis.z, -1);
 
   keydown({ key: 'Shift', code: 'Unidentified' });
   assert.strictEqual(keyboard.axis.running, true);
+  assert.strictEqual(keyboard.isActionDown(HOTKEY_IDS.movement.run), true);
 
   keydown({ key: 'ArrowLeft', code: 'Unidentified' });
   assert.strictEqual(keyboard.isDown('ArrowLeft'), true);
+  assert.strictEqual(keyboard.getActionState(HOTKEY_IDS.look.left).isDown, true);
   assert.strictEqual(keyboard.look.x, -1);
   assert.strictEqual(keyboard.axis.lookX, -1);
 
@@ -64,6 +72,7 @@ test('keyboard normalizes events without code to maintain controls', () => {
   keyup({ key: 'w', code: '' });
 
   assert.strictEqual(keyboard.isDown('KeyW'), false);
+  assert.strictEqual(keyboard.isActionDown(HOTKEY_IDS.movement.forward), false);
   assert.strictEqual(keyboard.axis.z, 0);
   assert.strictEqual(keyboard.axis.running, false);
   assert.strictEqual(keyboard.look.x, 0);
@@ -82,6 +91,7 @@ test('keyboard maps azerty movement aliases without triggering descend', () => {
 
   keydown({ key: 'z' });
   assert.strictEqual(keyboard.isDown('KeyW'), true);
+  assert.strictEqual(keyboard.isActionDown(HOTKEY_IDS.movement.forward), true);
   assert.strictEqual(keyboard.axis.z, -1);
 
   keyup({ key: 'z' });
@@ -89,6 +99,7 @@ test('keyboard maps azerty movement aliases without triggering descend', () => {
 
   keydown({ key: 'q' });
   assert.strictEqual(keyboard.isDown('KeyA'), true);
+  assert.strictEqual(keyboard.isActionDown(HOTKEY_IDS.movement.left), true);
   assert.strictEqual(keyboard.axis.x, -1);
   assert.strictEqual(keyboard.isDown('KeyQ'), false);
 


### PR DESCRIPTION
## Summary
- add a typed hotkey manifest that centralizes default bindings, fallbacks, and axis metadata
- refactor the keyboard input module to derive axis state and expose action-aware helpers from the manifest
- update fly bypass wiring, initialization, and tests to consume the new manifest-driven helpers

## Testing
- `npm test` *(fails: tsx not available in container)*

------
https://chatgpt.com/codex/tasks/task_b_68dce8e340848327a50fc68e5b037ac1