### PR TITLE
Add BVH-backed character controller and collision docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,9 @@ Development builds now launch straight into the main experience at `/`. For trou
 ## Entry points
 
 Use `src/entry/initializeAthens.js` as the runtime entry point for embedding Athens into other experiences.
+
+## Collision & Interiors
+
+- Building interiors and walkable areas should have dedicated collider meshes in the GLB.
+- Prefix collider meshes with `COL_` **or** set `userData.collision = true` in the authoring tool to ensure they are picked up by the collision BVH builder.
+- Colliders should be closed volumes or have sufficient thickness. Single-sided planes only collide from one side and may allow the player to tunnel through.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "name": "athens",
       "version": "1.0.0",
       "dependencies": {
-        "three": "^0.180.0"
+        "three": "^0.180.0",
+        "three-mesh-bvh": "^0.7.3"
       },
       "devDependencies": {
         "@gltf-transform/core": "^4.2.1",
@@ -3141,6 +3142,15 @@
       "resolved": "https://registry.npmjs.org/three/-/three-0.180.0.tgz",
       "integrity": "sha512-o+qycAMZrh+TsE01GqWUxUIKR1AL0S8pq7zDkYOQw8GqfX8b8VoCKYUoHbhiX5j+7hr8XsuHDVU6+gkQJQKg9w==",
       "license": "MIT"
+    },
+    "node_modules/three-mesh-bvh": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/three-mesh-bvh/-/three-mesh-bvh-0.7.6.tgz",
+      "integrity": "sha512-rCjsnxEqR9r1/C/lCqzGLS67NDty/S/eT6rAJfDvsanrIctTWdNoR4ZOGWewCB13h1QkVo2BpmC0wakj1+0m8A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">= 0.151.0"
+      }
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "gen:skyground": "node scripts/generate-sky-ground-assets.js"
   },
   "dependencies": {
-    "three": "^0.180.0"
+    "three": "^0.180.0",
+    "three-mesh-bvh": "^0.7.3"
   },
   "devDependencies": {
     "@gltf-transform/core": "^4.2.1",

--- a/src/controls/CharacterController.ts
+++ b/src/controls/CharacterController.ts
@@ -1,0 +1,263 @@
+import * as THREE from 'three';
+import { MeshBVH } from 'three-mesh-bvh';
+import { Capsule as ExampleCapsule } from 'three/examples/jsm/math/Capsule.js';
+
+import type { CollisionWorld } from '../physics/collisionWorld.ts';
+
+const Capsule = ExampleCapsule;
+
+const _up = new THREE.Vector3(0, 1, 0);
+const _movement = new THREE.Vector3();
+const _forward = new THREE.Vector3();
+const _right = new THREE.Vector3();
+const _desiredVelocity = new THREE.Vector3();
+const _horizontalVelocity = new THREE.Vector3();
+const _hitNormal = new THREE.Vector3();
+const _hitPoint = new THREE.Vector3();
+const _capsuleCenter = new THREE.Vector3();
+const _remaining = new THREE.Vector3();
+const _stepUp = new THREE.Vector3(0, 1, 0);
+const _pushOut = new THREE.Vector3();
+const _capsuleHit = {
+  normal: _hitNormal,
+  point: _hitPoint,
+  depth: 0
+};
+
+const EPSILON = 1e-5;
+const MAX_SWEEP_ITERATIONS = 5;
+
+export interface CharacterInput {
+  forward: number;
+  right: number;
+  jump: boolean;
+  sprint: boolean;
+}
+
+export interface CharacterControllerWorld extends CollisionWorld {}
+
+export class CharacterController {
+  public readonly capsule: InstanceType<typeof Capsule>;
+  public readonly velocity = new THREE.Vector3();
+  public onGround = false;
+  public gravity = 9.8;
+  public walkSpeed = 2.5;
+  public sprintSpeed = 4.5;
+  public jumpSpeed = 4.5;
+  public damping = 0.12;
+  public stepOffset = 0.3;
+
+  private readonly camera: THREE.PerspectiveCamera;
+  private readonly headOffset = new THREE.Vector3(0, 0.2, 0);
+  private readonly _position = new THREE.Vector3();
+
+  constructor(
+    camera: THREE.PerspectiveCamera,
+    start: THREE.Vector3,
+    height = 1.7,
+    radius = 0.35
+  ) {
+    this.camera = camera;
+    const clampedHeight = Math.max(height, radius * 2 + EPSILON);
+
+    const halfSegment = Math.max((clampedHeight - radius * 2) * 0.5, 0);
+    const center = start.clone();
+    const startLine = center.clone().addScaledVector(_up, -halfSegment);
+    const endLine = center.clone().addScaledVector(_up, halfSegment);
+
+    this.capsule = new Capsule(startLine, endLine, radius);
+    this.headOffset.set(0, Math.max(0.2, clampedHeight * 0.5 - 0.1), 0);
+    this.updateCameraPosition();
+  }
+
+  get position(): THREE.Vector3 {
+    return this.getCapsuleCenter(this._position);
+  }
+
+  public update(
+    dt: number,
+    input: CharacterInput,
+    world: CharacterControllerWorld
+  ): void {
+    if (!Number.isFinite(dt) || dt <= 0) {
+      return;
+    }
+
+    const clampedDt = Math.min(dt, 0.25);
+
+    this.resolveMovement(clampedDt, input);
+    this.integratePhysics(clampedDt, input);
+
+    _movement.copy(this.velocity).multiplyScalar(clampedDt);
+
+    if (this.onGround && world?.bvh && this.hasHorizontalMovement(_movement)) {
+      const attempted = this.attemptStep(_movement, world);
+      if (!attempted) {
+        this.sweepCapsule(_movement, world);
+      }
+    } else {
+      this.sweepCapsule(_movement, world);
+    }
+
+    this.updateCameraPosition();
+  }
+
+  private resolveMovement(dt: number, input: CharacterInput) {
+    const { forward = 0, right = 0, sprint = false } = input ?? {};
+
+    this.camera.getWorldDirection(_forward);
+    _forward.y = 0;
+    if (_forward.lengthSq() < EPSILON) {
+      _forward.set(0, 0, -1);
+    } else {
+      _forward.normalize();
+    }
+
+    _right.copy(_forward).cross(_up).normalize();
+
+    _desiredVelocity.set(0, 0, 0);
+    if (Math.abs(forward) > EPSILON) {
+      _desiredVelocity.addScaledVector(_forward, forward);
+    }
+    if (Math.abs(right) > EPSILON) {
+      _desiredVelocity.addScaledVector(_right, right);
+    }
+
+    if (_desiredVelocity.lengthSq() > EPSILON) {
+      _desiredVelocity.normalize();
+    }
+
+    const targetSpeed = sprint ? this.sprintSpeed : this.walkSpeed;
+    _desiredVelocity.multiplyScalar(targetSpeed);
+
+    _horizontalVelocity.set(this.velocity.x, 0, this.velocity.z);
+    const lerpFactor = 1 - Math.exp(-this.damping * dt);
+    _horizontalVelocity.lerp(_desiredVelocity, THREE.MathUtils.clamp(lerpFactor, 0, 1));
+
+    this.velocity.x = _horizontalVelocity.x;
+    this.velocity.z = _horizontalVelocity.z;
+  }
+
+  private integratePhysics(dt: number, input: CharacterInput) {
+    const { jump = false } = input ?? {};
+    this.velocity.y -= this.gravity * dt;
+    if (this.onGround) {
+      if (jump) {
+        this.velocity.y = this.jumpSpeed;
+        this.onGround = false;
+      } else if (this.velocity.y < 0) {
+        this.velocity.y = 0;
+      }
+    }
+  }
+
+  private attemptStep(delta: THREE.Vector3, world: CharacterControllerWorld): boolean {
+    const bvh = world?.bvh;
+    if (!(bvh instanceof MeshBVH)) {
+      return false;
+    }
+
+    const hasHorizontal = this.hasHorizontalMovement(delta);
+    if (!hasHorizontal) {
+      return false;
+    }
+
+    const startBottom = this.capsule.start.clone();
+    const startTop = this.capsule.end.clone();
+
+    _stepUp.set(0, this.stepOffset, 0);
+    this.capsule.translate(_stepUp);
+    const movedUp = this.sweepCapsule(delta, world, { allowRetry: false });
+    if (!movedUp) {
+      this.capsule.start.copy(startBottom);
+      this.capsule.end.copy(startTop);
+      return false;
+    }
+
+    _stepUp.set(0, -this.stepOffset, 0);
+    this.sweepCapsule(_stepUp, world, { allowRetry: false });
+
+    return true;
+  }
+
+  private sweepCapsule(
+    delta: THREE.Vector3,
+    world: CharacterControllerWorld,
+    { allowRetry = true }: { allowRetry?: boolean } = {}
+  ): boolean {
+    if (!delta || delta.lengthSq() <= EPSILON) {
+      return true;
+    }
+
+    this.onGround = false;
+
+    if (!(world?.bvh instanceof MeshBVH)) {
+      this.capsule.translate(delta);
+      return true;
+    }
+
+    const bvh = world.bvh;
+    _remaining.copy(delta);
+
+    for (let i = 0; i < MAX_SWEEP_ITERATIONS; i += 1) {
+      this.capsule.translate(_remaining);
+      const hit = (bvh as unknown as { capsuleIntersect?: typeof bvh.capsuleIntersect }).capsuleIntersect?.(
+        this.capsule,
+        _capsuleHit
+      );
+
+      if (!hit || hit.depth <= EPSILON) {
+        return true;
+      }
+
+      _pushOut.copy(_capsuleHit.normal).multiplyScalar(hit.depth + EPSILON);
+      this.capsule.translate(_pushOut);
+
+      const normalComponent = _remaining.dot(_capsuleHit.normal);
+      if (normalComponent >= 0) {
+        _remaining.set(0, 0, 0);
+      } else {
+        _remaining.addScaledVector(_capsuleHit.normal, -normalComponent);
+      }
+
+      const velocityNormal = this.velocity.dot(_capsuleHit.normal);
+      if (velocityNormal < 0) {
+        this.velocity.addScaledVector(_capsuleHit.normal, -velocityNormal);
+      }
+
+      if (_capsuleHit.normal.y > 0.5) {
+        this.onGround = true;
+      }
+
+      if (_remaining.lengthSq() <= EPSILON) {
+        return true;
+      }
+    }
+
+    if (allowRetry && _remaining.lengthSq() > EPSILON) {
+      _remaining.set(0, 0, 0);
+      return true;
+    }
+
+    return false;
+  }
+
+  private hasHorizontalMovement(delta: THREE.Vector3) {
+    if (!delta) {
+      return false;
+    }
+    return Math.abs(delta.x) > EPSILON || Math.abs(delta.z) > EPSILON;
+  }
+
+  private getCapsuleCenter(target: THREE.Vector3) {
+    target.copy(this.capsule.start).add(this.capsule.end).multiplyScalar(0.5);
+    return target;
+  }
+
+  private updateCameraPosition() {
+    const center = this.getCapsuleCenter(_capsuleCenter);
+    this.camera.position.copy(center).add(this.headOffset);
+  }
+}
+
+export default CharacterController;

--- a/src/controls/__tests__/input.test.ts
+++ b/src/controls/__tests__/input.test.ts
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import getInput, { __inputTest } from '../input.ts';
+
+test('input adapter maps WASD keys to movement axes', () => {
+  __inputTest.reset();
+
+  __inputTest.press('KeyW');
+  let input = getInput();
+  assert.strictEqual(input.forward, 1);
+  assert.strictEqual(input.right, 0);
+
+  __inputTest.press('KeyA');
+  input = getInput();
+  assert.strictEqual(input.forward, 1);
+  assert.strictEqual(input.right, -1);
+
+  __inputTest.release('KeyW');
+  __inputTest.release('KeyA');
+  input = getInput();
+  assert.strictEqual(input.forward, 0);
+  assert.strictEqual(input.right, 0);
+});
+
+test('input adapter respects arrow keys and sprint/jump modifiers', () => {
+  __inputTest.reset();
+
+  __inputTest.press('ArrowDown');
+  __inputTest.press('ArrowRight');
+  __inputTest.press('Space');
+  __inputTest.press('ShiftLeft');
+
+  const input = getInput();
+  assert.strictEqual(input.forward, -1);
+  assert.strictEqual(input.right, 1);
+  assert.strictEqual(input.jump, true);
+  assert.strictEqual(input.sprint, true);
+
+  __inputTest.reset();
+  const reset = getInput();
+  assert.strictEqual(reset.forward, 0);
+  assert.strictEqual(reset.right, 0);
+  assert.strictEqual(reset.jump, false);
+  assert.strictEqual(reset.sprint, false);
+});

--- a/src/controls/input.ts
+++ b/src/controls/input.ts
@@ -1,0 +1,130 @@
+import type { CharacterInput } from './CharacterController.ts';
+
+type KeyboardEventLike = { code?: string; key?: string; repeat?: boolean };
+
+const activeKeys = new Set<string>();
+
+const POSITIVE_FORWARD = new Set(['KeyW', 'ArrowUp']);
+const NEGATIVE_FORWARD = new Set(['KeyS', 'ArrowDown']);
+const POSITIVE_RIGHT = new Set(['KeyD', 'ArrowRight']);
+const NEGATIVE_RIGHT = new Set(['KeyA', 'ArrowLeft']);
+const JUMP_KEYS = new Set(['Space']);
+const SPRINT_KEYS = new Set(['ShiftLeft', 'ShiftRight']);
+
+const KEY_ALIAS: Record<string, string> = {
+  w: 'KeyW',
+  W: 'KeyW',
+  s: 'KeyS',
+  S: 'KeyS',
+  a: 'KeyA',
+  A: 'KeyA',
+  d: 'KeyD',
+  D: 'KeyD',
+  ArrowUp: 'ArrowUp',
+  ArrowDown: 'ArrowDown',
+  ArrowLeft: 'ArrowLeft',
+  ArrowRight: 'ArrowRight',
+  ' ': 'Space',
+  Space: 'Space',
+  Shift: 'ShiftLeft'
+};
+
+let listenersAttached = false;
+
+function normalizeCode(event: KeyboardEventLike): string {
+  if (!event) {
+    return '';
+  }
+
+  const code = event.code;
+  if (typeof code === 'string' && code && code !== 'Unidentified') {
+    return code;
+  }
+
+  const key = event.key;
+  if (typeof key === 'string' && key) {
+    return KEY_ALIAS[key] || KEY_ALIAS[key.toUpperCase()] || '';
+  }
+
+  return '';
+}
+
+function setKeyState(code: string, isDown: boolean) {
+  if (!code) {
+    return;
+  }
+
+  if (isDown) {
+    activeKeys.add(code);
+  } else {
+    activeKeys.delete(code);
+  }
+}
+
+function handleKeyDown(event: KeyboardEventLike) {
+  const code = normalizeCode(event);
+  if (!code || event.repeat) {
+    return;
+  }
+  setKeyState(code, true);
+}
+
+function handleKeyUp(event: KeyboardEventLike) {
+  const code = normalizeCode(event);
+  if (!code) {
+    return;
+  }
+  setKeyState(code, false);
+}
+
+function ensureListeners() {
+  if (listenersAttached) {
+    return;
+  }
+
+  if (typeof window !== 'undefined' && typeof window.addEventListener === 'function') {
+    window.addEventListener('keydown', handleKeyDown);
+    window.addEventListener('keyup', handleKeyUp);
+    listenersAttached = true;
+  }
+}
+
+function axisValue(positive: Set<string>, negative: Set<string>) {
+  const pos = hasAnyKey(positive) ? 1 : 0;
+  const neg = hasAnyKey(negative) ? 1 : 0;
+  return pos - neg;
+}
+
+function hasAnyKey(codes: Set<string>) {
+  for (const code of codes) {
+    if (activeKeys.has(code)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function getInput(): CharacterInput {
+  ensureListeners();
+
+  return {
+    forward: axisValue(POSITIVE_FORWARD, NEGATIVE_FORWARD),
+    right: axisValue(POSITIVE_RIGHT, NEGATIVE_RIGHT),
+    jump: hasAnyKey(JUMP_KEYS),
+    sprint: hasAnyKey(SPRINT_KEYS)
+  };
+}
+
+export const __inputTest = {
+  press(code: string) {
+    setKeyState(code, true);
+  },
+  release(code: string) {
+    setKeyState(code, false);
+  },
+  reset() {
+    activeKeys.clear();
+  }
+};
+
+export default getInput;

--- a/src/entry/initializeAthens.js
+++ b/src/entry/initializeAthens.js
@@ -28,6 +28,9 @@ import { createOriginalUi } from '../ui/originalUi.js';
 import { loadGrassMaterial } from '../materials/groundGrass.js';
 import { buildNavMeshFromMeshes } from '../navmesh/buildNavMesh.js';
 import { createNavMeshPathfinder } from '../navmesh/pathfinder.js';
+import { loadWorldWithColliders } from '../physics/collisionWorld.ts';
+import { CharacterController } from '../controls/CharacterController.ts';
+import { getInput } from '../controls/input.ts';
 import {
   LANDMARK_ALIASES,
   KNOWN_LANDMARK_KEYS,
@@ -62,6 +65,10 @@ import { setExternalGroundTexture } from '../materials/groundGrass.js';
 const _TMP_WORLD = new THREE.Vector3();
 const _TMP_LOCAL = new THREE.Vector3();
 const _TMP_GROUND = new THREE.Vector3();
+
+const WALKING_ENABLED = true;
+const _WALK_LOOK_DIR = new THREE.Vector3();
+const _WALK_LOOK_TARGET = new THREE.Vector3();
 
 function _setWorldPosition(object, x, y, z) {
   if (!object?.isObject3D) return false;
@@ -648,6 +655,10 @@ export async function initializeAthens(options = {}) {
     }
 
     if (typeof globalWindow.__athensDebug === 'object' && globalWindow.__athensDebug) {
+      globalWindow.__athensDebug.controller = WALKING_ENABLED && walkingController
+        ? walkingController
+        : controller;
+      globalWindow.__athensDebug.collision = collisionWorld;
       globalWindow.__athensDebug.skyJpgs = (SKY_JPGS || []).map((x) => ({
         id: x.id,
         url: x.url,
@@ -1028,6 +1039,23 @@ await environmentManager.applySky('day');
   const colliderMeshes = collectColliders(scene);
   const colliders = buildAABBs(colliderMeshes);
 
+  let collisionWorld = { colliderMesh: null, bvh: null };
+  if (WALKING_ENABLED) {
+    const collisionWorldUrl =
+      options?.collisionWorldUrl ??
+      options?.collision?.url ??
+      options?.worldUrl ??
+      null;
+
+    if (collisionWorldUrl) {
+      try {
+        collisionWorld = await loadWorldWithColliders(collisionWorldUrl, scene);
+      } catch (error) {
+        logger.warn('[Athens][CollisionWorld] Failed to load collision world.', error);
+      }
+    }
+  }
+
   const mainCharacterOptions = options.mainCharacter ?? options.mainCharacterConfig ?? null;
   const spawnHint = mainCharacterOptions?.initialPosition ?? DEFAULT_PLAYER_START;
   const playerSpawn = findSafePlayerSpawn({
@@ -1158,6 +1186,19 @@ await environmentManager.applySky('day');
 
   if (playerObject?.position) {
     sanitizeVec3(playerObject.position, SAFE_PLAYER_FALLBACK);
+  }
+
+  const controllerHeight = Number.isFinite(movementConfig?.character?.height)
+    ? Math.max(1, movementConfig.character.height)
+    : 1.7;
+  let walkingController = null;
+  if (WALKING_ENABLED) {
+    const controllerStart = playerSpawn.clone();
+    controllerStart.y += controllerHeight * 0.5;
+    walkingController = new CharacterController(camera, controllerStart, controllerHeight);
+    if (playerObject?.position) {
+      playerObject.position.copy(walkingController.position);
+    }
   }
 
 // CHAR_MAIN_HEIGHT_START
@@ -1459,17 +1500,28 @@ if (readyPromise && typeof readyPromise.then === 'function') {
       landmarks.update?.(camera);
 
       if (!skippedLargeDt) {
-        controller?.update?.(delta, camera);
+        if (WALKING_ENABLED && walkingController) {
+          walkingController.update(delta, getInput(), collisionWorld);
+          if (playerObject?.position) {
+            playerObject.position.copy(walkingController.position);
+          }
+        } else {
+          controller?.update?.(delta, camera);
+        }
       }
 
       ui?.update?.(delta, {
         position: playerObject?.position,
-        isFlying: controller?.isFlying?.() ?? false,
-        isRunning: controller?.isRunning?.(),
+        isFlying: WALKING_ENABLED ? false : controller?.isFlying?.() ?? false,
+        isRunning: WALKING_ENABLED && walkingController
+          ? walkingController.velocity.length() > walkingController.walkSpeed + 0.1
+          : controller?.isRunning?.(),
         skippedLargeDt: Boolean(skippedLargeDt)
       });
 
-      followCamera?.update?.(keyboard, delta);
+      if (!WALKING_ENABLED || !walkingController) {
+        followCamera?.update?.(keyboard, delta);
+      }
 
       const activePlayer = findPlayerObject() || playerObject;
       if (activePlayer?.position && !isFiniteVec3(activePlayer.position)) {
@@ -1491,13 +1543,23 @@ if (readyPromise && typeof readyPromise.then === 'function') {
         }
       }
 
-      const lookTarget = activePlayer?.position
-        ? activePlayer.position
-        : playerObject?.position
-          ? playerObject.position
-          : SAFE_PLAYER_VECTOR.clone();
-      sanitizeVec3(lookTarget, SAFE_PLAYER_FALLBACK);
-      camera.lookAt(lookTarget);
+      if (WALKING_ENABLED && walkingController) {
+        camera.getWorldDirection(_WALK_LOOK_DIR);
+        if (_WALK_LOOK_DIR.lengthSq() < 1e-6) {
+          _WALK_LOOK_DIR.set(0, 0, -1);
+        }
+        _WALK_LOOK_TARGET.copy(camera.position).addScaledVector(_WALK_LOOK_DIR, 10);
+        sanitizeVec3(_WALK_LOOK_TARGET, SAFE_PLAYER_FALLBACK);
+        camera.lookAt(_WALK_LOOK_TARGET);
+      } else {
+        const lookTarget = activePlayer?.position
+          ? activePlayer.position
+          : playerObject?.position
+            ? playerObject.position
+            : SAFE_PLAYER_VECTOR.clone();
+        sanitizeVec3(lookTarget, SAFE_PLAYER_FALLBACK);
+        camera.lookAt(lookTarget);
+      }
     } catch (error) {
       logger.warn('[Athens] Frame update failed.', error);
     }
@@ -1592,6 +1654,8 @@ if (readyPromise && typeof readyPromise.then === 'function') {
     city,
     container,
     ui,
+    collisionWorld,
+    walkingController,
     async setEnvironmentMode(mode, envOptions = {}) {
       const result = await environmentController?.setMode?.(mode, envOptions);
       const label = formatEnvironmentLabel(result || mode);
@@ -1634,6 +1698,8 @@ if (readyPromise && typeof readyPromise.then === 'function') {
     window.__athens.setSkyMode = (mode, envOptions) => context.setEnvironmentMode(mode, envOptions);
     window.__athens.city = context.city;
     window.__athens.ui = context.ui;
+    window.__athens.controller = WALKING_ENABLED && walkingController ? walkingController : controller;
+    window.__athens.collisionWorld = collisionWorld;
   }
 
   return context;

--- a/src/physics/__tests__/character-grounding.test.ts
+++ b/src/physics/__tests__/character-grounding.test.ts
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import * as THREE from 'three';
+import { MeshBVH } from 'three-mesh-bvh';
+
+import { ensureCapsuleIntersection } from '../collisionWorld.ts';
+import { CharacterController } from '../../controls/CharacterController.ts';
+
+const NO_INPUT = { forward: 0, right: 0, jump: false, sprint: false } as const;
+
+function createWorldFromGeometry(geometry: THREE.BufferGeometry) {
+  const bvh = new MeshBVH(geometry, { lazyGeneration: false });
+  ensureCapsuleIntersection(bvh);
+  return { bvh, colliderMesh: null };
+}
+
+test('character remains grounded on a simple floor', () => {
+  const camera = new THREE.PerspectiveCamera();
+  const floor = new THREE.BoxGeometry(10, 1, 10);
+  floor.translate(0, -0.5, 0);
+  const world = createWorldFromGeometry(floor);
+
+  const controller = new CharacterController(camera, new THREE.Vector3(0, 1, 0));
+
+  for (let i = 0; i < 120; i += 1) {
+    controller.update(1 / 60, NO_INPUT, world);
+  }
+
+  assert.ok(controller.onGround, 'controller should detect ground contact');
+  assert.ok(controller.position.y >= 0.3, 'controller should not sink below the floor');
+});
+
+test('character slides up an inclined plane without tunneling', () => {
+  const camera = new THREE.PerspectiveCamera();
+  camera.position.set(0, 1.6, 0);
+  camera.lookAt(new THREE.Vector3(0, 1.6, 1));
+
+  const slope = new THREE.BoxGeometry(8, 0.5, 8);
+  slope.rotateX(-Math.PI / 6);
+  slope.translate(0, 2.5, 0);
+  const world = createWorldFromGeometry(slope);
+
+  const start = new THREE.Vector3(0, 1.0, -3.0);
+  const controller = new CharacterController(camera, start);
+
+  const input = { forward: 1, right: 0, jump: false, sprint: false };
+  const initialY = controller.position.y;
+  const initialZ = controller.position.z;
+
+  for (let i = 0; i < 180; i += 1) {
+    controller.update(1 / 60, input, world);
+  }
+
+  assert.ok(controller.position.y > initialY + 0.05, 'controller should climb the slope');
+  assert.ok(
+    Math.abs(controller.position.z - initialZ) > 0.05,
+    'controller should advance along the slope'
+  );
+});

--- a/src/physics/collisionWorld.ts
+++ b/src/physics/collisionWorld.ts
@@ -1,0 +1,228 @@
+import * as THREE from 'three';
+import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
+import { mergeGeometries, mergeVertices } from 'three/examples/jsm/utils/BufferGeometryUtils.js';
+import { MeshBVH, acceleratedRaycast } from 'three-mesh-bvh';
+import { Capsule as ExampleCapsule } from 'three/examples/jsm/math/Capsule.js';
+
+import { logger } from '../utils/logger.ts';
+
+export type Capsule = ExampleCapsule;
+
+export interface CollisionWorld {
+  colliderMesh: THREE.Mesh | null;
+  bvh: MeshBVH | null;
+}
+
+type CapsuleHit = {
+  normal: THREE.Vector3;
+  point: THREE.Vector3;
+  depth: number;
+};
+
+const _loader = new GLTFLoader();
+const _matrixWorld = new THREE.Matrix4();
+const _expandedBox = new THREE.Box3();
+const _segment = new THREE.Line3();
+const _trianglePoint = new THREE.Vector3();
+const _segmentPoint = new THREE.Vector3();
+const _normal = new THREE.Vector3();
+const _defaultCapsuleHit: CapsuleHit = {
+  normal: new THREE.Vector3(0, 1, 0),
+  point: new THREE.Vector3(),
+  depth: 0
+};
+
+let warnedMissingColliderTags = false;
+let acceleratedRaycastEnabled = false;
+
+function ensureAcceleratedRaycast() {
+  if (acceleratedRaycastEnabled) {
+    return;
+  }
+  try {
+    const meshProto = (THREE.Mesh as unknown as { prototype: { raycast: unknown } }).prototype;
+    meshProto.raycast = acceleratedRaycast as unknown as typeof meshProto.raycast;
+    acceleratedRaycastEnabled = true;
+  } catch (error) {
+    logger.warn('[collisionWorld] Failed to enable accelerated raycast.', error);
+  }
+}
+
+function attachCapsuleIntersect(bvh: MeshBVH) {
+  const internal = bvh as MeshBVH & {
+    capsuleIntersect?: (capsule: Capsule, target?: CapsuleHit) => CapsuleHit | null;
+  };
+  if (typeof internal.capsuleIntersect === 'function') {
+    return;
+  }
+
+  internal.capsuleIntersect = (capsule: Capsule, target: CapsuleHit = _defaultCapsuleHit) => {
+    if (!capsule) {
+      return null;
+    }
+
+    const result = target;
+    let hit = false;
+    let bestDepth = 0;
+
+    result.depth = 0;
+    result.point.set(0, 0, 0);
+    result.normal.set(0, 1, 0);
+
+    const radius = capsule.radius ?? 0;
+    _segment.start.copy(capsule.start);
+    _segment.end.copy(capsule.end);
+
+    bvh.shapecast({
+      intersectsBounds(box) {
+        _expandedBox.copy(box);
+        _expandedBox.min.addScalar(-radius);
+        _expandedBox.max.addScalar(radius);
+        return (
+          _expandedBox.intersectsLine(_segment) ||
+          _expandedBox.containsPoint(_segment.start) ||
+          _expandedBox.containsPoint(_segment.end)
+        );
+      },
+      intersectsTriangle(tri) {
+        tri.needsUpdate = true;
+        tri.update();
+        const distance = tri.closestPointToSegment(_segment, _trianglePoint, _segmentPoint);
+        if (distance <= radius) {
+          const depth = radius - distance;
+          if (depth > bestDepth) {
+            bestDepth = depth;
+            hit = true;
+            result.depth = depth;
+            result.point.copy(_segmentPoint);
+            _normal.copy(_segmentPoint).sub(_trianglePoint);
+            if (_normal.lengthSq() > 1e-10) {
+              _normal.normalize();
+            } else {
+              tri.getNormal(_normal);
+            }
+            result.normal.copy(_normal);
+          }
+        }
+        return false;
+      }
+    });
+
+    return hit ? result : null;
+  };
+}
+
+function collectColliderMeshes(root: THREE.Object3D) {
+  const tagged: THREE.Mesh[] = [];
+  const fallback: THREE.Mesh[] = [];
+
+  root.traverse((child) => {
+    if (!(child as THREE.Mesh).isMesh) {
+      return;
+    }
+    const mesh = child as THREE.Mesh;
+    const hasTag = typeof mesh.name === 'string' && mesh.name.startsWith('COL_');
+    const hasUserData = mesh.userData?.collision === true;
+    if (hasTag || hasUserData) {
+      tagged.push(mesh);
+    } else if (mesh.visible !== false) {
+      fallback.push(mesh);
+    }
+  });
+
+  if (!tagged.length && fallback.length && !warnedMissingColliderTags) {
+    warnedMissingColliderTags = true;
+    logger.warn(
+      '[collisionWorld] No meshes tagged for collision were found. Falling back to all visible meshes.'
+    );
+  }
+
+  return tagged.length ? tagged : fallback;
+}
+
+function bakeGeometry(mesh: THREE.Mesh) {
+  const original = mesh.geometry;
+  if (!original || !original.attributes?.position) {
+    return null;
+  }
+
+  const cloned = original.clone();
+  mesh.updateWorldMatrix(true, false);
+  _matrixWorld.copy(mesh.matrixWorld);
+  cloned.applyMatrix4(_matrixWorld);
+  const withIndex = cloned.index ? cloned : mergeVertices(cloned, 1e-4);
+  return withIndex;
+}
+
+export function ensureCapsuleIntersection(bvh: MeshBVH | null | undefined) {
+  if (!bvh) {
+    return;
+  }
+  attachCapsuleIntersect(bvh);
+}
+
+export async function loadWorldWithColliders(
+  url: string,
+  scene: THREE.Scene
+): Promise<CollisionWorld> {
+  if (!url) {
+    return { colliderMesh: null, bvh: null };
+  }
+
+  const gltf = await _loader.loadAsync(url);
+  const root = gltf?.scene ?? gltf?.scenes?.[0] ?? null;
+  if (!root) {
+    logger.warn('[collisionWorld] GLB scene is empty:', url);
+    return { colliderMesh: null, bvh: null };
+  }
+
+  if (!scene.children.includes(root)) {
+    scene.add(root);
+  }
+
+  const candidates = collectColliderMeshes(root);
+  if (!candidates.length) {
+    return { colliderMesh: null, bvh: null };
+  }
+
+  const baked: THREE.BufferGeometry[] = [];
+  for (const mesh of candidates) {
+    const geometry = bakeGeometry(mesh);
+    if (geometry) {
+      baked.push(geometry);
+    }
+  }
+
+  if (!baked.length) {
+    logger.warn('[collisionWorld] Unable to bake any collider geometry from GLB:', url);
+    return { colliderMesh: null, bvh: null };
+  }
+
+  const merged = mergeGeometries(baked, false);
+  if (!merged) {
+    logger.warn('[collisionWorld] Failed to merge collider geometries:', url);
+    return { colliderMesh: null, bvh: null };
+  }
+
+  merged.computeBoundingBox();
+  merged.computeBoundingSphere();
+
+  const bvh = new MeshBVH(merged, { lazyGeneration: false });
+  attachCapsuleIntersect(bvh);
+  (merged as unknown as { boundsTree?: MeshBVH }).boundsTree = bvh;
+
+  ensureAcceleratedRaycast();
+
+  const material = new THREE.MeshBasicMaterial({ visible: false });
+  const colliderMesh = new THREE.Mesh(merged, material);
+  colliderMesh.name = 'CollisionWorld';
+  colliderMesh.matrixAutoUpdate = false;
+  colliderMesh.visible = false;
+  colliderMesh.updateMatrix();
+  colliderMesh.frustumCulled = false;
+  scene.add(colliderMesh);
+
+  return { colliderMesh, bvh };
+}
+
+export default loadWorldWithColliders;

--- a/src/types/three-mesh-bvh.d.ts
+++ b/src/types/three-mesh-bvh.d.ts
@@ -1,0 +1,11 @@
+import type { MeshBVH } from 'three-mesh-bvh';
+import type { Capsule as ExampleCapsule } from 'three/examples/jsm/math/Capsule.js';
+
+declare module 'three-mesh-bvh' {
+  interface MeshBVH {
+    capsuleIntersect?: (
+      capsule: ExampleCapsule,
+      target?: { normal: import('three').Vector3; point: import('three').Vector3; depth: number }
+    ) => { normal: import('three').Vector3; point: import('three').Vector3; depth: number } | null;
+  }
+}

--- a/tests/src-tests.test.js
+++ b/tests/src-tests.test.js
@@ -1,0 +1,2 @@
+import '../src/controls/__tests__/input.test.ts';
+import '../src/physics/__tests__/character-grounding.test.ts';


### PR DESCRIPTION
## Summary
- add a collision world loader that merges tagged GLB meshes into a three-mesh-bvh and exposes it via debug hooks
- implement a capsule-based character controller with gravity, stepping, and keyboard input adapter to drive the existing camera
- document collider authoring guidance and add unit/physics tests to guard the new controller and input mapping

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68dce624a83c8327bff8c2e42a2329c8