### PR TITLE
Add scoped dev hotkeys and tooling integrations

### DIFF
--- a/src/config/hotkeys.ts
+++ b/src/config/hotkeys.ts
@@ -12,12 +12,15 @@ type ContinuousAxisId = 'x' | 'z' | 'lookX' | 'lookY' | 'turn';
 
 type HotkeyFallbackEntry = string | [string, string];
 
+type HotkeyScope = 'gameplay' | 'dev';
+
 type HotkeyActionInit = {
   id: string;
   title: string;
   default: string;
   aliasCodes?: string[];
   fallback?: HotkeyFallbackEntry[];
+  scope?: HotkeyScope;
 };
 
 type HotkeyActionDefinition = {
@@ -28,6 +31,7 @@ type HotkeyActionDefinition = {
   codes: string[];
   fallback: [string, string][];
   category: HotkeyCategory;
+  scope: HotkeyScope;
 };
 
 type AxisBinding =
@@ -46,6 +50,7 @@ type AxisBinding =
 
 const actionRegistry = new Map<string, HotkeyActionDefinition>();
 const actionCodes = new Map<string, string[]>();
+const actionsByScope = new Map<HotkeyScope, HotkeyActionDefinition[]>();
 
 function createAction(
   category: HotkeyCategory,
@@ -72,6 +77,8 @@ function createAction(
     }
   }
 
+  const scope: HotkeyScope = init.scope ?? 'gameplay';
+
   const definition: HotkeyActionDefinition = {
     id: init.id,
     title: init.title,
@@ -79,11 +86,19 @@ function createAction(
     aliasCodes,
     codes,
     fallback: fallbackEntries,
-    category
+    category,
+    scope
   };
 
   actionRegistry.set(definition.id, definition);
   actionCodes.set(definition.id, definition.codes);
+
+  const scoped = actionsByScope.get(scope);
+  if (scoped) {
+    scoped.push(definition);
+  } else {
+    actionsByScope.set(scope, [definition]);
+  }
 
   return definition;
 }
@@ -200,6 +215,42 @@ const devToolActions = {
     title: 'Capture Screenshot',
     default: 'KeyP',
     fallback: ['p']
+  }),
+  landmarkNext: createAction(HotkeyCategoryId.DevTools, {
+    id: 'dev.landmark.next',
+    title: 'Select Next Landmark',
+    default: 'BracketRight',
+    fallback: [']', 'bracketright'],
+    scope: 'dev'
+  }),
+  landmarkPrev: createAction(HotkeyCategoryId.DevTools, {
+    id: 'dev.landmark.prev',
+    title: 'Select Previous Landmark',
+    default: 'BracketLeft',
+    fallback: ['[', 'bracketleft'],
+    scope: 'dev'
+  }),
+  landmarkSave: createAction(HotkeyCategoryId.DevTools, {
+    id: 'dev.landmark.save',
+    title: 'Save Landmark Positions',
+    default: 'F9',
+    fallback: [['f9', 'F9']],
+    scope: 'dev'
+  }),
+  landmarkExit: createAction(HotkeyCategoryId.DevTools, {
+    id: 'dev.landmark.exit',
+    title: 'Exit Landmark Placer',
+    default: 'KeyL',
+    aliasCodes: ['Escape'],
+    fallback: ['l', 'escape'],
+    scope: 'dev'
+  }),
+  flyBypassToggle: createAction(HotkeyCategoryId.DevTools, {
+    id: 'dev.flyBypass.toggle',
+    title: 'Toggle Fly Bypass',
+    default: 'Backquote',
+    fallback: ['`', 'backquote'],
+    scope: 'dev'
   })
 } as const;
 
