### PR TITLE
Handle slow Athens boot without failing

### DIFF
--- a/src/entry/landing.js
+++ b/src/entry/landing.js
@@ -203,21 +203,35 @@ async function runAthens(options = {}) {
     container.style.backgroundColor = container.style.backgroundColor || '#202834';
 
     let bootTimer = null;
-    const bootTimeout = new Promise((_, reject) => {
-      bootTimer = setTimeout(() => reject(new Error('Boot timeout')), 8000);
+    const bootTimeoutMarker = Symbol('athens.boot-timeout');
+    const bootTimeout = new Promise((resolve) => {
+      bootTimer = setTimeout(() => resolve(bootTimeoutMarker), 8000);
     });
 
-    const context = await Promise.race([
-      initializeAthens({ ...options, container }),
-      bootTimeout
-    ]).catch((error) => {
-      watchdog?.error?.(error?.message || 'boot failed');
-      console.error('[Athens] Boot failed:', error);
-      throw error;
-    });
+    const initializationTask = initializeAthens({ ...options, container });
+    let context;
+    try {
+      const firstResult = await Promise.race([initializationTask, bootTimeout]).catch((error) => {
+        watchdog?.error?.(error?.message || 'boot failed');
+        console.error('[Athens] Boot failed:', error);
+        throw error;
+      });
 
-    if (bootTimer) {
-      clearTimeout(bootTimer);
+      if (firstResult === bootTimeoutMarker) {
+        watchdog?.warn?.('boot timeout');
+        logger.warn('[Athens] Boot is taking longer than expected. Waiting for initialization to complete.');
+        context = await initializationTask.catch((error) => {
+          watchdog?.error?.(error?.message || 'boot failed');
+          console.error('[Athens] Boot failed:', error);
+          throw error;
+        });
+      } else {
+        context = firstResult;
+      }
+    } finally {
+      if (bootTimer) {
+        clearTimeout(bootTimer);
+      }
     }
     context.renderer?.setClearColor?.(0x202834, 1);
     if (context.scene) {


### PR DESCRIPTION
## Summary
- allow the landing boot sequence to keep waiting after the timeout instead of failing outright
- surface a watchdog warning and log message when initialization takes longer than expected

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68dd08a30bf883278fead7b1b31d2905