### PR TITLE
Instrument boot phases and add boot timeouts

### DIFF
--- a/src/audio/startAmbience.ts
+++ b/src/audio/startAmbience.ts
@@ -1,0 +1,15 @@
+export function startAmbience() {
+  try {
+    const winBase = typeof window !== 'undefined' ? (window as any).__ATHENS_BASE__ : undefined;
+    const base = (import.meta as any)?.env?.BASE_URL || winBase || '/';
+    const url = `${base}assets/audio/ambience_dawn.mp3`;
+    const audio = new Audio();
+    audio.loop = true;
+    audio.src = url;
+    audio.play().catch(() => {
+      console.warn('[Athens][Audio] ambience failed or missing:', url);
+    });
+  } catch (error) {
+    console.warn('[Athens][Audio] init error:', error);
+  }
+}

--- a/src/boot/__tests__/withTimeout.test.ts
+++ b/src/boot/__tests__/withTimeout.test.ts
@@ -1,0 +1,15 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { withTimeout } from '../withTimeout';
+
+test('withTimeout resolves with fallback when promise times out', async () => {
+  const result = await withTimeout(
+    new Promise<never>(() => {}),
+    5,
+    'unit-test',
+    () => 'fallback'
+  );
+
+  assert.equal(result, 'fallback');
+});

--- a/src/boot/withTimeout.ts
+++ b/src/boot/withTimeout.ts
@@ -1,0 +1,27 @@
+export async function withTimeout<T>(
+  p: Promise<T>,
+  ms: number,
+  label: string,
+  fallback?: () => T | Promise<T>
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | number | undefined;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      reject(new Error(`timeout:${label}`));
+    }, ms);
+  });
+
+  try {
+    return await Promise.race([p, timeoutPromise]);
+  } catch (error) {
+    console.warn('[Athens][Boot] timed out:', label, error);
+    if (fallback) {
+      return await fallback();
+    }
+    return undefined as unknown as T;
+  } finally {
+    if (typeof timer !== 'undefined') {
+      clearTimeout(timer as ReturnType<typeof setTimeout>);
+    }
+  }
+}

