### PR TITLE
Refactor flight controls to use manifest actions

### DIFF
--- a/src/dev/flyBypass.js
+++ b/src/dev/flyBypass.js
@@ -10,8 +10,8 @@ export function installFlyBypass({ state, input }){
   return {
     tick(dt){
       if (!on) return;
-      const up   = input?.held?.('flyUp')   || input?.held?.('Space');
-      const down = input?.held?.('flyDown') || input?.held?.('ShiftLeft') || input?.held?.('ShiftRight');
+      const up = Boolean(input?.held?.('flyUp'));
+      const down = Boolean(input?.held?.('flyDown'));
       const speed = 6;
       if (up)   state.position.y += speed * dt;
       if (down) state.position.y -= speed * dt;

--- a/src/entry/initializeAthens.js
+++ b/src/entry/initializeAthens.js
@@ -14,6 +14,7 @@ import { collectRoadPoints } from '../roads/collectRoadPoints.js';
 import { createNpcSystem } from '../npc/npcSystem.js';
 import { createMainCharacter } from '../npc/mainCharacter.js';
 import { createKeyboard } from '../input/keyboard.js';
+import { extendKeyboardManifest } from '../input/manifest.js';
 import { createFollowCamera } from '../camera/followCamera.js';
 import { seedCameraBehindPlayer } from '../camera/seedCameraBehindPlayer.js';
 import { createPlayerController } from '../player/playerController.js';
@@ -1190,6 +1191,25 @@ if (readyPromise && typeof readyPromise.then === 'function') {
   const cameraSettings = movementConfig?.camera ?? {};
   const cameraFollowConfig = cameraSettings?.follow ?? {};
   const cameraSeedConfig = cameraSettings?.seed ?? {};
+
+  const flightConfig = movementConfig?.flight ?? {};
+  const collectCodes = (values) => {
+    if (!Array.isArray(values)) {
+      return [];
+    }
+    return values.filter((code) => typeof code === 'string' && code.length > 0);
+  };
+  const toggleOverrides = new Set();
+  if (typeof flightConfig.toggleKey === 'string' && flightConfig.toggleKey.length > 0) {
+    toggleOverrides.add(flightConfig.toggleKey);
+  }
+  collectCodes(flightConfig.toggleKeys).forEach((code) => toggleOverrides.add(code));
+  extendKeyboardManifest({
+    flyToggle: [...toggleOverrides],
+    flyUp: collectCodes(flightConfig.ascendKeys),
+    flyDown: collectCodes(flightConfig.descendKeys)
+  });
+
   const keyboard = createKeyboard();
   registerDisposables(keyboard);
   const controller = createPlayerController(playerObject, keyboard, {
@@ -1536,24 +1556,20 @@ if (readyPromise && typeof readyPromise.then === 'function') {
 
   const flyBypassInput = {
     held(code) {
-      if (!keyboard || typeof keyboard.isDown !== 'function') {
+      if (!keyboard) {
         return false;
       }
-      switch (code) {
-        case 'flyUp':
-          return keyboard.isDown('Space') || keyboard.isDown('KeyE');
-        case 'flyDown':
-          return (
-            keyboard.isDown('ShiftLeft') ||
-            keyboard.isDown('ShiftRight') ||
-            keyboard.isDown('ControlLeft') ||
-            keyboard.isDown('ControlRight') ||
-            keyboard.isDown('KeyQ') ||
-            keyboard.isDown('KeyC')
-          );
-        default:
-          return keyboard.isDown(code);
+      const actionApi = keyboard.actions;
+      if (actionApi && typeof actionApi.isDown === 'function') {
+        const actionCodes = typeof actionApi.codes === 'function' ? actionApi.codes(code) : [];
+        if (Array.isArray(actionCodes) && actionCodes.length > 0) {
+          return actionApi.isDown(code);
+        }
       }
+      if (typeof keyboard.isDown === 'function') {
+        return keyboard.isDown(code);
+      }
+      return false;
     }
   };
 

--- a/src/input/keyboard.js
+++ b/src/input/keyboard.js
@@ -1,3 +1,5 @@
+import { getManifestActionCodes, hasManifestCode } from './manifest.js';
+
 const INV_SQRT2 = 1 / Math.sqrt(2);
 
 const MOVEMENT_KEYS = [
@@ -31,7 +33,7 @@ const EXTRA_KEYS = [
   'KeyP'
 ];
 
-const RELEVANT_KEYS = new Set([...MOVEMENT_KEYS, ...LOOK_KEYS, ...MODIFIER_KEYS, ...EXTRA_KEYS]);
+const BASE_RELEVANT_KEYS = new Set([...MOVEMENT_KEYS, ...LOOK_KEYS, ...MODIFIER_KEYS, ...EXTRA_KEYS]);
 
 const KEY_FALLBACK_MAP = new Map([
   ['w', 'KeyW'],
@@ -57,6 +59,16 @@ const KEY_FALLBACK_MAP = new Map([
   ['shift', 'ShiftLeft'],
   ['control', 'ControlLeft']
 ]);
+
+const isRelevantKey = (code) => {
+  if (typeof code !== 'string' || code.length === 0) {
+    return false;
+  }
+  if (BASE_RELEVANT_KEYS.has(code)) {
+    return true;
+  }
+  return hasManifestCode(code);
+};
 
 const normalizeCode = (event) => {
   if (!event) {
@@ -103,7 +115,7 @@ export function createKeyboard(target = typeof window !== 'undefined' ? window :
       }
     }
 
-    if (!RELEVANT_KEYS.has(code)) {
+    if (!isRelevantKey(code)) {
       return;
     }
     if (!pressed.has(code)) {
@@ -116,7 +128,7 @@ export function createKeyboard(target = typeof window !== 'undefined' ? window :
   const handleKeyUp = (event) => {
     const code = normalizeCode(event);
 
-    if (!RELEVANT_KEYS.has(code)) {
+    if (!isRelevantKey(code)) {
       return;
     }
     pressed.delete(code);
@@ -243,6 +255,38 @@ export function createKeyboard(target = typeof window !== 'undefined' ? window :
     return false;
   };
 
+  const actions = {
+    isDown(action) {
+      const codes = getManifestActionCodes(action);
+      if (!codes.length) {
+        return false;
+      }
+      for (let i = 0; i < codes.length; i += 1) {
+        if (isDown(codes[i])) {
+          return true;
+        }
+      }
+      return false;
+    },
+    wasPressed(action) {
+      const codes = getManifestActionCodes(action);
+      if (!codes.length) {
+        return false;
+      }
+      for (let i = 0; i < codes.length; i += 1) {
+        const code = codes[i];
+        if (frameJustPressed.has(code)) {
+          frameJustPressed.delete(code);
+          return true;
+        }
+      }
+      return false;
+    },
+    codes(action) {
+      return getManifestActionCodes(action);
+    }
+  };
+
   const dispose = () => {
     if (!target || !target.removeEventListener) {
       return;
@@ -263,6 +307,7 @@ export function createKeyboard(target = typeof window !== 'undefined' ? window :
     axis,
     look,
     wasPressed,
+    actions,
     dispose
   };
 }

--- a/src/input/manifest.js
+++ b/src/input/manifest.js
@@ -1,0 +1,173 @@
+const DEFAULT_KEYBOARD_MANIFEST = Object.freeze({
+  flyToggle: ['KeyF', 'KeyX'],
+  flyUp: ['Space', 'KeyE'],
+  flyDown: ['ShiftLeft', 'ShiftRight', 'ControlLeft', 'ControlRight', 'KeyQ', 'KeyC']
+});
+
+let manifest = {
+  flyToggle: [...DEFAULT_KEYBOARD_MANIFEST.flyToggle],
+  flyUp: [...DEFAULT_KEYBOARD_MANIFEST.flyUp],
+  flyDown: [...DEFAULT_KEYBOARD_MANIFEST.flyDown]
+};
+
+let manifestKeySet = buildKeySet(manifest);
+
+function buildKeySet(source) {
+  const set = new Set();
+  if (!source || typeof source !== 'object') {
+    return set;
+  }
+  Object.values(source).forEach((codes) => {
+    if (!Array.isArray(codes)) {
+      return;
+    }
+    codes.forEach((code) => {
+      if (typeof code === 'string' && code) {
+        set.add(code);
+      }
+    });
+  });
+  return set;
+}
+
+function uniqueCodes(list) {
+  const seen = new Set();
+  const result = [];
+  if (!Array.isArray(list)) {
+    return result;
+  }
+  for (const value of list) {
+    if (typeof value !== 'string' || value.length === 0) {
+      continue;
+    }
+    if (seen.has(value)) {
+      continue;
+    }
+    seen.add(value);
+    result.push(value);
+  }
+  return result;
+}
+
+function arraysEqual(a, b) {
+  if (a === b) return true;
+  if (!Array.isArray(a) || !Array.isArray(b)) {
+    return false;
+  }
+  if (a.length !== b.length) {
+    return false;
+  }
+  for (let i = 0; i < a.length; i += 1) {
+    if (a[i] !== b[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function normalizeManifestEntry(value) {
+  if (!value && value !== 0) {
+    return { codes: [], mode: 'extend' };
+  }
+  if (typeof value === 'string') {
+    return { codes: uniqueCodes([value]), mode: 'extend' };
+  }
+  if (Array.isArray(value)) {
+    return { codes: uniqueCodes(value), mode: 'extend' };
+  }
+  if (typeof value === 'object') {
+    const mode = value.mode === 'replace' ? 'replace' : 'extend';
+    const codes = Array.isArray(value.keys) ? uniqueCodes(value.keys) : [];
+    return { codes, mode };
+  }
+  return { codes: [], mode: 'extend' };
+}
+
+function rebuildManifestKeySet() {
+  manifestKeySet = buildKeySet(manifest);
+}
+
+export function getKeyboardManifest() {
+  const copy = {};
+  Object.entries(manifest).forEach(([action, codes]) => {
+    copy[action] = Array.isArray(codes) ? [...codes] : [];
+  });
+  return copy;
+}
+
+export function getManifestActionCodes(action) {
+  if (!action || typeof action !== 'string') {
+    return [];
+  }
+  const codes = manifest[action];
+  return Array.isArray(codes) ? [...codes] : [];
+}
+
+export function hasManifestCode(code) {
+  if (typeof code !== 'string' || code.length === 0) {
+    return false;
+  }
+  return manifestKeySet.has(code);
+}
+
+export function getManifestKeySet() {
+  return new Set(manifestKeySet);
+}
+
+export function extendKeyboardManifest(overrides = {}) {
+  if (!overrides || typeof overrides !== 'object') {
+    return getKeyboardManifest();
+  }
+  let mutated = false;
+  Object.entries(overrides).forEach(([action, value]) => {
+    if (!action || typeof action !== 'string') {
+      return;
+    }
+    const { codes, mode } = normalizeManifestEntry(value);
+    if (!codes.length) {
+      return;
+    }
+    const existing = Array.isArray(manifest[action]) ? manifest[action] : [];
+    let next = [];
+    if (mode === 'replace') {
+      next = uniqueCodes(codes);
+    } else {
+      next = uniqueCodes([...existing, ...codes]);
+    }
+    if (!arraysEqual(existing, next)) {
+      manifest[action] = next;
+      mutated = true;
+    }
+  });
+  if (mutated) {
+    rebuildManifestKeySet();
+  }
+  return getKeyboardManifest();
+}
+
+export function isActionActive(keyboard, action) {
+  if (!keyboard || typeof keyboard.isDown !== 'function' || !action) {
+    return false;
+  }
+  const codes = getManifestActionCodes(action);
+  if (!codes.length) {
+    return false;
+  }
+  for (let i = 0; i < codes.length; i += 1) {
+    if (keyboard.isDown(codes[i])) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function resetKeyboardManifest() {
+  manifest = {
+    flyToggle: [...DEFAULT_KEYBOARD_MANIFEST.flyToggle],
+    flyUp: [...DEFAULT_KEYBOARD_MANIFEST.flyUp],
+    flyDown: [...DEFAULT_KEYBOARD_MANIFEST.flyDown]
+  };
+  rebuildManifestKeySet();
+}
+
+export { DEFAULT_KEYBOARD_MANIFEST };

--- a/src/player/playerController.js
+++ b/src/player/playerController.js
@@ -4,6 +4,7 @@ import { keepUpright } from '../physics/upright.js';
 import { Capsule, resolveCapsuleVsAABBs } from '../physics/collision.js';
 import { movementConfig, FLIGHT as FLIGHT_DEFAULTS } from '../config/movement.ts';
 import { sanitizeVec3, DEFAULT_PLAYER } from '../utils/sanitize.ts';
+import { isActionActive } from '../input/manifest.js';
 import { logger } from '../utils/logger.ts';
 
 const moveDirection = new THREE.Vector3();
@@ -60,19 +61,6 @@ const SAFE_POSITION = {
 const ZERO_VECTOR = { x: 0, y: 0, z: 0 };
 
 const flightOptions = movementConfig?.flight ?? {};
-const FLIGHT_TOGGLE_KEY = typeof flightOptions.toggleKey === 'string' ? flightOptions.toggleKey : 'KeyF';
-const defaultToggleKeys = (() => {
-  const configured = Array.isArray(flightOptions.toggleKeys) && flightOptions.toggleKeys.length
-    ? flightOptions.toggleKeys
-    : [];
-  const combined = configured.filter((value) => typeof value === 'string');
-  if (typeof FLIGHT_TOGGLE_KEY === 'string') {
-    combined.push(FLIGHT_TOGGLE_KEY);
-  }
-  combined.push('KeyX');
-  return combined.filter((value, index, array) => array.indexOf(value) === index);
-})();
-const toggleKeySet = new Set(defaultToggleKeys.length ? defaultToggleKeys : [FLIGHT_TOGGLE_KEY]);
 const FLIGHT_HORIZONTAL_SPEED = Number.isFinite(flightOptions.horizontalSpeed)
   ? flightOptions.horizontalSpeed
   : FLIGHT_DEFAULTS.horizontalSpeed;
@@ -92,27 +80,6 @@ const FLIGHT_EXIT_HOVER = Number.isFinite(flightOptions.exitHover) ? flightOptio
 const FLIGHT_GRACE_FRAMES = Number.isFinite(flightOptions.startGraceFrames)
   ? Math.max(0, flightOptions.startGraceFrames)
   : 3;
-
-const defaultAscendKeys = Array.isArray(flightOptions.ascendKeys) && flightOptions.ascendKeys.length
-  ? flightOptions.ascendKeys
-  : ['Space', 'KeyE'];
-const defaultDescendKeys = Array.isArray(flightOptions.descendKeys) && flightOptions.descendKeys.length
-  ? flightOptions.descendKeys
-  : ['ShiftLeft', 'ShiftRight', 'ControlLeft', 'ControlRight', 'KeyQ', 'KeyC'];
-const ascendKeySet = new Set(defaultAscendKeys);
-const descendKeySet = new Set(defaultDescendKeys);
-
-function isAnyKeyDown(keyboard, keySet) {
-  if (!keyboard || typeof keyboard.isDown !== 'function') {
-    return false;
-  }
-  for (const code of keySet) {
-    if (keyboard.isDown(code)) {
-      return true;
-    }
-  }
-  return false;
-}
 
 function sanitizePosition(vec3) {
   if (!vec3) {
@@ -284,7 +251,7 @@ export function createPlayerController(
     }
     sanitizePosition(position);
 
-    const toggleDown = isAnyKeyDown(currentKeyboard, toggleKeySet);
+    const toggleDown = isActionActive(currentKeyboard, 'flyToggle');
     if (toggleDown && !prevToggleDown) {
       if (isFlying) {
         exitFlight();
@@ -392,8 +359,8 @@ export function createPlayerController(
     sanitizeVec3(velocity, ZERO_VECTOR);
 
     if (isFlying) {
-      const ascendHeld = isAnyKeyDown(currentKeyboard, ascendKeySet);
-      const descendHeld = isAnyKeyDown(currentKeyboard, descendKeySet);
+      const ascendHeld = isActionActive(currentKeyboard, 'flyUp');
+      const descendHeld = isActionActive(currentKeyboard, 'flyDown');
       const verticalInput = (ascendHeld ? 1 : 0) - (descendHeld ? 1 : 0);
       const verticalSpeed = Number.isFinite(FLIGHT_VERTICAL_SPEED)
         ? Math.max(0, FLIGHT_VERTICAL_SPEED)


### PR DESCRIPTION
## Summary
- add a keyboard manifest with default flight bindings and helpers for manifest-aware queries
- use the manifest-driven action APIs across the keyboard, player controller, and init flow so flight keys come from config overrides
- update the fly bypass helpers to rely on manifest action state instead of direct key checks

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68dceabc31f08327a42f716cddb18c91