### PR TITLE
Fix dev tool hotkey references

### DIFF
--- a/src/dev/flyBypass.js
+++ b/src/dev/flyBypass.js
@@ -7,7 +7,7 @@ import { registerScopedHotkeys } from '../input/hotkeyScopes.js';
 
 const ASCEND_ACTION = HOTKEY_IDS.flight.ascend;
 const DESCEND_ACTION = HOTKEY_IDS.flight.descend;
-const FLY_BYPASS_TOGGLE_ACTION = HOTKEY_IDS.dev.flyBypass.toggle;
+const FLY_BYPASS_TOGGLE_ACTION = HOTKEY_IDS.devTools.flyBypass.toggle;
 
 function resolveEventCode(event) {
   const code = typeof event?.code === 'string' && event.code !== 'Unidentified' ? event.code : '';

--- a/src/dev/landmarkPlacer.js
+++ b/src/dev/landmarkPlacer.js
@@ -11,10 +11,10 @@ import { registerScopedHotkeys } from '../input/hotkeyScopes.js';
 const DEFAULT_LANDMARKS = [...KNOWN_LANDMARK_KEYS];
 
 const DEV_ACTION_IDS = {
-  next: HOTKEY_IDS.dev.landmark.next,
-  prev: HOTKEY_IDS.dev.landmark.prev,
-  save: HOTKEY_IDS.dev.landmark.save,
-  exit: HOTKEY_IDS.dev.landmark.exit
+  next: HOTKEY_IDS.devTools.landmark.next,
+  prev: HOTKEY_IDS.devTools.landmark.prev,
+  save: HOTKEY_IDS.devTools.landmark.save,
+  exit: HOTKEY_IDS.devTools.landmark.exit
 };
 
 function eventToCode(event) {


### PR DESCRIPTION
## Summary
- correct the dev tool landmark placer to use the devTools hotkey identifiers
- align fly bypass toggle hotkey lookup with the devTools identifiers

## Testing
- npm test -- src/entry/__tests__/boot-smoke.test.ts *(fails: TypeError [Error]: Cannot redefine property: TextureLoader)*

------
https://chatgpt.com/codex/tasks/task_b_68dd024fdf9c8327b77f9996206cb0e7