### PR TITLE
Refactor environment initialization to avoid import cycles

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "size-report": "tsx scripts/file-sizes.ts",
     "tag:checkpoint": "node -e \"const d=new Date();const p=n=>String(n).padStart(2,'0');const v=`v${d.getFullYear()}.${p(d.getMonth()+1)}.${p(d.getDate())}-a`;console.log(v)\" | xargs -I {} git tag -a {} -m \"Checkpoint\" && git push --tags",
     "lint:unused": "eslint 'src/**/*.{ts,tsx,js}' --max-warnings=0",
-    "reachability": "node ./scripts/reachability.mjs",
+    "reachability": "node ./scripts/reachability.mjs && tsx scripts/check-cycles.ts",
     "gen:skyground": "node scripts/generate-sky-ground-assets.js"
   },
   "dependencies": {

--- a/scripts/check-cycles.ts
+++ b/scripts/check-cycles.ts
@@ -1,0 +1,240 @@
+import { readFileSync, existsSync, statSync } from 'node:fs';
+import { readdir } from 'node:fs/promises';
+import path from 'node:path';
+
+type Graph = Map<string, Set<string>>;
+
+const SRC_DIR = path.resolve(process.cwd(), 'src');
+const EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs'];
+
+async function collectSourceFiles(dir: string): Promise<string[]> {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files: string[] = [];
+
+  for (const entry of entries) {
+    const entryPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await collectSourceFiles(entryPath)));
+    } else if (EXTENSIONS.some((ext) => entry.name.endsWith(ext))) {
+      files.push(entryPath);
+    }
+  }
+
+  return files;
+}
+
+function normalizeNode(filePath: string): string | null {
+  const relative = path.relative(SRC_DIR, filePath);
+  if (relative.startsWith('..')) {
+    return null;
+  }
+  return relative.replace(/\\/g, '/');
+}
+
+function resolveImport(fromFile: string, specifier: string): string | null {
+  if (!specifier.startsWith('.')) {
+    return null;
+  }
+
+  const fromDir = path.dirname(fromFile);
+  const resolved = path.resolve(fromDir, specifier);
+
+  const candidateFiles: string[] = [];
+
+  if (existsSync(resolved) && statSync(resolved).isFile()) {
+    candidateFiles.push(resolved);
+  }
+
+  for (const ext of EXTENSIONS) {
+    candidateFiles.push(`${resolved}${ext}`);
+  }
+
+  for (const ext of EXTENSIONS) {
+    candidateFiles.push(path.join(resolved, `index${ext}`));
+  }
+
+  for (const candidate of candidateFiles) {
+    if (existsSync(candidate) && statSync(candidate).isFile()) {
+      return candidate;
+    }
+  }
+
+  return null;
+}
+
+function addEdge(graph: Graph, from: string, to: string) {
+  if (!graph.has(from)) {
+    graph.set(from, new Set());
+  }
+  graph.get(from)!.add(to);
+}
+
+function parseImports(filePath: string): string[] {
+  const content = readFileSync(filePath, 'utf8');
+  const edges: string[] = [];
+
+  const importRegex = /import\s+(?:type\s+)?[^'";]*?from\s*['"]([^'"\\]+)['"];?|import\s*\(\s*['"]([^'"\\]+)['"]\s*\)/g;
+
+  for (let match = importRegex.exec(content); match; match = importRegex.exec(content)) {
+    const specifier = match[1] ?? match[2];
+    const fullMatch = match[0];
+
+    if (!specifier) {
+      continue;
+    }
+
+    if (/^import\s+type\b/.test(fullMatch)) {
+      continue;
+    }
+
+    const resolved = resolveImport(filePath, specifier);
+    if (!resolved) {
+      continue;
+    }
+
+    const normalized = normalizeNode(resolved);
+    if (normalized) {
+      edges.push(normalized);
+    }
+  }
+
+  return edges;
+}
+
+function buildGraph(files: string[]): Graph {
+  const graph: Graph = new Map();
+
+  for (const file of files) {
+    const fromNode = normalizeNode(file);
+    if (!fromNode) {
+      continue;
+    }
+    const imports = parseImports(file);
+    for (const to of imports) {
+      addEdge(graph, fromNode, to);
+    }
+  }
+
+  return graph;
+}
+
+type TarjanState = {
+  index: number;
+  stack: string[];
+  indices: Map<string, number>;
+  lowlinks: Map<string, number>;
+  onStack: Set<string>;
+  components: string[][];
+};
+
+function strongConnect(node: string, graph: Graph, state: TarjanState) {
+  state.indices.set(node, state.index);
+  state.lowlinks.set(node, state.index);
+  state.index += 1;
+  state.stack.push(node);
+  state.onStack.add(node);
+
+  const neighbours = graph.get(node) ?? new Set();
+  for (const neighbour of neighbours) {
+    if (!state.indices.has(neighbour)) {
+      strongConnect(neighbour, graph, state);
+      state.lowlinks.set(
+        node,
+        Math.min(state.lowlinks.get(node)!, state.lowlinks.get(neighbour)!)
+      );
+    } else if (state.onStack.has(neighbour)) {
+      state.lowlinks.set(
+        node,
+        Math.min(state.lowlinks.get(node)!, state.indices.get(neighbour)!)
+      );
+    }
+  }
+
+  if (state.lowlinks.get(node) === state.indices.get(node)) {
+    const component: string[] = [];
+    let w: string | undefined;
+    do {
+      w = state.stack.pop();
+      if (!w) {
+        break;
+      }
+      state.onStack.delete(w);
+      component.push(w);
+    } while (w !== node);
+    if (component.length > 0) {
+      state.components.push(component);
+    }
+  }
+}
+
+function findStronglyConnectedComponents(graph: Graph): string[][] {
+  const state: TarjanState = {
+    index: 0,
+    stack: [],
+    indices: new Map(),
+    lowlinks: new Map(),
+    onStack: new Set(),
+    components: [],
+  };
+
+  for (const node of graph.keys()) {
+    if (!state.indices.has(node)) {
+      strongConnect(node, graph, state);
+    }
+  }
+
+  return state.components.filter((component) => {
+    if (component.length > 1) {
+      return true;
+    }
+    const single = component[0];
+    const neighbours = graph.get(single);
+    return neighbours?.has(single) ?? false;
+  });
+}
+
+function componentLabel(component: string[]): string {
+  return component.map((node) => `- ${node}`).join('\n');
+}
+
+function isPriorityComponent(component: string[]): boolean {
+  const priorityPatterns = [
+    /entry\/initializeAthens/i,
+    /environment\//i,
+    /sky/i,
+  ];
+  return component.some((node) => priorityPatterns.some((pattern) => pattern.test(node)));
+}
+
+async function main() {
+  const files = await collectSourceFiles(SRC_DIR);
+  const graph = buildGraph(files);
+  const components = findStronglyConnectedComponents(graph);
+
+  if (components.length === 0) {
+    console.log('No import cycles detected.');
+    return;
+  }
+
+  console.log('Import cycles detected:');
+  let priority = false;
+  for (const component of components) {
+    const label = componentLabel(component);
+    const marker = isPriorityComponent(component) ? ' (priority)' : '';
+    console.log(`\nCycle${marker}:\n${label}`);
+    if (!priority && isPriorityComponent(component)) {
+      priority = true;
+    }
+  }
+
+  if (priority) {
+    console.error('\nPriority cycles remain among initializeAthens/environment/sky modules.');
+    process.exitCode = 1;
+  }
+}
+
+main().catch((error) => {
+  console.error('Failed to analyze import graph:', error);
+  process.exitCode = 1;
+});
+