@@ -293,7 +344,16 @@ export const HOTKEY_IDS = Object.freeze({
     toggleStats: debugActions.toggleStats.id
   },
   devTools: {
-    captureScreenshot: devToolActions.captureScreenshot.id
+    captureScreenshot: devToolActions.captureScreenshot.id,
+    landmark: {
+      next: devToolActions.landmarkNext.id,
+      prev: devToolActions.landmarkPrev.id,
+      save: devToolActions.landmarkSave.id,
+      exit: devToolActions.landmarkExit.id
+    },
+    flyBypass: {
+      toggle: devToolActions.flyBypassToggle.id
+    }
   }
 });
 
@@ -305,4 +365,9 @@ export function getActionDefinition(actionId: string): HotkeyActionDefinition | 
   return actionRegistry.get(actionId);
 }
 
+export function getActionsByScope(scope: HotkeyScope): HotkeyActionDefinition[] {
+  return actionsByScope.get(scope) ?? [];
+}
+
 export type { HotkeyActionDefinition };
+export type { HotkeyScope };

--- a/src/dev/flyBypass.js
+++ b/src/dev/flyBypass.js
@@ -1,7 +1,40 @@
-import { HOTKEY_IDS } from '../config/hotkeys.ts';
+import {
+  HOTKEY_IDS,
+  KEY_FALLBACK_MAP,
+  getActionCodes
+} from '../config/hotkeys.ts';
+import { registerScopedHotkeys } from '../input/hotkeyScopes.js';
 
 const ASCEND_ACTION = HOTKEY_IDS.flight.ascend;
 const DESCEND_ACTION = HOTKEY_IDS.flight.descend;
