### PR TITLE
Guard service worker from synthetic cache-only requests

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -47,6 +47,14 @@ self.addEventListener('fetch', (event) => {
     return;
   }
 
+  // Chrome will issue synthetic requests with cache: "only-if-cached" and
+  // mode !== "same-origin" during navigation preload. Intercepting them and
+  // attempting to respond manually causes `TypeError: Failed to convert value
+  // to 'Response'`. Let the browser handle those requests instead.
+  if (req.cache === 'only-if-cached' && req.mode !== 'same-origin') {
+    return;
+  }
+
   event.respondWith((async () => {
     try {
       const cached = await caches.match(req);


### PR DESCRIPTION
## Summary
- skip handling synthetic only-if-cached requests generated by Chrome navigation preload
- add documentation in the service worker explaining why these requests are ignored

## Testing
- `npm test` *(fails: tsx command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_b_68dcf60fbc78832795af39c672129dcc