--- a/src/config/hotkeys.ts
+++ b/src/config/hotkeys.ts
@@ -220,14 +220,16 @@ for (const def of actionRegistry.values()) {
 
 export const RELEVANT_KEYS = relevantKeys;
 
-const fallbackPairs: [string, string][] = [];
+const fallbackMap = new Map<string, string>();
 for (const def of actionRegistry.values()) {
-  for (const entry of def.fallback) {
-    fallbackPairs.push(entry);
+  for (const [key, code] of def.fallback) {
+    if (!fallbackMap.has(key)) {
+      fallbackMap.set(key, code);
+    }
   }
 }
 
-export const KEY_FALLBACK_MAP = new Map(fallbackPairs);
+export const KEY_FALLBACK_MAP = fallbackMap;
 
 export const ACTION_CODES = actionCodes;
 export const ACTION_REGISTRY = actionRegistry;

--- a/src/entry/__tests__/boot-smoke.test.ts
+++ b/src/entry/__tests__/boot-smoke.test.ts
@@ -1,0 +1,443 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { mock } from 'node:test';
+
+type ThreeModule = typeof import('three');
+
+class FakeElement {
+  style: Record<string, string> = {};
+  children: FakeElement[] = [];
+  parentNode: FakeElement | null = null;
+  id = '';
+  clientWidth = 1024;
+  clientHeight = 768;
+
+  appendChild(child: FakeElement) {
+    this.children.push(child);
+    child.parentNode = this;
+    return child;
+  }
+
+  removeChild(child: FakeElement) {
+    this.children = this.children.filter((c) => c !== child);
+    child.parentNode = null;
+    return child;
+  }
+
+  contains(child: FakeElement) {
+    return this.children.includes(child);
+  }
+
+  getContext(_: string) {
+    return {};
+  }
+
+  addEventListener() {}
+  removeEventListener() {}
+}
+
+class FakeCanvas extends FakeElement {
+  width = 1024;
+  height = 768;
+
+  getContext() {
+    return {};
+  }
+}
+
+function createFakeContainer(): FakeElement {
+  const container = new FakeElement();
+  container.clientWidth = 1024;
+  container.clientHeight = 768;
+  return container;
+}
+
+function setupDom(three: ThreeModule) {
+  const body = new FakeElement();
+  const documentStub = {
+    body,
+    createElement(tag: string) {
+      return tag === 'canvas' ? new FakeCanvas() : new FakeElement();
+    },
+    getElementById: () => null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+  } as unknown as Document;
+
+  const rafHandles = new Map<number, NodeJS.Timeout>();
+  let rafId = 1;
+
+  const windowStub: any = {
+    devicePixelRatio: 1,
+    innerWidth: 1024,
+    innerHeight: 768,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    requestAnimationFrame: (cb: FrameRequestCallback) => {
+      const id = rafId++;
+      const handle = setTimeout(() => cb(0), 0);
+      rafHandles.set(id, handle);
+      return id;
+    },
+    cancelAnimationFrame: (id: number) => {
+      const handle = rafHandles.get(id);
+      if (handle) {
+        clearTimeout(handle);
+        rafHandles.delete(id);
+      }
+    },
+    setTimeout,
+    clearTimeout,
+    location: { search: '' },
+    navigator: {},
+    THREE: three,
+    performance: { now: () => Date.now() },
+  };
+
+  (globalThis as any).window = windowStub;
+  (globalThis as any).document = documentStub;
+  (globalThis as any).performance = windowStub.performance;
+  (globalThis as any).requestAnimationFrame = windowStub.requestAnimationFrame;
+  (globalThis as any).cancelAnimationFrame = windowStub.cancelAnimationFrame;
+}
+
+function teardownDom() {
+  delete (globalThis as any).window;
+  delete (globalThis as any).document;
+  delete (globalThis as any).performance;
+  delete (globalThis as any).requestAnimationFrame;
+  delete (globalThis as any).cancelAnimationFrame;
+}
+
+async function stubThree(): Promise<ThreeModule> {
+  const THREE = await import('three');
+
+  mock.method(THREE, 'WebGLRenderer', function WebGLRenderer(this: any) {
+    this.domElement = new FakeCanvas();
+    this.domElement.style = this.domElement.style || {};
+    this.shadowMap = { enabled: false };
+    this.autoClear = true;
+    this.setClearColor = () => {};
+    this.setClearAlpha = () => {};
+    this.setPixelRatio = () => {};
+    this.setSize = () => {};
+    this.render = () => {};
+    this.dispose = () => {};
+    this.getContext = () => ({
+      getExtension: () => null,
+    });
+    this.capabilities = { getMaxAnisotropy: () => 1 };
+    return this;
+  });
+
+  mock.method(THREE, 'TextureLoader', function TextureLoader(this: any) {
+    this.load = (
+      _url: string,
+      onLoad: (tex: any) => void,
+      _onProgress?: () => void,
+      onError?: (err: unknown) => void,
+    ) => {
+      try {
+        const texture = new THREE.Texture();
+        texture.repeat.set(1, 1);
+        texture.dispose = () => {};
+        setTimeout(() => onLoad(texture), 0);
+      } catch (error) {
+        onError?.(error);
+      }
+      return {};
+    };
+    return this;
+  });
+
+  mock.method(THREE, 'CubeTextureLoader', function CubeTextureLoader(this: any) {
+    this.load = (
+      _urls: string[],
+      onLoad: (tex: any) => void,
+      _onProgress?: () => void,
+      onError?: (err: unknown) => void,
+    ) => {
+      try {
+        const texture = new THREE.CubeTexture();
+        texture.dispose = () => {};
+        setTimeout(() => onLoad(texture), 0);
+      } catch (error) {
+        onError?.(error);
+      }
+      return {};
+    };
+    return this;
+  });
+
+  mock.method(THREE, 'PMREMGenerator', function PMREMGenerator(this: any) {
+    this.compileEquirectangularShader = () => {};
+    this.fromEquirectangular = () => ({ texture: new THREE.Texture() });
+    this.fromCubemap = () => ({ texture: new THREE.Texture() });
+    this.dispose = () => {};
+    return this;
+  });
+
+  mock.method(THREE, 'AudioListener', function AudioListener(this: any) {
+    this.context = { state: 'running', resume: () => Promise.resolve() };
+    this.getContext = () => this.context;
+    return this;
+  });
+
+  mock.method(THREE, 'AudioLoader', function AudioLoader(this: any) {
+    this.load = (
+      _url: string,
+      onLoad: (buffer: any) => void,
+      _onProgress?: () => void,
+      onError?: (err: unknown) => void,
+    ) => {
+      try {
+        setTimeout(() => onLoad({}), 0);
+      } catch (error) {
+        onError?.(error);
+      }
+      return {};
+    };
+    return this;
+  });
+
+  mock.method(THREE, 'Audio', function Audio(this: any, _listener: any) {
+    this.setBuffer = () => {};
+    this.setLoop = () => {};
+    this.setVolume = () => {};
+    this.play = () => {};
+    this.stop = () => {};
+    return this;
+  });
+
+  return THREE;
+}
+
+async function stubEnvironmentModule() {
+  const environmentModule = await import('../../environment/EnvironmentController.ts');
+  mock.method(environmentModule, 'createEnvironmentController', () => {
+    const manager: any = {
+      mode: 'day',
+      async applySky() {
+        return manager.mode;
+      },
+      setMode(next: string) {
+        manager.mode = next;
+        return next;
+      },
+      dispose() {},
+    };
+    Object.defineProperty(manager, 'skyMode', {
+      get() {
+        return manager.mode;
+      },
+      set(value: string) {
+        manager.mode = value;
+      },
+      configurable: true,
+    });
+    return manager;
+  });
+  mock.method(environmentModule, 'registerExternalSkyImages', () => {});
+  mock.method(environmentModule, 'applySkyImage', async () => {});
+}
+
+async function stubAppModules(THREE: ThreeModule) {
+  await stubEnvironmentModule();
+
+  const mainModule = await import('../../main.js');
+  mock.method(mainModule, 'setupGround', async () => ({
+    root: new THREE.Group(),
+    dispose() {},
+  }));
+  mock.method(mainModule, 'updateTrees', () => {});
+
+  const cityModule = await import('../../buildings/createCity.js');
+  mock.method(cityModule, 'createCity', async () => {
+    const root = new THREE.Group();
+    root.userData = { layeredGround: false } as any;
+    root.getObjectByName = () => ({ isMesh: true, material: { dispose() {} } }) as any;
+    return {
+      root,
+      materials: [],
+      dispose() {},
+    };
+  });
+
+  const grassModule = await import('../../materials/groundGrass.js');
+  mock.method(grassModule, 'loadGrassMaterial', async () => ({ dispose() {} }));
+
+  const navmeshModule = await import('../../navmesh/buildNavMesh.js');
+  mock.method(navmeshModule, 'buildNavMeshFromMeshes', () => ({ dispose() {} }));
+
+  const navPathModule = await import('../../navmesh/pathfinder.js');
+  mock.method(navPathModule, 'createNavMeshPathfinder', () => ({ dispose() {} }));
+
+  const npcModule = await import('../../npc/npcSystem.js');
+  mock.method(npcModule, 'createNpcSystem', () => ({
+    initializeNpcs: () => {},
+    update: () => {},
+    dispose: () => {},
+  }));
+
+  const mainCharModule = await import('../../npc/mainCharacter.js');
+  mock.method(mainCharModule, 'createMainCharacter', () => ({
+    object3d: new THREE.Object3D(),
+    ready: Promise.resolve(),
+    update: () => {},
+    dispose: () => {},
+  }));
+
+  const keyboardModule = await import('../../input/keyboard.js');
+  mock.method(keyboardModule, 'createKeyboard', () => ({
+    isActionDown: () => false,
+    isDown: () => false,
+    dispose: () => {},
+  }));
+
+  const followCameraModule = await import('../../camera/followCamera.js');
+  mock.method(followCameraModule, 'createFollowCamera', () => ({
+    target: new THREE.Vector3(),
+    update: () => {},
+    dispose: () => {},
+    setPointerLockElement: () => {},
+    setTarget: () => {},
+    syncImmediate: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+  }));
+
+  const seedCameraModule = await import('../../camera/seedCameraBehindPlayer.js');
+  mock.method(seedCameraModule, 'seedCameraBehindPlayer', () => {});
+
+  const playerControllerModule = await import('../../player/playerController.js');
+  mock.method(playerControllerModule, 'createPlayerController', () => ({
+    setGroundMeshes: () => {},
+    setColliders: () => {},
+    setObject: () => {},
+    update: () => {},
+    dispose: () => {},
+  }));
+
+  const flyBypassModule = await import('../../dev/flyBypass.js');
+  mock.method(flyBypassModule, 'installFlyBypass', () => ({ tick: () => {} }));
+
+  const loopModule = await import('../../engine/loop.js');
+  mock.method(loopModule, 'createGameLoop', () => ({
+    start: () => {},
+    stop: () => {},
+    pause: () => {},
+    resume: () => {},
+    dispose: () => {},
+    isRunning: () => true,
+    resetClock: () => {},
+  }));
+
+  const groundRegistryModule = await import('../../physics/groundRegistry.js');
+  mock.method(groundRegistryModule, 'markGround', () => {});
+  mock.method(groundRegistryModule, 'collectGround', () => []);
+
+  const colliderRegistryModule = await import('../../physics/colliderRegistry.js');
+  mock.method(colliderRegistryModule, 'markColliders', () => {});
+  mock.method(colliderRegistryModule, 'collectColliders', () => []);
+  mock.method(colliderRegistryModule, 'buildAABBs', () => []);
+
+  const groundProjectModule = await import('../../physics/groundProject.js');
+  mock.method(groundProjectModule, 'sampleGroundY', () => null);
+  mock.method(groundProjectModule, 'snapGroupToGround', () => false);
+  mock.method(groundProjectModule, 'snapObjectToGround', () => false);
+  mock.method(groundProjectModule, 'snapChildrenToGround', () => {});
+
+  const collisionWorldModule = await import('../../physics/collisionWorld.ts');
+  mock.method(collisionWorldModule, 'loadWorldWithColliders', async () => ({ colliderMesh: null, bvh: null }));
+
+  const characterModule = await import('../../controls/CharacterController.ts');
+  mock.method(characterModule, 'CharacterController', class CharacterController {
+    position = new THREE.Vector3();
+    velocity = new THREE.Vector3();
+    walkSpeed = 4;
+    update() {}
+    dispose() {}
+  } as any);
+
+  const inputModule = await import('../../controls/input.ts');
+  mock.method(inputModule, 'getInput', () => ({ forward: 0, right: 0, jump: false, sprint: false }));
+
+  const landmarksLoader = await import('../../landmarks-loader.js');
+  mock.method(landmarksLoader, 'loadLandmarks', async () => ({
+    dispose: () => {},
+    featureLines: { updateResolution: () => {} },
+  }));
+
+  const landmarkOverlayModule = await import('../../map/landmarks.js');
+  mock.method(landmarkOverlayModule, 'createLandmarkOverlay', async () => ({
+    requestRender: () => {},
+    destroy: () => {},
+  }));
+
+  const placerModule = await import('../../dev/landmarkPlacer.js');
+  mock.method(placerModule, 'createLandmarkPlacer', () => ({ dispose: () => {} }));
+
+  const roadsPointsModule = await import('../../roads/collectRoadPoints.js');
+  mock.method(roadsPointsModule, 'collectRoadPoints', () => []);
+
+  const roadNetworkModule = await import('../../roads/roadNetwork.js');
+  mock.method(roadNetworkModule, 'buildRoadNetwork', () => new THREE.Group());
+
+  const uiModule = await import('../../ui/originalUi.js');
+  mock.method(uiModule, 'createOriginalUi', () => ({ setTimeLabel: () => {}, destroy: () => {}, dispose: () => {} }));
+
+  const ambientModule = await import('../../audio/ambient.ts');
+  mock.method(ambientModule, 'initAmbient', async () => {});
+  mock.method(ambientModule, 'registerExternalAmbientTracks', () => {});
+
+  const renderGuardModule = await import('../../safety/hardenPositions.ts');
+  mock.method(renderGuardModule, 'installRenderGuard', () => {});
+
+  const skyDebugModule = await import('../../dev/skyDebugHooks.js');
+  mock.method(skyDebugModule, 'installSkyDev', () => {});
+}
+
+test('environment modules import without runtime side effects', async () => {
+  mock.restoreAll();
+  const THREE = await import('three');
+  let loaderCount = 0;
+  mock.method(THREE, 'TextureLoader', function TextureLoader(this: any) {
+    loaderCount += 1;
+    this.load = () => { throw new Error('should not load during import'); };
+    return this;
+  });
+  mock.method(THREE, 'CubeTextureLoader', function CubeTextureLoader(this: any) {
+    loaderCount += 1;
+    this.load = () => { throw new Error('should not load during import'); };
+    return this;
+  });
+  mock.method(THREE, 'PMREMGenerator', function PMREMGenerator(this: any) {
+    loaderCount += 1;
+    return this;
+  });
+
+  await import('../../environment/EnvironmentController.ts');
+  await import('../../scene/sky.ts');
+
+  assert.strictEqual(loaderCount, 0);
+  mock.restoreAll();
+});
+
+test('initializeAthens resolves with stubbed environment', async () => {
+  mock.restoreAll();
+  const THREE = await stubThree();
+  setupDom(THREE);
+  await stubAppModules(THREE);
+
+  const { initializeAthens } = await import('../initializeAthens.js');
+  const container = createFakeContainer();
+
+  try {
+    const context = await initializeAthens({ container, layout: 'classic', layoutConfig: {} });
+    assert.ok(context);
+    context.dispose?.();
+  } finally {
+    mock.restoreAll();
+    teardownDom();
+  }
+});

--- a/src/entry/initializeAthens.js
+++ b/src/entry/initializeAthens.js
@@ -51,10 +51,8 @@ import {
 import { CUSTOM_AMBIENT_TRACKS } from '../audio/customAmbientTracks.generated.ts';
 import { initAmbient, AmbientAPI, AMBIENT_TRACKS, registerExternalAmbientTracks } from '../audio/ambient.ts';
 // SKYSYS_START
-import { installSkyDev } from '../dev/skyDebugHooks.js';
-import { EnvironmentController } from '../environment/EnvironmentController.ts';
 import { SKY_JPGS, GROUND_JPGS } from '../assets/skyGround.generated.ts';
-import { registerExternalSkyImages, applySkyImage } from '../environment/EnvironmentController.ts';
+import { installSkyDev } from '../dev/skyDebugHooks.js';
 import { setExternalGroundTexture } from '../materials/groundGrass.js';
 // SKYSYS_END
 
@@ -560,7 +558,13 @@ export async function initializeAthens(options = {}) {
 
   renderer.setClearAlpha(1);
 
-  const environmentManager = new EnvironmentController(scene, renderer);
+  const {
+    createEnvironmentController,
+    registerExternalSkyImages,
+    applySkyImage,
+  } = await import('../environment/EnvironmentController.ts');
+
+  const environmentManager = createEnvironmentController({ scene, renderer });
 
   // Register discovered assets (safe no-ops if arrays are empty)
   try {

--- a/src/environment/EnvironmentController.ts
+++ b/src/environment/EnvironmentController.ts
@@ -56,6 +56,18 @@ export class EnvironmentController {
   }
 }
 
+export type EnvironmentControllerArgs = {
+  scene: THREE.Scene;
+  renderer: THREE.WebGLRenderer;
+};
+
+export function createEnvironmentController({
+  scene,
+  renderer,
+}: EnvironmentControllerArgs): EnvironmentController {
+  return new EnvironmentController(scene, renderer);
+}
+
 // Optional registry for external sky images discovered at build time
 let _externalSkyImages: Array<{ id: string; url: string; tags?: string[] }> = [];
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -53,6 +53,7 @@ export default defineConfig(() => ({
     },
   },
   build: {
+    sourcemap: true,
     target: 'esnext',
     rollupOptions: {
       input: {


### PR DESCRIPTION
## Summary
- add a TypeScript cycle checker script and wire it into the reachability npm script for visibility
- refactor initializeAthens to import environment helpers lazily and expose a factory for EnvironmentController to avoid TDZ issues
- harden keyboard fallback mappings and add a headless initializeAthens smoke test while enabling build sourcemaps

## Testing
- npm test
- npm run reachability

------
https://chatgpt.com/codex/tasks/task_b_68dceeaf306c83279a7ff03eedb15308