+const FLY_BYPASS_TOGGLE_ACTION = HOTKEY_IDS.dev.flyBypass.toggle;
+
+function resolveEventCode(event) {
+  const code = typeof event?.code === 'string' && event.code !== 'Unidentified' ? event.code : '';
+  if (code) {
+    return code;
+  }
+  const key = typeof event?.key === 'string' ? event.key.toLowerCase() : '';
+  if (!key) {
+    return '';
+  }
+  return KEY_FALLBACK_MAP.get(key) || '';
+}
+
+function shouldIgnoreKeyEvent(event) {
+  const target = event?.target;
+  if (!target || typeof target !== 'object') {
+    return false;
+  }
+  if (target.isContentEditable) {
+    return true;
+  }
+  if (typeof HTMLElement !== 'undefined' && target instanceof HTMLElement) {
+    const tag = target.tagName ? target.tagName.toLowerCase() : '';
+    return tag === 'input' || tag === 'textarea' || tag === 'select';
+  }
+  return false;
+}
 
 export function installFlyBypass({ state, input }){
   if (typeof window==='undefined') return;
@@ -12,6 +45,75 @@ export function installFlyBypass({ state, input }){
   window.dev.fly = {
     on(){ isFlying = on = true; }, off(){ isFlying = on = false; }, toggle,
   };
+
+  const toggleCodes = new Set();
+  let devHotkeysActive = false;
+  let keydownListener = null;
+
+  const devSession = registerScopedHotkeys('dev', {
+    onActivate(manifest) {
+      toggleCodes.clear();
+      const entry = Array.isArray(manifest)
+        ? manifest.find((action) => action?.id === FLY_BYPASS_TOGGLE_ACTION)
+        : null;
+      const codes = entry?.codes ?? getActionCodes(FLY_BYPASS_TOGGLE_ACTION);
+      for (const code of codes) {
+        if (typeof code === 'string' && code) {
+          toggleCodes.add(code);
+        }
+      }
+      devHotkeysActive = true;
+      bindKeyListener();
+    },
+    onDeactivate() {
+      devHotkeysActive = false;
+      toggleCodes.clear();
+      unbindKeyListener();
+    }
+  });
+
+  function matchesToggle(event) {
+    if (!devHotkeysActive || toggleCodes.size === 0) {
+      return false;
+    }
+    const resolved = resolveEventCode(event);
+    return resolved ? toggleCodes.has(resolved) : false;
+  }
+
+  function handleToggleKeydown(event) {
+    if (!devHotkeysActive) {
+      return;
+    }
+    if (event?.repeat) {
+      return;
+    }
+    if (shouldIgnoreKeyEvent(event)) {
+      return;
+    }
+    if (matchesToggle(event)) {
+      event.preventDefault?.();
+      event.stopImmediatePropagation?.();
+      toggle();
+    }
+  }
+
+  function bindKeyListener() {
+    if (keydownListener || typeof window === 'undefined') {
+      return;
+    }
+    keydownListener = handleToggleKeydown;
+    window.addEventListener('keydown', keydownListener, true);
+  }
+
+  function unbindKeyListener() {
+    if (keydownListener && typeof window !== 'undefined') {
+      window.removeEventListener('keydown', keydownListener, true);
+    }
+    keydownListener = null;
+  }
+
+  devSession.activate();
+
   return {
     tick(dt){
       if (!on) return;
@@ -30,6 +132,14 @@ export function installFlyBypass({ state, input }){
       if (up)   state.position.y += speed * dt;
       if (down) state.position.y -= speed * dt;
       if (state.velocity) state.velocity.y = 0;
+    },
+    dispose(){
+      if (typeof devSession.dispose === 'function') {
+        devSession.dispose();
+      } else {
+        devSession.deactivate();
+      }
+      unbindKeyListener();
     }
   };
 }

--- a/src/dev/landmarkPlacer.js
+++ b/src/dev/landmarkPlacer.js
@@ -1,27 +1,32 @@
 // PLACER_START
 import * as THREE from 'three';
 import { KNOWN_LANDMARK_KEYS } from '../config/landmarkLayout.ts';
+import {
+  HOTKEY_IDS,
+  KEY_FALLBACK_MAP,
+  getActionCodes
+} from '../config/hotkeys.ts';
+import { registerScopedHotkeys } from '../input/hotkeyScopes.js';
 
 const DEFAULT_LANDMARKS = [...KNOWN_LANDMARK_KEYS];
 
-const KEY_BINDINGS = {
-  next: { key: ']', code: 'BracketRight' },
-  prev: { key: '[', code: 'BracketLeft' },
-  exit: { key: 'l', code: 'KeyL' },
-  saveCode: 'F9'
+const DEV_ACTION_IDS = {
+  next: HOTKEY_IDS.dev.landmark.next,
+  prev: HOTKEY_IDS.dev.landmark.prev,
+  save: HOTKEY_IDS.dev.landmark.save,
+  exit: HOTKEY_IDS.dev.landmark.exit
 };
 
-function matchesKey(event, binding) {
-  if (!event || !binding) return false;
-  const key = typeof event.key === 'string' ? event.key : '';
-  if (binding.key && key.toLowerCase() === String(binding.key).toLowerCase()) {
-    return true;
+function eventToCode(event) {
+  const code = typeof event?.code === 'string' && event.code !== 'Unidentified' ? event.code : '';
+  if (code) {
+    return code;
   }
-  const code = typeof event.code === 'string' ? event.code : '';
-  if (binding.code && code === binding.code) {
-    return true;
+  const key = typeof event?.key === 'string' ? event.key.toLowerCase() : '';
+  if (!key) {
+    return '';
   }
-  return false;
+  return KEY_FALLBACK_MAP.get(key) || '';
 }
 
 function shouldIgnoreKeyEvent(event) {
@@ -48,6 +53,44 @@ function shouldIgnoreKeyEvent(event) {
 }
 
 const POINTER_BUTTON_PRIMARY = 0;
+
+function formatCodeLabel(code) {
+  if (typeof code !== 'string' || code === '') {
+    return '';
+  }
+  if (code.startsWith('Key') && code.length === 4) {
+    return code.slice(3).toUpperCase();
+  }
+  if (code.startsWith('Digit') && code.length === 5) {
+    return code.slice(5);
+  }
+  switch (code) {
+    case 'BracketLeft':
+      return '[';
+    case 'BracketRight':
+      return ']';
+    case 'Backquote':
+      return '`';
+    case 'Escape':
+      return 'Esc';
+    default:
+      return code;
+  }
+}
+
+function formatCodeList(codes) {
+  if (!codes || codes.size === 0) {
+    return '';
+  }
+  const entries = [];
+  for (const code of codes) {
+    const label = formatCodeLabel(code);
+    if (label) {
+      entries.push(label);
+    }
+  }
+  return entries.join(', ');
+}
 
 function isGround(mesh) {
   if (!mesh) return false;
@@ -199,6 +242,64 @@ export function createLandmarkPlacer({
     lastHit: null
   };
 
+  const devHotkeys = {
+    active: false,
+    next: new Set(),
+    prev: new Set(),
+    save: new Set(),
+    exit: new Set()
+  };
+
+  function syncDevHotkeys(manifest) {
+    const byId = new Map();
+    if (Array.isArray(manifest)) {
+      for (const entry of manifest) {
+        if (entry && typeof entry.id === 'string') {
+          byId.set(entry.id, entry);
+        }
+      }
+    }
+
+    const updateSet = (actionId, targetSet) => {
+      targetSet.clear();
+      if (!actionId) {
+        return;
+      }
+      const manifestEntry = byId.get(actionId);
+      const codes = manifestEntry?.codes ?? getActionCodes(actionId);
+      for (const code of codes) {
+        if (typeof code === 'string' && code) {
+          targetSet.add(code);
+        }
+      }
+    };
+
+    updateSet(DEV_ACTION_IDS.next, devHotkeys.next);
+    updateSet(DEV_ACTION_IDS.prev, devHotkeys.prev);
+    updateSet(DEV_ACTION_IDS.save, devHotkeys.save);
+    updateSet(DEV_ACTION_IDS.exit, devHotkeys.exit);
+    devHotkeys.active = true;
+    updateHud();
+  }
+
+  function clearDevHotkeys() {
+    devHotkeys.active = false;
+    devHotkeys.next.clear();
+    devHotkeys.prev.clear();
+    devHotkeys.save.clear();
+    devHotkeys.exit.clear();
+    updateHud();
+  }
+
+  const devHotkeySession = registerScopedHotkeys('dev', {
+    onActivate(manifest) {
+      syncDevHotkeys(manifest);
+    },
+    onDeactivate() {
+      clearDevHotkeys();
+    }
+  });
+
   let groundMeshes = [];
 
   const listeners = {
@@ -221,6 +322,24 @@ export function createLandmarkPlacer({
     return state.names[state.index] ?? null;
   }
 
+  function buildHotkeySummary() {
+    if (!devHotkeys.active) {
+      return 'Hotkeys: Prev [ [ ] Next | Save Ctrl/Cmd+S or F9 | Exit L/Esc';
+    }
+
+    const prev = formatCodeList(devHotkeys.prev) || '[';
+    const next = formatCodeList(devHotkeys.next) || ']';
+    const saveCodes = formatCodeList(devHotkeys.save);
+    const exitCodes = formatCodeList(devHotkeys.exit);
+    const saveSummary = saveCodes ? `Ctrl/Cmd+S or ${saveCodes}` : 'Ctrl/Cmd+S';
+    const exitSummary = devHotkeys.exit.has('Escape')
+      ? exitCodes
+      : exitCodes
+        ? `${exitCodes} or Esc`
+        : 'Esc';
+    return `Hotkeys: Prev ${prev} | Next ${next} | Save ${saveSummary} | Exit ${exitSummary}`;
+  }
+
   function updateHud() {
     if (!hud) return;
     if (!state.enabled) {
@@ -230,10 +349,11 @@ export function createLandmarkPlacer({
     }
     const name = currentName() || '—';
     const saved = state.positions[name] ? ' (set)' : '';
+    const summary = buildHotkeySummary();
     hud.innerHTML = `
       <div style="font-weight:600;margin-bottom:4px;">Landmark Placer</div>
       <div>Landmark: <span style="color:#facc15;">${name}</span>${saved}</div>
-      <div style="margin-top:6px;opacity:0.8;">Hotkeys: Prev [ [ ] Next | Save Ctrl/Cmd+S or F9 | Exit L/Esc</div>
+      <div style="margin-top:6px;opacity:0.8;">${summary}</div>
     `;
     hud.style.display = 'block';
   }
@@ -312,11 +432,19 @@ export function createLandmarkPlacer({
     selectNext(-1);
   }
 
+  function matchesAction(event, codes) {
+    if (!codes || codes.size === 0) {
+      return false;
+    }
+    const resolved = eventToCode(event);
+    return resolved ? codes.has(resolved) : false;
+  }
+
   function handleKeyDown(event) {
     if (!state.enabled) return;
+    if (!devHotkeys.active) return;
     if (shouldIgnoreKeyEvent(event)) return;
     const keyLower = typeof event.key === 'string' ? event.key.toLowerCase() : '';
-    const code = typeof event.code === 'string' ? event.code : '';
 
     if ((event.ctrlKey || event.metaKey) && keyLower === 's') {
       event.preventDefault();
@@ -327,7 +455,7 @@ export function createLandmarkPlacer({
       return;
     }
 
-    if (code === KEY_BINDINGS.saveCode || event.key === KEY_BINDINGS.saveCode) {
+    if (matchesAction(event, devHotkeys.save)) {
       event.preventDefault();
       event.stopImmediatePropagation();
       if (!event.repeat) {
@@ -336,21 +464,21 @@ export function createLandmarkPlacer({
       return;
     }
 
-    if (matchesKey(event, KEY_BINDINGS.next)) {
+    if (matchesAction(event, devHotkeys.next)) {
       event.preventDefault();
       event.stopImmediatePropagation();
       selectNext(1);
       return;
     }
 
-    if (matchesKey(event, KEY_BINDINGS.prev)) {
+    if (matchesAction(event, devHotkeys.prev)) {
       event.preventDefault();
       event.stopImmediatePropagation();
       selectPrev();
       return;
     }
 
-    if (keyLower === 'escape' || matchesKey(event, KEY_BINDINGS.exit)) {
+    if (keyLower === 'escape' || matchesAction(event, devHotkeys.exit)) {
       event.preventDefault();
       event.stopImmediatePropagation();
       api.disable();
@@ -394,6 +522,7 @@ export function createLandmarkPlacer({
   const api = {
     enable() {
       if (state.enabled) return;
+      devHotkeySession.activate();
       state.enabled = true;
       groundMeshes = collectGroundMeshes();
       if (!scene.getObjectByName(ghost.name)) {
@@ -405,6 +534,7 @@ export function createLandmarkPlacer({
     },
     disable() {
       if (!state.enabled) return;
+      devHotkeySession.deactivate();
       state.enabled = false;
       ghost.visible = false;
       state.lastHit = null;
@@ -455,6 +585,23 @@ export function createLandmarkPlacer({
     },
     refreshGround() {
       groundMeshes = collectGroundMeshes();
+    },
+    dispose() {
+      if (typeof devHotkeySession.dispose === 'function') {
+        devHotkeySession.dispose();
+      } else {
+        devHotkeySession.deactivate();
+      }
+      unbindListeners();
+      if (ghost?.parent) {
+        ghost.parent.remove(ghost);
+      }
+      if (hud?.parentElement) {
+        hud.parentElement.removeChild(hud);
+      }
+      state.enabled = false;
+      state.lastHit = null;
+      devHotkeys.active = false;
     }
   };
 

--- a/src/input/hotkeyScopes.js
+++ b/src/input/hotkeyScopes.js
@@ -1,0 +1,127 @@
+import { getActionsByScope } from '../config/hotkeys.ts';
+
+const ALWAYS_ACTIVE_SCOPES = new Set(['gameplay']);
+
+const scopeState = new Map();
+const loggedConflicts = new Set();
+
+function ensureScopeState(scope) {
+  let state = scopeState.get(scope);
+  if (!state) {
+    state = {
+      sessions: new Set(),
+      activeSessions: 0
+    };
+    scopeState.set(scope, state);
+  }
+  return state;
+}
+
+function buildScopeManifest(scope) {
+  const definitions = getActionsByScope(scope);
+  return definitions.map((definition) => ({
+    id: definition.id,
+    title: definition.title,
+    codes: [...definition.codes],
+    default: definition.default,
+    scope: definition.scope
+  }));
+}
+
+function warnDevConflicts(scope, manifest) {
+  if (scope !== 'dev') {
+    return;
+  }
+
+  const gameplayActions = getActionsByScope('gameplay');
+  if (!gameplayActions.length || !manifest.length) {
+    return;
+  }
+
+  const gameplayCodes = new Map();
+  for (const action of gameplayActions) {
+    for (const code of action.codes) {
+      if (typeof code === 'string' && code) {
+        gameplayCodes.set(code, action.id);
+      }
+    }
+  }
+
+  for (const action of manifest) {
+    for (const code of action.codes) {
+      if (typeof code !== 'string' || code === '') {
+        continue;
+      }
+      const conflictId = gameplayCodes.get(code);
+      if (!conflictId) {
+        continue;
+      }
+      const key = `${action.id}|${code}|${conflictId}`;
+      if (loggedConflicts.has(key)) {
+        continue;
+      }
+      loggedConflicts.add(key);
+      if (typeof console !== 'undefined' && console && console.warn) {
+        console.warn(
+          `[Athens][Hotkeys] Dev action "${action.id}" shares binding "${code}" with gameplay action "${conflictId}".`
+        );
+      }
+    }
+  }
+}
+
+export function registerScopedHotkeys(scope, callbacks = {}) {
+  const state = ensureScopeState(scope);
+  const session = {
+    active: false,
+    callbacks
+  };
+
+  state.sessions.add(session);
+
+  const api = {
+    activate() {
+      if (session.active) {
+        return;
+      }
+      session.active = true;
+      state.activeSessions += 1;
+      const manifest = buildScopeManifest(scope);
+      warnDevConflicts(scope, manifest);
+      if (typeof session.callbacks.onActivate === 'function') {
+        session.callbacks.onActivate(manifest);
+      }
+    },
+    deactivate() {
+      if (!session.active) {
+        return;
+      }
+      session.active = false;
+      state.activeSessions = Math.max(0, state.activeSessions - 1);
+      if (typeof session.callbacks.onDeactivate === 'function') {
+        session.callbacks.onDeactivate();
+      }
+    },
+    isActive() {
+      return session.active;
+    },
+    dispose() {
+      api.deactivate();
+      state.sessions.delete(session);
+    }
+  };
+
+  if (ALWAYS_ACTIVE_SCOPES.has(scope)) {
+    api.activate();
+  }
+
+  return api;
+}
+
+export function getActiveScopeCount(scope) {
+  const state = scopeState.get(scope);
+  if (!state) {
+    return ALWAYS_ACTIVE_SCOPES.has(scope) ? 1 : 0;
+  }
+  return state.activeSessions + (ALWAYS_ACTIVE_SCOPES.has(scope) ? 1 : 0);
+}


### PR DESCRIPTION
## Summary
- add developer-only hotkey definitions for landmark navigation, saving, exit, and fly bypass toggle with scope metadata
- introduce a scoped hotkey registry that notifies listeners and warns on gameplay conflicts when dev actions activate
- refactor landmark placer and fly bypass dev tools to subscribe to scoped hotkeys and release bindings on disable

## Testing
- npm run lint:unused

------
https://chatgpt.com/codex/tasks/task_b_68dcfc2099988327b92fcc3e7238dfc0