### PR TITLE
Add procedural procedural sky cycle

### DIFF
--- a/public/dev/index.html
+++ b/public/dev/index.html
@@ -116,7 +116,7 @@
     <script type="module">
       import * as THREE from '../node_modules/three/build/three.module.js';
       import { setupGround, updateTrees, initPerformanceStats } from '../src/main.js';
-      import { setEnvironment } from '../src/scene/sky.js';
+      import { EnvironmentController } from '../src/environment/EnvironmentController.ts';
       import boot from '../src/core/bootstrap.js';
 
       const INITIALIZER_SOURCE = 'page:public/dev/index.html';
@@ -294,18 +294,14 @@
           options
         });
 
-        if (typeof setEnvironment === 'function') {
-          try {
-            const mode = options?.skyMode || 'day';
-            const preserveBackgroundOption = options?.preserveBackground;
-            const environmentOptions = {
-              preserveBackground:
-                preserveBackgroundOption === undefined ? true : Boolean(preserveBackgroundOption)
-            };
-            setEnvironment(renderer, scene, mode, environmentOptions);
-          } catch (error) {
-            console.warn('[Athens][Dev] setEnvironment failed', error);
-          }
+        const environmentController = new EnvironmentController(scene, renderer);
+        cleanupCallbacks.push(() => environmentController.dispose());
+
+        const requestedMode = typeof options?.skyMode === 'string' ? options.skyMode : 'procedural';
+        try {
+          await environmentController.setMode(requestedMode);
+        } catch (error) {
+          console.warn('[Athens][Dev] environmentController.setMode failed', error);
         }
 
         const fallbackGround = createFallbackGround();
@@ -373,6 +369,11 @@
               console.warn('[Athens][Dev] updater callback failed', error);
             }
           });
+          try {
+            environmentController.skyController?.update?.(delta);
+          } catch (error) {
+            console.warn('[Athens][Dev] procedural sky update failed', error);
+          }
           renderer.render(scene, camera);
         };
 
@@ -493,6 +494,7 @@
           renderer,
           scene,
           camera,
+          environmentController,
           dispose,
           fallbackGround,
           ground: groundResult ?? fallbackGround

--- a/src/engine/safeEntry.js
+++ b/src/engine/safeEntry.js
@@ -1,5 +1,5 @@
 import * as THREE from 'three';
