### PR TITLE
Harden service worker cache handling

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -1,83 +1,153 @@
 // ---- service-worker.js ----
 
-// Bump this whenever you change the SW to force an update
-const CACHE_NAME = 'athens-static-v8';
+const CACHE_NAME = 'athens-static-v9';
+const ASSET_EXT = /\.(?:js|css|html|json|wasm|png|jpg|jpeg|webp|gif|svg|ico|mp3|wav|ogg|flac|glb|gltf|ktx2|hdr|bin|txt)(\?.*)?$/i;
 
-// Optional pre-cache list (can stay empty for GH Pages)
-const PRECACHE_URLS = [];
+const INDEX_CACHE_KEY = (() => {
+  try {
+    const scope = self?.registration?.scope ?? self?.location?.origin ?? '/';
+    return new URL('index.html', scope).href;
+  } catch (error) {
+    return '/index.html';
+  }
+})();
 
 self.addEventListener('install', (event) => {
   self.skipWaiting();
-  event.waitUntil(
-    caches.open(CACHE_NAME).then(cache => cache.addAll(PRECACHE_URLS)).catch(() => {})
-  );
+  const precache = caches.open(CACHE_NAME).then((cache) => cache.addAll([])).catch(() => {});
+  event.waitUntil(precache);
 });
 
 self.addEventListener('activate', (event) => {
   event.waitUntil((async () => {
-    const keys = await caches.keys();
-    await Promise.all(keys.filter(k => k !== CACHE_NAME).map(k => caches.delete(k)));
-    await self.clients.claim();
+    try {
+      const keys = await caches.keys();
+      await Promise.all(
+        keys.map((key) => (key !== CACHE_NAME ? caches.delete(key) : Promise.resolve()))
+      );
+    } catch (error) {
+      // ignore cache cleanup errors
+    }
+    try {
+      await self.clients.claim();
+    } catch (error) {
+      // ignore claim failures
+    }
   })());
 });
 