--- a/src/entry/__tests__/boot-phase.test.ts
+++ b/src/entry/__tests__/boot-phase.test.ts
@@ -1,0 +1,139 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { mock } from 'node:test';
+
+test('landing boot resolves to ready phase under normal conditions', async (t) => {
+  const originalSetTimeout = globalThis.setTimeout;
+  const originalClearTimeout = globalThis.clearTimeout;
+  const timeouts: number[] = [];
+  let handle = 1;
+  const pending = new Map<number, () => void>();
+
+  function fakeSetTimeout(callback: (...args: any[]) => void, ms?: number) {
+    const id = handle++;
+    timeouts.push(typeof ms === 'number' ? ms : 0);
+    pending.set(id, () => {
+      try {
+        callback();
+      } catch {}
+    });
+    return id;
+  }
+
+  function fakeClearTimeout(id?: number) {
+    if (typeof id === 'number') {
+      pending.delete(id);
+    }
+  }
+
+  globalThis.setTimeout = fakeSetTimeout as any;
+  globalThis.clearTimeout = fakeClearTimeout as any;
+
+  const windowStub: any = {
+    devicePixelRatio: 1,
+    location: { search: '' },
+    navigator: {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => true,
+    performance: { now: () => 0 },
+    requestAnimationFrame: () => 1,
+    cancelAnimationFrame: () => {},
+    setTimeout: fakeSetTimeout,
+    clearTimeout: fakeClearTimeout,
+  };
+  const body = {
+    appendChild: () => {},
+    removeChild: () => {},
+    style: {},
+  };
+  const containerEl = {
+    id: 'app',
+    style: {},
+    contains: () => true,
+    appendChild: () => {},
+  } as any;
+  const documentStub: any = {
+    body,
+    readyState: 'complete',
+    createElement: () => ({
+      id: '',
+      style: {},
+      appendChild: () => {},
+      removeChild: () => {},
+    }),
+    getElementById: (id: string) => (id === 'app' ? containerEl : null),
+    addEventListener: () => {},
+    removeEventListener: () => {},
+  };
+
+  windowStub.document = documentStub;
+
+  (globalThis as any).window = windowStub;
+  (globalThis as any).document = documentStub;
+  (globalThis as any).performance = windowStub.performance;
+  (globalThis as any).requestAnimationFrame = windowStub.requestAnimationFrame;
+  (globalThis as any).cancelAnimationFrame = windowStub.cancelAnimationFrame;
+
+  t.after(() => {
+    globalThis.setTimeout = originalSetTimeout;
+    globalThis.clearTimeout = originalClearTimeout;
+    delete (globalThis as any).window;
+    delete (globalThis as any).document;
+    delete (globalThis as any).performance;
+    delete (globalThis as any).requestAnimationFrame;
+    delete (globalThis as any).cancelAnimationFrame;
+    mock.restoreAll();
+  });
+
+  mock.module('../block-remote-guard.js', () => ({}));
+  mock.module('../registerServiceWorker.ts', () => ({ registerSW: () => {} }));
+  mock.module('../core/bootstrap.js', () => ({
+    default: () => {},
+    whenBootReady: async () => {},
+  }));
+  mock.module('../engine/loop.js', () => ({
+    startGameLoop: () => ({ stop: () => {} }),
+    setLoopWatchdog: () => {},
+  }));
+  mock.module('../engine/safeEntry.js', () => ({
+    createSafeScene: async () => ({
+      renderer: { domElement: { style: {} } },
+      dispose: () => {},
+      render: () => {},
+      update: () => {},
+    }),
+  }));
+  mock.module('../ui/watchdog.js', () => ({
+    attachWatchdog: () => ({ warn: () => {}, error: () => {} }),
+  }));
+  mock.module('../services/remote.js', () => ({
+    maybeRemoteInit: () => {},
+  }));
+  mock.module('../../audio/startAmbience.ts', () => ({
+    startAmbience: () => {},
+  }));
+  mock.module('../utils/logger.ts', () => ({
+    logger: { info: () => {}, warn: () => {}, error: () => {} },
+  }));
+  mock.module('../initializeAthens.js', () => ({
+    initializeAthens: async () => ({
+      renderer: { setClearColor: () => {} },
+      scene: {},
+    }),
+  }));
+  mock.module('three', () => ({
+    Color: class Color {
+      constructor(_hex: number) {}
+    },
+  }));
+
+  await import('../landing.js');
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.equal(windowStub.__athensBoot?.phase, 'ready');
+  assert.ok(
+    timeouts.every((ms) => ms <= 10000),
+    'no watchdog should exceed 10s'
+  );
+});

--- a/src/entry/block-remote-guard.js
+++ b/src/entry/block-remote-guard.js
@@ -1,6 +1,5 @@
 import { USE_REMOTE } from '../config/flags';
 import { logger } from '../utils/logger.ts';
-import { buildBaseRelativeUrl } from '../utils/baseUrl.ts';
 
 if (typeof window !== 'undefined' && !USE_REMOTE) {
   (function () {
@@ -33,8 +32,8 @@ if (typeof window !== 'undefined' && !USE_REMOTE) {
     }
 
     try {
-      const swRelative = buildBaseRelativeUrl('service-worker.js');
-      const swUrl = new URL(swRelative, window.location.href).toString();
+      const base = (import.meta?.env?.BASE_URL ?? window.__ATHENS_BASE__ ?? '/');
+      const swUrl = new URL(`${base}service-worker.js`, window.location.href).toString();
 
       Promise.resolve()
         .then(() =>

--- a/src/entry/initializeAthens.js
+++ b/src/entry/initializeAthens.js
@@ -55,6 +55,7 @@ import { SKY_JPGS, GROUND_JPGS } from '../assets/skyGround.generated.ts';
 import { installSkyDev } from '../dev/skyDebugHooks.js';
 import { setExternalGroundTexture } from '../materials/groundGrass.js';
 // SKYSYS_END
+import { withTimeout } from '../boot/withTimeout.ts';
 
 // CHAR_MAIN_HEIGHT_START
 // Height scaling for the main character is no longer required.
@@ -68,6 +69,13 @@ const _TMP_GROUND = new THREE.Vector3();
 const WALKING_ENABLED = true;
 const _WALK_LOOK_DIR = new THREE.Vector3();
 const _WALK_LOOK_TARGET = new THREE.Vector3();
+
+function getPhaseSetter() {
+  if (typeof window !== 'undefined' && typeof window.__athensSetPhase === 'function') {
+    return window.__athensSetPhase;
+  }
+  return () => {};
+}
 
 function _setWorldPosition(object, x, y, z) {
   if (!object?.isObject3D) return false;
@@ -511,6 +519,7 @@ function createPlaceholderPlayer() {
 }
 
 export async function initializeAthens(options = {}) {
+  const setPhase = getPhaseSetter();
   const container = ensureContainerElement(options);
   container.style.position = container.style.position || 'relative';
 
@@ -537,6 +546,10 @@ export async function initializeAthens(options = {}) {
     container.appendChild(renderer.domElement);
   }
 
+  try {
+    setPhase('renderer-ready');
+  } catch {}
+
   const scene = new THREE.Scene();
   scene.background = new THREE.Color(DEFAULT_BACKGROUND_HEX);
   const camera = new THREE.PerspectiveCamera(60, initialWidth / initialHeight, 0.1, 2000);
@@ -558,11 +571,38 @@ export async function initializeAthens(options = {}) {
 
   renderer.setClearAlpha(1);
 
-  const {
-    createEnvironmentController,
-    registerExternalSkyImages,
-    applySkyImage,
-  } = await import('../environment/EnvironmentController.ts');
+  const environmentModule = await withTimeout(
+    import('../environment/EnvironmentController.ts'),
+    1500,
+    'environment-module',
+    async () => ({
+      createEnvironmentController: () => {
+        const stub = {
+          mode: 'day',
+          skyMode: 'day',
+          async applySky(next) {
+            if (typeof next === 'string' && next) {
+              stub.mode = next;
+              stub.skyMode = next;
+            }
+            return stub.mode;
+          },
+          setMode(next) {
+            if (typeof next === 'string' && next) {
+              stub.mode = next;
+              stub.skyMode = next;
+            }
+            return stub.mode;
+          },
+          dispose() {}
+        };
+        return stub;
+      },
+      registerExternalSkyImages: () => {},
+      applySkyImage: async () => {}
+    })
+  );
+  const { createEnvironmentController, registerExternalSkyImages, applySkyImage } = environmentModule;
 
   const environmentManager = createEnvironmentController({ scene, renderer });
 
@@ -685,8 +725,13 @@ export async function initializeAthens(options = {}) {
     }
   }
 
-  try {
-await environmentManager.applySky('day');
+  const applyInitialEnvironment = async () => {
+    try {
+      await environmentManager.applySky('day');
+    } catch (error) {
+      logger.warn('[Athens] applySky failed during initializeAthens.', error);
+      throw error;
+    }
 
     environmentManager.setMode('procedural');
     try {
@@ -698,10 +743,30 @@ await environmentManager.applySky('day');
         await applySkyImage(scene, renderer, match.url);
       }
     } catch {}
-  } catch (error) {
-    logger.warn('[Athens] applySky failed during initializeAthens.', error);
-    renderer.setClearColor(DEFAULT_BACKGROUND_HEX, 1);
-  }
+  };
+
+  try {
+    setPhase('env-start');
+  } catch {}
+
+  await withTimeout(
+    applyInitialEnvironment(),
+    2000,
+    'environment',
+    async () => {
+      try {
+        environmentManager?.setMode?.('day');
+      } catch {}
+      renderer.setClearColor(DEFAULT_BACKGROUND_HEX, 1);
+      try {
+        scene.background = new THREE.Color(DEFAULT_BACKGROUND_HEX);
+      } catch {}
+    }
+  );
+
+  try {
+    setPhase('env-ready');
+  } catch {}
 
   const ambientMuted = searchParams ? searchParams.get('mute') === '1' : false;
   const ambientOverrideSelected = searchParams ? searchParams.has('amb') : false;
@@ -1295,6 +1360,10 @@ if (readyPromise && typeof readyPromise.then === 'function') {
     playerNameCandidates: ['MainCharacter', 'Player']
   });
 
+  try {
+    setPhase('scene-ready');
+  } catch {}
+
   const resolveSavedState = () => {
     if (options?.savedState) {
       return options.savedState;
@@ -1671,6 +1740,10 @@ if (readyPromise && typeof readyPromise.then === 'function') {
   };
 
   const flyBypass = installFlyBypass({ state: flyBypassState, input: flyBypassInput });
+
+  try {
+    setPhase('first-frame');
+  } catch {}
   gameLoop.start();
 
   function startTimeOfDayCycle({ minutesPerDay = 10 } = {}) {

--- a/src/entry/landing.js
+++ b/src/entry/landing.js
@@ -8,6 +8,18 @@ import { createSafeScene } from '../engine/safeEntry.js';
 import { attachWatchdog } from '../ui/watchdog.js';
 import { maybeRemoteInit } from '../services/remote.js';
 import { logger } from '../utils/logger.ts';
+import { startAmbience } from '../audio/startAmbience.ts';
+
+(function () {
+  const S = (window.__athensBoot ||= { phase: 'html', t0: performance.now(), log: [] });
+  function set(p) {
+    S.phase = p;
+    S.log.push([performance.now(), p]);
+    console.info('[Athens][Boot]', p);
+  }
+  window.__athensSetPhase = set;
+  set('bundle-loaded');
+})();
 
 /**
  * @typedef {ReturnType<typeof initializeAthens> extends Promise<infer T> ? T : never} AthensContext
@@ -27,6 +39,78 @@ let fallbackLoop = null;
 let fallbackScene = null;
 let fallbackRoot = null;
 let fallbackInitTask = null;
+
+function renderBootFailureOverlay(error) {
+  if (typeof document === 'undefined') {
+    return;
+  }
+  const existing = document.getElementById('athens-boot-overlay');
+  if (existing) {
+    existing.textContent = error?.message || 'Boot failed';
+    return;
+  }
+
+  if (!document.body) {
+    return;
+  }
+
+  const overlay = document.createElement('div');
+  overlay.id = 'athens-boot-overlay';
+  overlay.style.cssText =
+    'position:fixed;inset:0;z-index:9999;display:flex;flex-direction:column;align-items:center;justify-content:center;background:rgba(16,18,24,0.92);color:#fff;font-family:system-ui,sans-serif;padding:24px;text-align:center;gap:12px;';
+
+  const title = document.createElement('div');
+  title.textContent = 'Athens could not start.';
+  title.style.fontSize = '20px';
+  title.style.fontWeight = '600';
+  overlay.appendChild(title);
+
+  const details = document.createElement('div');
+  details.textContent = error?.message || 'An unknown error occurred.';
+  details.style.fontSize = '14px';
+  details.style.opacity = '0.85';
+  overlay.appendChild(details);
+
+  const buttonRow = document.createElement('div');
+  buttonRow.style.display = 'flex';
+  buttonRow.style.flexDirection = 'row';
+  buttonRow.style.gap = '12px';
+  overlay.appendChild(buttonRow);
+
+  const resetButton = document.createElement('button');
+  resetButton.textContent = 'Reset Cache';
+  resetButton.style.cssText =
+    'padding:8px 16px;border-radius:6px;border:1px solid rgba(255,255,255,0.2);background:#1f2937;color:#fff;cursor:pointer;font-size:14px;';
+  resetButton.addEventListener('click', () => {
+    try {
+      if ('caches' in window && typeof caches.keys === 'function') {
+        caches
+          .keys()
+          .then((keys) => Promise.all(keys.map((key) => caches.delete(key))))
+          .catch(() => {});
+      }
+    } catch {}
+  });
+  buttonRow.appendChild(resetButton);
+
+  const swButton = document.createElement('button');
+  swButton.textContent = 'Unregister SW';
+  swButton.style.cssText = resetButton.style.cssText;
+  swButton.addEventListener('click', () => {
+    try {
+      const nav = window.navigator;
+      if (nav?.serviceWorker?.getRegistrations) {
+        nav.serviceWorker
+          .getRegistrations()
+          .then((regs) => Promise.all(regs.map((reg) => reg.unregister())))
+          .catch(() => {});
+      }
+    } catch {}
+  });
+  buttonRow.appendChild(swButton);
+
+  document.body.appendChild(overlay);
+}
 
 const ensureFallback = () => {
   if (fallbackActive || fallbackInitTask || typeof document === 'undefined') {
@@ -202,37 +286,30 @@ async function runAthens(options = {}) {
     container.style.position = container.style.position || 'relative';
     container.style.backgroundColor = container.style.backgroundColor || '#202834';
 
-    let bootTimer = null;
-    const bootTimeoutMarker = Symbol('athens.boot-timeout');
-    const bootTimeout = new Promise((resolve) => {
-      bootTimer = setTimeout(() => resolve(bootTimeoutMarker), 8000);
-    });
+    const setPhase =
+      typeof window !== 'undefined' && typeof window.__athensSetPhase === 'function'
+        ? window.__athensSetPhase
+        : () => {};
+    setPhase('init-start');
 
     const initializationTask = initializeAthens({ ...options, container });
+    let bootTimer = null;
     let context;
     try {
-      const firstResult = await Promise.race([initializationTask, bootTimeout]).catch((error) => {
-        watchdog?.error?.(error?.message || 'boot failed');
-        console.error('[Athens] Boot failed:', error);
-        throw error;
+      const watchdogTimer = new Promise((_, reject) => {
+        bootTimer = setTimeout(() => {
+          const lastPhase = window.__athensBoot?.phase;
+          reject(new Error(`Boot timeout; last phase=${lastPhase}`));
+        }, 10000);
       });
 
-      if (firstResult === bootTimeoutMarker) {
-        watchdog?.warn?.('boot timeout');
-        logger.warn('[Athens] Boot is taking longer than expected. Waiting for initialization to complete.');
-        context = await initializationTask.catch((error) => {
-          watchdog?.error?.(error?.message || 'boot failed');
-          console.error('[Athens] Boot failed:', error);
-          throw error;
-        });
-      } else {
-        context = firstResult;
-      }
+      context = await Promise.race([initializationTask, watchdogTimer]);
     } finally {
       if (bootTimer) {
         clearTimeout(bootTimer);
       }
     }
+
     context.renderer?.setClearColor?.(0x202834, 1);
     if (context.scene) {
       try {
@@ -243,7 +320,15 @@ async function runAthens(options = {}) {
     }
 
     teardownFallback();
-    maybeRemoteInit(context);
+    try {
+      setPhase('ready');
+    } catch {}
+    try {
+      startAmbience();
+    } catch {}
+    Promise.resolve()
+      .then(() => maybeRemoteInit(context))
+      .catch(() => {});
     initializedContext = context;
     return context;
   })();
@@ -251,6 +336,10 @@ async function runAthens(options = {}) {
   try {
     return await initializationTask;
   } catch (error) {
+    renderBootFailureOverlay(error);
+    if (typeof error?.message === 'string' && error.message.toLowerCase().includes('timeout')) {
+      watchdog?.warn?.('boot timeout');
+    }
     watchdog?.error?.(error?.message || 'boot failed');
     throw error;
   } finally {


### PR DESCRIPTION
## Summary
- track boot phases from bundle load through ready state and show a recovery overlay on failures
- wrap initialization steps with per-task timeouts, including environment setup, and add non-blocking ambience startup
- add reusable timeout helper plus smoke tests covering boot readiness and timeout fallbacks

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68dd0bf4cfbc83279a0128f65c40c8a5