-import { applySky } from '../scene/sky.ts';
+import { EnvironmentController } from '../environment/EnvironmentController.ts';
 import { logger } from '../utils/logger.ts';
 
 export async function createSafeScene(canvasSelector = 'canvas') {
@@ -20,8 +20,9 @@ export async function createSafeScene(canvasSelector = 'canvas') {
   camera.position.set(0, 3.5, 7);
   scene.add(camera);
 
+  const environment = new EnvironmentController(scene, renderer);
   try {
-    await applySky(scene, renderer, 'day');
+    await environment.setMode('procedural');
   } catch (error) {
     logger.warn('[safeEntry] applySky failed.', error);
     renderer.setClearColor(0x202834, 1);
@@ -59,6 +60,11 @@ export async function createSafeScene(canvasSelector = 'canvas') {
   }
 
   const update = (dt = 0) => {
+    try {
+      environment.skyController?.update?.(dt);
+    } catch (error) {
+      logger.warn('[safeEntry] Procedural sky update failed.', error);
+    }
     cube.rotation.y += dt;
   };
 
@@ -70,10 +76,11 @@ export async function createSafeScene(canvasSelector = 'canvas') {
     if (typeof window !== 'undefined') {
       window.removeEventListener('resize', onResize);
     }
+    environment.dispose();
     renderer.dispose();
   };
 
-  return { renderer, scene, camera, update, render, dispose };
+  return { renderer, scene, camera, update, render, dispose, environment };
 }
 
 export default createSafeScene;

--- a/src/entry/initializeAthens.js
+++ b/src/entry/initializeAthens.js
@@ -180,6 +180,7 @@ function _installLandmarkDev(scene, options) {
 const DEFAULT_STATS_STYLE = 'position:fixed;left:0;top:0;z-index:9999';
 
 const DEFAULT_BACKGROUND_HEX = 0x202834;
+const DEFAULT_PROCEDURAL_CYCLE_SPEED = 0.25;
 
 let stats = null;
 let statsVisible = true;
@@ -599,11 +600,22 @@ export async function initializeAthens(options = {}) {
 
     window.dev = window.dev || {};
     window.dev.sky = window.dev.sky || {};
-    window.dev.sky.on = (mode = 'day') => environmentManager.applySky(mode);
+    window.dev.sky.on = (mode = 'procedural') => environmentManager.setMode(mode);
+    window.dev.sky.apply = (mode = 'day') => environmentManager.applySky(mode);
     window.dev.sky.off = () => { scene.background = null; scene.environment = null; };
     window.dev.sky.color = (hex = 0x87ceeb) => {
       renderer.setClearAlpha(1);
       renderer.setClearColor(hex, 1);
+    };
+    window.dev.sky.setTime = (hours = 12) => {
+      const target = Number(hours);
+      environmentManager.skyController?.setTimeOfDay?.(Number.isFinite(target) ? target : 12);
+    };
+    window.dev.sky.speed = (speed = DEFAULT_PROCEDURAL_CYCLE_SPEED) => {
+      const value = Number(speed);
+      environmentManager.skyController?.setCycleSpeed?.(
+        Number.isFinite(value) ? value : DEFAULT_PROCEDURAL_CYCLE_SPEED
+      );
     };
   }
 
@@ -615,6 +627,17 @@ export async function initializeAthens(options = {}) {
   }
 
   await initAmbient(camera);
+
+  const normalizeSkyId = (value) => {
+    if (!value || typeof value !== 'string') {
+      return null;
+    }
+    const trimmed = value.trim().toLowerCase();
+    if (!trimmed) {
+      return null;
+    }
+    return trimmed.replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+  };
 
   try {
     // Register all discovered mp3 tracks before the environment mode picks a track.
@@ -663,18 +686,17 @@ export async function initializeAthens(options = {}) {
   }
 
   try {
-await environmentManager.applySky('day');
+    const requestedSky = searchParams?.get('sky');
+    const normalizedSky = normalizeSkyId(requestedSky);
 
-    environmentManager.setMode('procedural');
-    try {
-      const currentMode = environmentManager?.skyMode || appliedSkyMode || 'day';
-      const match = (SKY_JPGS || []).find((i) =>
-        (i.tags || []).some((t) => t.toLowerCase() === String(currentMode).toLowerCase())
-      );
-      if (match) {
-        await applySkyImage(scene, renderer, match.url);
+    if (normalizedSky) {
+      await environmentManager.applySky(requestedSky || undefined);
+      if (normalizedSky === 'procedural') {
+        await environmentManager.setMode('procedural');
       }
-    } catch {}
+    } else {
+      await environmentManager.setMode('procedural');
+    }
   } catch (error) {
     logger.warn('[Athens] applySky failed during initializeAthens.', error);
     renderer.setClearColor(DEFAULT_BACKGROUND_HEX, 1);
@@ -685,6 +707,7 @@ await environmentManager.applySky('day');
   const ambientTrackIds = new Set(AMBIENT_TRACKS.map((track) => track.id));
   const defaultAmbientTrack = AMBIENT_TRACKS.length > 0 ? AMBIENT_TRACKS[0].id : null;
   const MODE_TO_AMBIENT = {
+    procedural: ['day', 'forest', 'coast', 'market'],
     dawn: ['dawn', 'forest', 'coast', 'night_crickets'],
     day: ['day', 'forest', 'coast', 'market'],
     high_noon: ['day', 'forest', 'coast', 'market'],
@@ -740,13 +763,14 @@ await environmentManager.applySky('day');
       // Ignore stats setup errors.
     });
 
-  let environmentMode = 'day';
+  let environmentMode = 'procedural';
 
   const setEnvironmentMode = (mode, { allowAmbient = true } = {}) => {
     const normalized = typeof mode === 'string' && mode ? mode : 'day';
     environmentMode = normalized;
     if (allowAmbient) {
-      applyAmbientForMode(normalized, true);
+      const ambientKey = normalized === 'procedural' ? 'day' : normalized;
+      applyAmbientForMode(ambientKey, true);
     }
     return environmentMode;
   };
@@ -759,7 +783,7 @@ await environmentManager.applySky('day');
       const allowAmbient = envOptions?.playAmbient !== false;
       const next = setEnvironmentMode(mode, { allowAmbient });
       try {
-        await environmentManager.applySky(next);
+        await environmentManager.setMode(next);
       } catch {
         // keep running if sky load fails
       }
@@ -774,6 +798,9 @@ await environmentManager.applySky('day');
       return next;
     },
     applySky(mode) {
+      if (mode) {
+        setEnvironmentMode(mode, { allowAmbient: true });
+      }
       return environmentManager.applySky(mode);
     },
     dispose() {
@@ -1431,6 +1458,12 @@ if (readyPromise && typeof readyPromise.then === 'function') {
         updateTrees?.(delta);
       } catch (error) {
         logger.warn('[Athens] Tree animation update failed.', error);
+      }
+
+      try {
+        environmentManager.skyController?.update?.(delta);
+      } catch (error) {
+        logger.warn('[Athens] Procedural sky update failed.', error);
       }
 
       if (playerObject?.position && !isFiniteVec3(playerObject.position)) {

--- a/src/environment/EnvironmentController.ts
+++ b/src/environment/EnvironmentController.ts
@@ -1,5 +1,6 @@
 import * as THREE from 'three';
 import { applySky } from '../scene/sky.ts';
+import { createProceduralSky, ProceduralSkyController } from '../scene/proceduralSky.ts';
 import { disposeAll } from '../utils/disposable.ts';
 
 export type SkyMode = 'procedural' | string;
@@ -10,6 +11,9 @@ export class EnvironmentController {
   private disposed = false;
   private currentSkyMode: SkyMode = 'procedural';
   private lastAppliedSkyId: string | null = null;
+  private proceduralSkyController: ProceduralSkyController | null = null;
+  private proceduralSkyPromise: Promise<ProceduralSkyController | null> | null = null;
+  private proceduralSkyToken = 0;
 
   constructor(scene: THREE.Scene, renderer: THREE.WebGLRenderer) {
     this.scene = scene;
@@ -20,23 +24,41 @@ export class EnvironmentController {
     return (this.lastAppliedSkyId ?? this.currentSkyMode) as SkyMode;
   }
 
+  get skyController(): ProceduralSkyController | null {
+    return this.proceduralSkyController;
+  }
+
   async applySky(choice?: string): Promise<string | null> {
     if (this.disposed) {
       return null;
     }
-    const appliedId = await applySky(this.scene, this.renderer, choice);
-    this.lastAppliedSkyId = appliedId ?? null;
+    if (this.shouldUseProcedural(choice)) {
+      this.currentSkyMode = 'procedural';
+      this.lastAppliedSkyId = null;
+      const controller = await this.ensureProceduralSky();
+      return controller ? 'procedural' : null;
+    }
+
+    const appliedId = await this.applyStaticSky(choice);
+    if (appliedId) {
+      this.currentSkyMode = appliedId as SkyMode;
+    }
     return appliedId;
   }
 
-  setMode(mode: SkyMode): void {
+  async setMode(mode: SkyMode): Promise<string | null> {
     if (this.disposed) {
-      return;
+      return null;
     }
-    this.currentSkyMode = mode;
     if (mode === 'procedural') {
+      this.currentSkyMode = 'procedural';
       this.lastAppliedSkyId = null;
+      const controller = await this.ensureProceduralSky();
+      return controller ? 'procedural' : null;
     }
+
+    this.currentSkyMode = mode;
+    return this.applyStaticSky(mode);
   }
 
   dispose(): void {
@@ -44,15 +66,128 @@ export class EnvironmentController {
     this.disposed = true;
     this.currentSkyMode = 'procedural';
     this.lastAppliedSkyId = null;
-    const environment = this.scene.environment as THREE.Texture | null;
+    this.disposeProceduralSky();
+    this.disposeSceneEnvironment();
+    this.updateDebugSky(null);
+  }
+
+  // TODO: Remove legacy sky modules (src/scene/sky.ts, src/scene/sky.js) once all callers migrate.
+
+  private async ensureProceduralSky(): Promise<ProceduralSkyController | null> {
+    if (this.disposed) {
+      return null;
+    }
+    if (this.proceduralSkyController) {
+      return this.proceduralSkyController;
+    }
+    if (this.proceduralSkyPromise) {
+      return this.proceduralSkyPromise;
+    }
+
+    this.disposeSceneEnvironment();
+
+    const token = ++this.proceduralSkyToken;
+    this.proceduralSkyPromise = createProceduralSky({
+      renderer: this.renderer,
+      scene: this.scene
+    })
+      .then((controller) => {
+        if (this.proceduralSkyToken !== token) {
+          try {
+            controller.dispose();
+          } catch {}
+          return this.proceduralSkyController;
+        }
+        this.proceduralSkyController = controller;
+        this.updateDebugSky(controller);
+        return controller;
+      })
+      .catch((error) => {
+        if (this.proceduralSkyToken === token) {
+          this.proceduralSkyPromise = null;
+        }
+        this.updateDebugSky(null);
+        throw error;
+      });
+
+    return this.proceduralSkyPromise;
+  }
+
+  private disposeProceduralSky(): void {
+    this.proceduralSkyToken += 1;
+    if (this.proceduralSkyController) {
+      try {
+        this.proceduralSkyController.dispose();
+      } catch {}
+    }
+    this.proceduralSkyController = null;
+    this.proceduralSkyPromise = null;
+  }
+
+  private disposeSceneEnvironment(): void {
+    const env = this.scene.environment;
     const background = this.scene.background;
-    const backgroundTexture =
-      background instanceof THREE.Texture || background instanceof THREE.CubeTexture
-        ? background
-        : null;
-    disposeAll(environment, backgroundTexture);
+    const textures: Array<THREE.Texture | THREE.CubeTexture> = [];
+
+    if (env instanceof THREE.Texture || env instanceof THREE.CubeTexture) {
+      textures.push(env);
+    }
+    if (background instanceof THREE.Texture || background instanceof THREE.CubeTexture) {
+      if (!textures.includes(background)) {
+        textures.push(background);
+      }
+    }
+
+    if (textures.length) {
+      disposeAll(textures);
+    }
+
     this.scene.environment = null;
     this.scene.background = null;
+  }
+
+  private async applyStaticSky(choice?: string): Promise<string | null> {
+    this.disposeProceduralSky();
+    this.disposeSceneEnvironment();
+    const appliedId = await applySky(this.scene, this.renderer, choice);
+    this.lastAppliedSkyId = appliedId ?? null;
+    this.updateDebugSky(null);
+    return appliedId;
+  }
+
+  private shouldUseProcedural(choice?: string): boolean {
+    const normalized = this.normalizeSkyId(choice);
+    if (normalized === 'procedural') {
+      return true;
+    }
+    if (!choice && typeof window !== 'undefined') {
+      try {
+        const params = new URLSearchParams(window.location.search || '');
+        return this.normalizeSkyId(params.get('sky')) === 'procedural';
+      } catch {}
+    }
+    return false;
+  }
+
+  private normalizeSkyId(value?: string | null): string | null {
+    if (!value || typeof value !== 'string') {
+      return null;
+    }
+    const trimmed = value.trim().toLowerCase();
+    if (!trimmed) {
+      return null;
+    }
+    return trimmed.replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+  }
+
+  private updateDebugSky(controller: ProceduralSkyController | null): void {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    const globalWindow = window as typeof window & { __athensDebug?: Record<string, any> };
+    const debug = globalWindow.__athensDebug || {};
+    debug.skyController = controller ?? null;
+    globalWindow.__athensDebug = debug;
   }
 }
 

--- a/src/environment/__tests__/EnvironmentController.test.ts
+++ b/src/environment/__tests__/EnvironmentController.test.ts
@@ -1,0 +1,105 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import * as THREE from 'three';
+
+import { EnvironmentController } from '../EnvironmentController.ts';
+
+test('EnvironmentController switches between procedural and static skies cleanly', async (t) => {
+  const originalPMREM = THREE.PMREMGenerator;
+  const originalLoader = THREE.TextureLoader.prototype.load;
+
+  const scene = new THREE.Scene();
+  const renderer = { toneMappingExposure: 1 } as unknown as THREE.WebGLRenderer;
+
+  const fromSceneCalls: number[] = [];
+  const fromEquirectangularCalls: number[] = [];
+  const proceduralTargets: Array<{ disposed: boolean; textureDisposed: boolean }> = [];
+  const staticTargets: Array<{ disposed: boolean; textureDisposed: boolean }> = [];
+
+  class MockRenderTarget {
+    public disposed = false;
+    public textureDisposed = false;
+    public texture: { dispose: () => void; disposed?: boolean };
+
+    constructor() {
+      this.texture = {
+        disposed: false,
+        dispose: () => {
+          this.textureDisposed = true;
+          this.texture.disposed = true;
+        }
+      };
+    }
+
+    dispose() {
+      this.disposed = true;
+    }
+  }
+
+  class MockPMREMGenerator {
+    fromScene() {
+      const target = new MockRenderTarget();
+      proceduralTargets.push(target);
+      fromSceneCalls.push(1);
+      return target as unknown as THREE.WebGLRenderTarget;
+    }
+
+    fromEquirectangular() {
+      const target = new MockRenderTarget();
+      fromEquirectangularCalls.push(1);
+      staticTargets.push(target);
+      return target as unknown as THREE.WebGLRenderTarget;
+    }
+
+    dispose() {}
+  }
+
+  THREE.TextureLoader.prototype.load = function (_url, onLoad) {
+    const texture = new THREE.Texture();
+    (texture as any).disposed = false;
+    texture.dispose = () => {
+      (texture as any).disposed = true;
+    };
+    if (typeof onLoad === 'function') {
+      onLoad(texture);
+    }
+    return texture;
+  } as any;
+
+  (THREE as any).PMREMGenerator = MockPMREMGenerator;
+
+  t.after(() => {
+    (THREE as any).PMREMGenerator = originalPMREM;
+    THREE.TextureLoader.prototype.load = originalLoader;
+  });
+
+  const controller = new EnvironmentController(scene, renderer);
+
+  await controller.setMode('procedural');
+  assert.strictEqual(fromSceneCalls.length, 1, 'procedural mode builds environment once');
+  assert.ok(controller.skyController, 'procedural controller should be active');
+
+  const proceduralTexture = scene.environment;
+  assert.ok(proceduralTexture, 'procedural environment assigned');
+
+  await controller.applySky('day');
+  assert.strictEqual(fromEquirectangularCalls.length, 1, 'static sky uses equirectangular PMREM once');
+  assert.strictEqual(fromSceneCalls.length, 1, 'procedural PMREM should not run during static sky');
+  assert.ok(proceduralTargets[0].disposed, 'procedural render target disposed when leaving procedural mode');
+  assert.ok(proceduralTargets[0].textureDisposed, 'procedural texture disposed when leaving procedural mode');
+
+  const dayBackground = scene.background as THREE.Texture & { disposed?: boolean };
+  const dayEnvironment = scene.environment as THREE.Texture & { disposed?: boolean };
+  assert.ok(dayBackground, 'background texture should be set for day sky');
+  assert.ok(dayEnvironment, 'environment texture should be set for day sky');
+  assert.ok(staticTargets.length > 0, 'static PMREM target recorded');
+
+  await controller.setMode('procedural');
+  assert.strictEqual(fromSceneCalls.length, 2, 'procedural rebuilds after returning to cycle');
+  assert.ok(dayBackground.disposed, 'day background texture disposed when switching back to procedural');
+  assert.ok(staticTargets[0].textureDisposed, 'day environment texture disposed when switching back to procedural');
+
+  controller.dispose();
+  assert.strictEqual(scene.environment, null, 'dispose clears environment');
+  assert.strictEqual(scene.background, null, 'dispose clears background');
+});

--- a/src/scene/__tests__/proceduralSky.test.ts
+++ b/src/scene/__tests__/proceduralSky.test.ts
@@ -1,0 +1,81 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import * as THREE from 'three';
+
+import { createProceduralSky } from '../proceduralSky.ts';
+
+test('createProceduralSky sets environment and advances over time', async (t) => {
+  const originalPMREM = THREE.PMREMGenerator;
+  const targets: Array<{ disposed: boolean; textureDisposed: boolean }> = [];
+  const fromSceneCalls: number[] = [];
+  const disposeCalls: number[] = [];
+
+  class MockRenderTarget {
+    public textureDisposed = false;
+    public disposed = false;
+    public texture: { dispose: () => void };
+
+    constructor() {
+      this.texture = {
+        dispose: () => {
+          this.textureDisposed = true;
+        }
+      };
+    }
+
+    dispose() {
+      this.disposed = true;
+    }
+  }
+
+  class MockPMREMGenerator {
+    constructor() {}
+
+    fromScene() {
+      const target = new MockRenderTarget();
+      targets.push(target);
+      fromSceneCalls.push(targets.length);
+      return target as unknown as THREE.WebGLRenderTarget;
+    }
+
+    dispose() {
+      disposeCalls.push(1);
+    }
+  }
+
+  (THREE as any).PMREMGenerator = MockPMREMGenerator;
+  t.after(() => {
+    (THREE as any).PMREMGenerator = originalPMREM;
+  });
+
+  const scene = new THREE.Scene();
+  const renderer = { toneMappingExposure: 1 } as unknown as THREE.WebGLRenderer;
+
+  await t.test('initial environment build', async () => {
+    const controller = await createProceduralSky({ renderer, scene });
+
+    assert.ok(scene.environment, 'environment texture should be assigned');
+    assert.strictEqual(scene.environment, scene.background, 'background should share environment texture');
+    assert.strictEqual(fromSceneCalls.length, 1, 'initial PMREM build only runs once');
+
+    controller.setCycleSpeed(1);
+    const before = scene.environment;
+    controller.update(0.2);
+    assert.strictEqual(fromSceneCalls.length, 2, 'update triggers rebuild after throttle');
+    assert.notStrictEqual(scene.environment, before, 'environment texture should refresh');
+    assert.ok(targets[0].disposed, 'previous render target disposed after rebuild');
+    assert.ok(targets[0].textureDisposed, 'previous texture disposed after rebuild');
+
+    controller.setCycleSpeed(0);
+    controller.update(0.05);
+    assert.strictEqual(fromSceneCalls.length, 2, 'no rebuild when cycle speed is zero');
+
+    controller.dispose();
+    assert.strictEqual(scene.environment, null, 'environment cleared on dispose');
+    assert.strictEqual(scene.background, null, 'background cleared on dispose');
+    assert.ok(targets[targets.length - 1].disposed, 'current render target disposed on dispose');
+    assert.ok(targets[targets.length - 1].textureDisposed, 'current texture disposed on dispose');
+    assert.ok(disposeCalls.length >= 1, 'pmrem generator disposed for each rebuild');
+  });
+
+});

--- a/src/scene/proceduralSky.ts
+++ b/src/scene/proceduralSky.ts
@@ -1,0 +1,272 @@
+import * as THREE from 'three';
+import { Sky } from 'three/examples/jsm/objects/Sky.js';
+
+export interface ProceduralSkyOptions {
+  timeOfDay?: number;
+  cycleSpeed?: number;
+  atmosphere?: {
+    turbidity?: number;
+    rayleigh?: number;
+    mieCoefficient?: number;
+    mieDirectionalG?: number;
+    exposure?: number;
+  };
+}
+
+export interface ProceduralSkyController {
+  update(dt: number): void;
+  setTimeOfDay(hours: number): void;
+  setCycleSpeed(hoursPerSecond: number): void;
+  setAtmosphere(values: {
+    turbidity?: number;
+    rayleigh?: number;
+    mieCoefficient?: number;
+    mieDirectionalG?: number;
+    exposure?: number;
+  }): void;
+  dispose(): void;
+}
+
+const FULL_DAY_HOURS = 24;
+const MIN_REBUILD_INTERVAL = 0.1; // seconds (10 Hz)
+const DEFAULT_TIME_OF_DAY = 12;
+const DEFAULT_CYCLE_SPEED = 0.25; // hours per second
+
+const DEFAULT_ATMOSPHERE = {
+  turbidity: 10,
+  rayleigh: 2,
+  mieCoefficient: 0.005,
+  mieDirectionalG: 0.8,
+  exposure: 0.5
+} as const;
+
+type AtmosphereState = Required<typeof DEFAULT_ATMOSPHERE>;
+
+type CreateParams = {
+  renderer: THREE.WebGLRenderer;
+  scene: THREE.Scene;
+  options?: ProceduralSkyOptions;
+};
+
+export async function createProceduralSky({
+  renderer,
+  scene,
+  options = {}
+}: CreateParams): Promise<ProceduralSkyController> {
+  if (!renderer) {
+    throw new Error('[proceduralSky] renderer is required');
+  }
+  if (!scene) {
+    throw new Error('[proceduralSky] scene is required');
+  }
+
+  const skyScene = new THREE.Scene();
+  const sky = new Sky();
+  sky.scale.setScalar(10000);
+  skyScene.add(sky);
+
+  const sun = new THREE.Vector3();
+  const uniforms = sky.material.uniforms;
+
+  const atmosphere: AtmosphereState = {
+    turbidity: options.atmosphere?.turbidity ?? DEFAULT_ATMOSPHERE.turbidity,
+    rayleigh: options.atmosphere?.rayleigh ?? DEFAULT_ATMOSPHERE.rayleigh,
+    mieCoefficient: options.atmosphere?.mieCoefficient ?? DEFAULT_ATMOSPHERE.mieCoefficient,
+    mieDirectionalG: options.atmosphere?.mieDirectionalG ?? DEFAULT_ATMOSPHERE.mieDirectionalG,
+    exposure: options.atmosphere?.exposure ?? DEFAULT_ATMOSPHERE.exposure
+  };
+
+  const initialRendererExposure = renderer.toneMappingExposure ?? 1;
+
+  let timeOfDay = normalizeHours(options.timeOfDay ?? DEFAULT_TIME_OF_DAY);
+  let cycleSpeed = Number.isFinite(options.cycleSpeed) ? Number(options.cycleSpeed) : DEFAULT_CYCLE_SPEED;
+  let disposed = false;
+  let elapsed = 0;
+  let lastRebuildTime = -Infinity;
+  let dirty = true;
+  let currentTarget: THREE.WebGLRenderTarget | null = null;
+
+  applyAtmosphere();
+  updateSun();
+  await rebuildEnvironment(true);
+
+  function normalizeHours(value: number): number {
+    if (!Number.isFinite(value)) {
+      return DEFAULT_TIME_OF_DAY;
+    }
+    let hours = value % FULL_DAY_HOURS;
+    if (hours < 0) {
+      hours += FULL_DAY_HOURS;
+    }
+    return hours;
+  }
+
+  function applyAtmosphere() {
+    if (uniforms.turbidity) {
+      uniforms.turbidity.value = atmosphere.turbidity;
+    }
+    if (uniforms.rayleigh) {
+      uniforms.rayleigh.value = atmosphere.rayleigh;
+    }
+    if (uniforms.mieCoefficient) {
+      uniforms.mieCoefficient.value = atmosphere.mieCoefficient;
+    }
+    if (uniforms.mieDirectionalG) {
+      uniforms.mieDirectionalG.value = atmosphere.mieDirectionalG;
+    }
+    renderer.toneMappingExposure = atmosphere.exposure;
+    dirty = true;
+  }
+
+  function updateSun() {
+    const dayFraction = timeOfDay / FULL_DAY_HOURS;
+    const angle = (dayFraction - 0.25) * Math.PI * 2;
+    const elevation = Math.sin(angle) * (Math.PI / 2);
+    const azimuth = Math.PI + angle;
+    sun.setFromSphericalCoords(1, Math.max(0, Math.PI / 2 - elevation), azimuth);
+    if (uniforms.sunPosition) {
+      uniforms.sunPosition.value.copy(sun);
+    }
+    dirty = true;
+  }
+
+  function disposeRenderTarget(target: THREE.WebGLRenderTarget | null) {
+    if (!target) return;
+    try {
+      target.texture?.dispose?.();
+    } catch {}
+    try {
+      target.dispose();
+    } catch {}
+  }
+
+  async function rebuildEnvironment(force = false) {
+    if (disposed) {
+      return;
+    }
+    if (!dirty && !force) {
+      return;
+    }
+    if (!force && elapsed - lastRebuildTime < MIN_REBUILD_INTERVAL) {
+      return;
+    }
+    dirty = false;
+    lastRebuildTime = elapsed;
+
+    const pmrem = new THREE.PMREMGenerator(renderer);
+    const target = pmrem.fromScene(skyScene, 0.1);
+    pmrem.dispose();
+
+    const previousTarget = currentTarget;
+    currentTarget = target;
+    scene.environment = target.texture;
+    scene.background = target.texture;
+
+    if (previousTarget && previousTarget !== target) {
+      disposeRenderTarget(previousTarget);
+    }
+  }
+
+  function update(dt: number) {
+    if (disposed) return;
+    const safeDt = Number.isFinite(dt) ? Math.max(0, dt) : 0;
+    elapsed += safeDt;
+
+    if (cycleSpeed !== 0 && safeDt > 0) {
+      timeOfDay = normalizeHours(timeOfDay + cycleSpeed * safeDt);
+      updateSun();
+    }
+
+    void rebuildEnvironment(false);
+  }
+
+  function setTimeOfDay(hours: number) {
+    if (disposed) return;
+    timeOfDay = normalizeHours(hours);
+    updateSun();
+  }
+
+  function setCycleSpeed(value: number) {
+    if (disposed) return;
+    if (!Number.isFinite(value)) {
+      cycleSpeed = 0;
+      return;
+    }
+    cycleSpeed = value;
+  }
+
+  function setAtmosphere(values: {
+    turbidity?: number;
+    rayleigh?: number;
+    mieCoefficient?: number;
+    mieDirectionalG?: number;
+    exposure?: number;
+  }) {
+    if (disposed || !values || typeof values !== 'object') {
+      return;
+    }
+    if (Number.isFinite(values.turbidity)) {
+      atmosphere.turbidity = Number(values.turbidity);
+    }
+    if (Number.isFinite(values.rayleigh)) {
+      atmosphere.rayleigh = Number(values.rayleigh);
+    }
+    if (Number.isFinite(values.mieCoefficient)) {
+      atmosphere.mieCoefficient = Number(values.mieCoefficient);
+    }
+    if (Number.isFinite(values.mieDirectionalG)) {
+      atmosphere.mieDirectionalG = Number(values.mieDirectionalG);
+    }
+    if (Number.isFinite(values.exposure)) {
+      atmosphere.exposure = Number(values.exposure);
+    }
+    applyAtmosphere();
+  }
+
+  function dispose() {
+    if (disposed) return;
+    disposed = true;
+
+    if (scene.environment === currentTarget?.texture) {
+      scene.environment = null;
+    }
+    if (scene.background === currentTarget?.texture) {
+      scene.background = null;
+    }
+
+    disposeRenderTarget(currentTarget);
+    currentTarget = null;
+
+    if (sky.parent) {
+      sky.parent.remove(sky);
+    }
+    disposeObject(sky);
+
+    renderer.toneMappingExposure = initialRendererExposure;
+  }
+
+  function disposeObject(object: THREE.Object3D | THREE.Material | THREE.BufferGeometry) {
+    if (!object) return;
+    if ('dispose' in object && typeof (object as any).dispose === 'function') {
+      try {
+        (object as any).dispose();
+      } catch {}
+    }
+    if ((object as any).geometry) {
+      disposeObject((object as any).geometry);
+    }
+    if ((object as any).material) {
+      disposeObject((object as any).material);
+    }
+  }
+
+  const controller: ProceduralSkyController = {
+    update,
+    setTimeOfDay,
+    setCycleSpeed,
+    setAtmosphere,
+    dispose
+  };
+
+  return controller;
+}


### PR DESCRIPTION
## Summary
- implement a reusable procedural sky controller with a throttled day/night cycle and adjustable atmosphere parameters
- integrate the procedural controller into the environment manager, app initialization, safe scene bootstrap, and dev runner while exposing debug hooks
- cover the new behaviour with unit and integration tests to ensure single environment updates per frame

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68dcea95c7408327b890b0f8072bbdca