-async function safeNetwork(req) {
-  try {
-    return await fetch(req);
-  } catch (err) {
-    // Always return a Response so respondWith never rejects
-    return new Response(JSON.stringify({ ok: false, error: 'network-error' }), {
-      status: 502,
-      headers: { 'Content-Type': 'application/json' }
-    });
+function isHtmlRequest(request) {
+  if (!request) {
+    return false;
   }
+  if (request.mode === 'navigate') {
+    return true;
+  }
+  const accept = request.headers?.get?.('accept') ?? '';
+  return accept.includes('text/html');
+}
+
+function putInCache(request, response) {
+  if (!request || !response) {
+    return Promise.resolve();
+  }
+  return caches
+    .open(CACHE_NAME)
+    .then((cache) => cache.put(request, response))
+    .catch(() => {});
+}
+
+function putIndexInCache(response) {
+  if (!response) {
+    return Promise.resolve();
+  }
+  return caches
+    .open(CACHE_NAME)
+    .then((cache) => cache.put(INDEX_CACHE_KEY, response))
+    .catch(() => {});
+}
+
+async function matchInCache(request, options) {
+  try {
+    const cache = await caches.open(CACHE_NAME);
+    const match = await cache.match(request, options);
+    if (match) {
+      return match;
+    }
+  } catch (error) {
+    // ignore cache lookup errors
+  }
+  return null;
 }
 
 self.addEventListener('fetch', (event) => {
-  const req = event.request;
-  const url = new URL(req.url);
-  const isSameOrigin = url.origin === self.location.origin;
-
-  // Only handle same-origin GET requests. Others should be left to the
-  // browser's default network handling. Responding to cross-origin or
-  // non-GET requests can trigger "Failed to convert value to 'Response'"
-  // errors in some browsers because the response must comply with stricter
-  // mode/type requirements (e.g. opaque responses for no-cors fetches).
-  if (req.method !== 'GET' || !isSameOrigin) {
+  const request = event.request;
+  if (!request || request.method !== 'GET') {
     return;
   }
 
-  // Chrome will issue synthetic requests with cache: "only-if-cached" and
-  // mode !== "same-origin" during navigation preload. Intercepting them and
-  // attempting to respond manually causes `TypeError: Failed to convert value
-  // to 'Response'`. Let the browser handle those requests instead.
-  if (req.cache === 'only-if-cached' && req.mode !== 'same-origin') {
+  const url = new URL(request.url);
+  const sameOrigin = url.origin === self.location.origin;
+
+  if (!sameOrigin) {
+    return;
+  }
+
+  if (request.cache === 'only-if-cached' && request.mode !== 'same-origin') {
+    return;
+  }
+
+  if (isHtmlRequest(request)) {
+    event.respondWith((async () => {
+      try {
+        const networkResponse = await fetch(request);
+        if (networkResponse && networkResponse.ok) {
+          const clone = networkResponse.clone();
+          event.waitUntil(putIndexInCache(clone));
+        }
+        return networkResponse;
+      } catch (error) {
+        const cached = await matchInCache(INDEX_CACHE_KEY, { ignoreSearch: true });
+        if (cached) {
+          return cached;
+        }
+        return new Response('', { status: 504, statusText: 'Gateway Timeout' });
+      }
+    })());
+    return;
+  }
+
+  const isStaticAsset = ASSET_EXT.test(url.pathname);
+
+  if (isStaticAsset) {
+    event.respondWith((async () => {
+      try {
+        const networkResponse = await fetch(request);
+        if (networkResponse && networkResponse.ok) {
+          const clone = networkResponse.clone();
+          event.waitUntil(putInCache(request, clone));
+        }
+        return networkResponse;
+      } catch (error) {
+        const cached = await matchInCache(request, { ignoreSearch: true });
+        if (cached) {
+          return cached;
+        }
+        return new Response('', { status: 504, statusText: 'Gateway Timeout' });
+      }
+    })());
     return;
   }
 
   event.respondWith((async () => {
     try {
-      const cached = await caches.match(req);
-      if (cached) return cached;
-
-      const res = await fetch(req);
-      if (res && res.ok && res.type === 'basic') {
-        const cache = await caches.open(CACHE_NAME);
-        cache.put(req, res.clone());
+      return await fetch(request);
+    } catch (error) {
+      const cached = await matchInCache(request, { ignoreSearch: true });
+      if (cached) {
+        return cached;
       }
-      return res;
-    } catch (err) {
-      const wantsHtml = req.destination === 'document' || req.headers.get('accept')?.includes('text/html');
-      if (wantsHtml) {
-        return new Response(
-          '<!doctype html><meta charset="utf-8"><title>Offline</title><h1>Offline</h1><p>Network error.</p>',
-          { status: 503, headers: { 'Content-Type': 'text/html' } }
-        );
-      }
-      return new Response(JSON.stringify({ ok: false, error: 'offline' }), {
-        status: 502,
-        headers: { 'Content-Type': 'application/json' }
-      });
+      return new Response('', { status: 504, statusText: 'Gateway Timeout' });
     }
   })());
 });

--- a/src/entry/landing.js
+++ b/src/entry/landing.js
@@ -1,5 +1,6 @@
 import './block-remote-guard.js';
 import * as THREE from 'three';
+import '../registerServiceWorker.ts';
 import { initializeAthens } from './initializeAthens.js';
 import boot, { whenBootReady } from '../core/bootstrap.js';
 import { startGameLoop, setLoopWatchdog } from '../engine/loop.js';

--- a/src/registerServiceWorker.ts
+++ b/src/registerServiceWorker.ts
@@ -1,0 +1,55 @@
+function resolveEnv(): { BASE_URL?: string; DEV?: boolean } {
+  try {
+    if (typeof import.meta !== 'undefined' && import.meta && import.meta.env) {
+      return import.meta.env as { BASE_URL?: string; DEV?: boolean };
+    }
+  } catch (error) {
+    // ignore inability to access import.meta
+  }
+
+  if (typeof globalThis !== 'undefined' && (globalThis as any).__ATHENS_IMPORT_META_ENV__) {
+    return (globalThis as any).__ATHENS_IMPORT_META_ENV__;
+  }
+
+  return {};
+}
+
+function normalizeBaseUrl(base: string | undefined): string {
+  if (!base) {
+    return '/';
+  }
+  return base.endsWith('/') ? base : `${base}/`;
+}
+
+export function setupServiceWorker(env: { BASE_URL?: string; DEV?: boolean } = resolveEnv()): Promise<void> | void {
+  if (typeof window === 'undefined' || typeof navigator === 'undefined') {
+    return;
+  }
+
+  const sw = navigator.serviceWorker;
+  if (!sw) {
+    return;
+  }
+
+  const baseUrl = normalizeBaseUrl(env?.BASE_URL);
+  const isDev = Boolean(env?.DEV);
+
+  if (isDev) {
+    return sw
+      .getRegistrations()
+      .then((registrations) => Promise.all(registrations.map((reg) => reg.unregister().catch(() => {}))))
+      .then(() => {})
+      .catch(() => {});
+  }
+
+  const registerOnLoad = () => {
+    sw.register(`${baseUrl}service-worker.js`).catch(() => {});
+  };
+
+  window.addEventListener('load', registerOnLoad, { once: true });
+  return;
+}
+
+if (typeof window !== 'undefined' && typeof navigator !== 'undefined' && navigator.serviceWorker) {
+  setupServiceWorker();
+}

--- a/tests/asset-url.test.js
+++ b/tests/asset-url.test.js
@@ -32,6 +32,15 @@ test('assetUrl resolves URLs for different base formats', async (t) => {
     });
   });
 
+  await t.test('respects GitHub Pages base path', () => {
+    withBaseUrl('/Athens/', () => {
+      assert.equal(
+        assetUrl('assets/audio/ambience_dawn.mp3'),
+        '/Athens/assets/audio/ambience_dawn.mp3'
+      );
+    });
+  });
+
   await t.test('preserves protocol delimiters for absolute bases', () => {
     withBaseUrl('https://cdn.example.com/assets/', () => {
       assert.equal(

--- a/tests/register-service-worker.test.ts
+++ b/tests/register-service-worker.test.ts
@@ -1,0 +1,109 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { setupServiceWorker } from '../src/registerServiceWorker.ts';
+
+type GlobalPatch = Partial<Record<string, any>>;
+
+const UNDEFINED_SENTINEL = Symbol.for('athens.global.undefined');
+
+async function withPatchedGlobals(patch: GlobalPatch, fn: () => Promise<void> | void) {
+  const g = globalThis as Record<string, any>;
+  const previous = new Map<string, any>();
+
+  for (const [key, value] of Object.entries(patch)) {
+    previous.set(key, key in g ? g[key] : UNDEFINED_SENTINEL);
+    g[key] = value;
+  }
+
+  try {
+    await fn();
+  } finally {
+    for (const [key, value] of previous.entries()) {
+      if (value === UNDEFINED_SENTINEL) {
+        delete g[key];
+      } else {
+        g[key] = value;
+      }
+    }
+  }
+}
+
+test('setupServiceWorker registers service worker with base URL on window load', async () => {
+  const registerCalls: string[] = [];
+  const loadHandlers: Array<() => void | Promise<void>> = [];
+
+  await withPatchedGlobals(
+    {
+      window: {
+        addEventListener(type: string, handler: () => void | Promise<void>) {
+          if (type === 'load') {
+            loadHandlers.push(handler);
+          }
+        }
+      },
+      navigator: {
+        serviceWorker: {
+          register(url: string) {
+            registerCalls.push(url);
+            return Promise.resolve();
+          },
+          getRegistrations() {
+            return Promise.resolve([]);
+          }
+        }
+      }
+    },
+    async () => {
+      setupServiceWorker({ BASE_URL: '/Athens/', DEV: false });
+
+      assert.equal(registerCalls.length, 0);
+      assert.ok(loadHandlers.length > 0, 'expected load handler to be registered');
+
+      for (const handler of loadHandlers) {
+        await handler();
+      }
+
+      assert.deepEqual(registerCalls, ['/Athens/service-worker.js']);
+    }
+  );
+});
+
+test('setupServiceWorker unregisters existing registrations during development', async () => {
+  const unregisterCalls: number[] = [];
+
+  await withPatchedGlobals(
+    {
+      window: {
+        addEventListener() {
+          // no-op
+        }
+      },
+      navigator: {
+        serviceWorker: {
+          getRegistrations() {
+            return Promise.resolve([
+              {
+                unregister() {
+                  unregisterCalls.push(1);
+                  return Promise.resolve();
+                }
+              },
+              {
+                unregister() {
+                  unregisterCalls.push(2);
+                  return Promise.reject(new Error('fail'));
+                }
+              }
+            ]);
+          }
+        }
+      }
+    },
+    async () => {
+      await setupServiceWorker({ BASE_URL: '/Athens/', DEV: true });
+
+      assert.deepEqual(unregisterCalls, [1, 2]);
+    }
+  );
+});


### PR DESCRIPTION
## Summary
- harden the service worker with network-first fetch handling, offline fallbacks, and updated cache versioning
- add a service worker registration helper that unregisters stale dev workers and respects the configured base path
- extend tests to cover base-aware asset URLs and the new registration helper behaviour

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68dcf9a2ec80832786db545822c3828c