### PR TITLE
Refactor environment bootstrapping to break initializeAthens sky cycle

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -29,3 +29,6 @@ jobs:
       - name: Check for unused dependencies
         run: npm run depcheck
 
+      - name: Check for import cycles
+        run: npx tsx scripts/check-cycles.ts
+

--- a/src/entry/__tests__/boot-smoke.test.ts
+++ b/src/entry/__tests__/boot-smoke.test.ts
@@ -213,32 +213,13 @@ async function stubThree(): Promise<ThreeModule> {
 }
 
 async function stubEnvironmentModule() {
-  const environmentModule = await import('../../environment/EnvironmentController.ts');
-  mock.method(environmentModule, 'createEnvironmentController', () => {
-    const manager: any = {
-      mode: 'day',
-      async applySky() {
-        return manager.mode;
-      },
-      setMode(next: string) {
-        manager.mode = next;
-        return next;
-      },
-      dispose() {},
-    };
-    Object.defineProperty(manager, 'skyMode', {
-      get() {
-        return manager.mode;
-      },
-      set(value: string) {
-        manager.mode = value;
-      },
-      configurable: true,
-    });
-    return manager;
-  });
-  mock.method(environmentModule, 'registerExternalSkyImages', () => {});
-  mock.method(environmentModule, 'applySkyImage', async () => {});
+  const environmentModule = await import('../../environment/envCore.ts');
+  mock.method(environmentModule, 'createEnvironment', () => ({
+    async applySkyMode() {},
+    async applySkyImage() {},
+    setMode() {},
+    dispose() {},
+  }));
 }
 
 async function stubAppModules(THREE: ThreeModule) {

--- a/src/entry/initializeAthens.js
+++ b/src/entry/initializeAthens.js
@@ -55,7 +55,7 @@ import { SKY_JPGS, GROUND_JPGS } from '../assets/skyGround.generated.ts';
 import { installSkyDev } from '../dev/skyDebugHooks.js';
 import { setExternalGroundTexture } from '../materials/groundGrass.js';
 // SKYSYS_END
-import { withTimeout } from '../boot/withTimeout.ts';
+import { withTimeout as withBootTimeout } from '../boot/withTimeout.ts';
 
 // CHAR_MAIN_HEIGHT_START
 // Height scaling for the main character is no longer required.
@@ -571,46 +571,63 @@ export async function initializeAthens(options = {}) {
 
   renderer.setClearAlpha(1);
 
-  const environmentModule = await withTimeout(
-    import('../environment/EnvironmentController.ts'),
+  const environmentModule = await withBootTimeout(
+    import('../environment/envCore.ts'),
     1500,
     'environment-module',
     async () => ({
-      createEnvironmentController: () => {
+      createEnvironment: () => {
         const stub = {
-          mode: 'day',
-          skyMode: 'day',
-          async applySky(next) {
-            if (typeof next === 'string' && next) {
-              stub.mode = next;
-              stub.skyMode = next;
-            }
-            return stub.mode;
-          },
-          setMode(next) {
-            if (typeof next === 'string' && next) {
-              stub.mode = next;
-              stub.skyMode = next;
-            }
-            return stub.mode;
-          },
+          async applySkyMode() {},
+          async applySkyImage() {},
+          setMode() {},
           dispose() {}
         };
         return stub;
-      },
-      registerExternalSkyImages: () => {},
-      applySkyImage: async () => {}
+      }
     })
   );
-  const { createEnvironmentController, registerExternalSkyImages, applySkyImage } = environmentModule;
+  const { createEnvironment } = environmentModule;
 
-  const environmentManager = createEnvironmentController({ scene, renderer });
+  const environmentManager = createEnvironment({ scene, renderer });
+
+  const sanitizeSkyToken = (value) =>
+    typeof value === 'string'
+      ? value.trim().toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '')
+      : '';
+
+  const SKY_MODE_ALIASES = new Map([
+    ['dawn', 'dawn'],
+    ['sunrise', 'dawn'],
+    ['day', 'day'],
+    ['high-noon', 'day'],
+    ['high_noon', 'day'],
+    ['highnoon', 'day'],
+    ['noon', 'day'],
+    ['midday', 'day'],
+    ['dusk', 'dusk'],
+    ['sunset', 'dusk'],
+    ['evening', 'dusk'],
+    ['golden-hour', 'dusk'],
+    ['goldenhour', 'dusk'],
+    ['blue-hour', 'dusk'],
+    ['night', 'night'],
+    ['midnight', 'night'],
+    ['night-sky', 'night'],
+    ['starlit-night', 'night'],
+    ['night-4k', 'night'],
+    ['night4k', 'night'],
+    ['procedural', 'day'],
+    ['image', 'day']
+  ]);
+
+  const resolveSkyMode = (mode) => SKY_MODE_ALIASES.get(sanitizeSkyToken(mode)) || 'day';
+
+  let lastAppliedSkyMode = 'day';
+  let environmentMode = 'day';
 
   // Register discovered assets (safe no-ops if arrays are empty)
   try {
-    if (Array.isArray(SKY_JPGS)) {
-      registerExternalSkyImages(SKY_JPGS);
-    }
     if (Array.isArray(GROUND_JPGS) && GROUND_JPGS.length > 0) {
       // Use the first ground jpg as default override (non-breaking: only affects grass when feature is used)
       setExternalGroundTexture(GROUND_JPGS[0].url);
@@ -651,7 +668,12 @@ export async function initializeAthens(options = {}) {
 
     window.dev = window.dev || {};
     window.dev.sky = window.dev.sky || {};
-    window.dev.sky.on = (mode = 'day') => environmentManager.applySky(mode);
+    window.dev.sky.on = (mode = 'day') => {
+      const skyMode = resolveSkyMode(mode);
+      lastAppliedSkyMode = skyMode;
+      environmentManager.setMode('procedural');
+      return environmentManager.applySkyMode(skyMode);
+    };
     window.dev.sky.off = () => { scene.background = null; scene.environment = null; };
     window.dev.sky.color = (hex = 0x87ceeb) => {
       renderer.setClearAlpha(1);
@@ -719,28 +741,47 @@ export async function initializeAthens(options = {}) {
       globalWindow.__athensDebug.setSkyImage = async (idOrUrl) => {
         const item = (SKY_JPGS || []).find((x) => x.id === idOrUrl || x.url === idOrUrl);
         if (item) {
-          await applySkyImage(scene, renderer, item.url);
+          await environmentManager.applySkyImage(item.url);
+          environmentManager.setMode('image');
         }
       };
     }
   }
 
-  const applyInitialEnvironment = async () => {
+  const withTimeout = async (p, ms, fb) => {
+    let t;
+    const to = new Promise((_, r) => {
+      t = setTimeout(() => r(new Error('timeout')), ms);
+    });
     try {
-      await environmentManager.applySky('day');
-    } catch (error) {
-      logger.warn('[Athens] applySky failed during initializeAthens.', error);
-      throw error;
+      return await Promise.race([p, to]);
+    } catch {
+      return typeof fb === 'function' ? fb() : fb;
+    } finally {
+      if (t) {
+        clearTimeout(t);
+      }
     }
+  };
 
+  const applyInitialEnvironment = async () => {
+    await withTimeout(environmentManager.applySkyMode('day'), 2000, () => {
+      try {
+        logger.warn('[Athens] applySkyMode("day") timed out; using clear color fallback.');
+      } catch {}
+      renderer.setClearColor(DEFAULT_BACKGROUND_HEX, 1);
+    });
+
+    lastAppliedSkyMode = 'day';
     environmentManager.setMode('procedural');
     try {
-      const currentMode = environmentManager?.skyMode || appliedSkyMode || 'day';
+      const currentMode = environmentMode || lastAppliedSkyMode || 'day';
       const match = (SKY_JPGS || []).find((i) =>
         (i.tags || []).some((t) => t.toLowerCase() === String(currentMode).toLowerCase())
       );
       if (match) {
-        await applySkyImage(scene, renderer, match.url);
+        await environmentManager.applySkyImage(match.url);
+        environmentManager.setMode('image');
       }
     } catch {}
   };
@@ -749,7 +790,7 @@ export async function initializeAthens(options = {}) {
     setPhase('env-start');
   } catch {}
 
-  await withTimeout(
+  await withBootTimeout(
     applyInitialEnvironment(),
     2000,
     'environment',
@@ -828,8 +869,6 @@ export async function initializeAthens(options = {}) {
       // Ignore stats setup errors.
     });
 
-  let environmentMode = 'day';
-
   const setEnvironmentMode = (mode, { allowAmbient = true } = {}) => {
     const normalized = typeof mode === 'string' && mode ? mode : 'day';
     environmentMode = normalized;
@@ -846,8 +885,11 @@ export async function initializeAthens(options = {}) {
     async setMode(mode, envOptions = {}) {
       const allowAmbient = envOptions?.playAmbient !== false;
       const next = setEnvironmentMode(mode, { allowAmbient });
+      const skyMode = resolveSkyMode(next);
       try {
-        await environmentManager.applySky(next);
+        await environmentManager.applySkyMode(skyMode);
+        lastAppliedSkyMode = skyMode;
+        environmentManager.setMode('procedural');
       } catch {
         // keep running if sky load fails
       }
@@ -862,7 +904,10 @@ export async function initializeAthens(options = {}) {
       return next;
     },
     applySky(mode) {
-      return environmentManager.applySky(mode);
+      const skyMode = resolveSkyMode(mode);
+      lastAppliedSkyMode = skyMode;
+      environmentManager.setMode('procedural');
+      return environmentManager.applySkyMode(skyMode);
     },
     dispose() {
       environmentManager.dispose();

--- a/src/environment/EnvironmentController.ts
+++ b/src/environment/EnvironmentController.ts
@@ -1,19 +1,46 @@
 import * as THREE from 'three';
-import { applySky } from '../scene/sky.ts';
+import { createEnvironment, type EnvAPI, type EnvDeps } from './envCore.ts';
 import { disposeAll } from '../utils/disposable.ts';
 
 export type SkyMode = 'procedural' | string;
 
+function normalizeChoice(choice?: string | null): string | null {
+  if (!choice || typeof choice !== 'string') {
+    return null;
+  }
+  return choice.trim();
+}
+
+function canonicalSkyMode(choice?: string | null): 'dawn' | 'day' | 'dusk' | 'night' {
+  const normalized = normalizeChoice(choice)?.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+  switch (normalized) {
+    case 'dawn':
+    case 'sunrise':
+      return 'dawn';
+    case 'dusk':
+    case 'sunset':
+    case 'evening':
+    case 'golden-hour':
+    case 'goldenhour':
+      return 'dusk';
+    case 'night':
+    case 'midnight':
+    case 'night-sky':
+    case 'starlit-night':
+      return 'night';
+    default:
+      return 'day';
+  }
+}
+
 export class EnvironmentController {
-  private readonly scene: THREE.Scene;
-  private readonly renderer: THREE.WebGLRenderer;
+  private readonly api: EnvAPI;
   private disposed = false;
   private currentSkyMode: SkyMode = 'procedural';
   private lastAppliedSkyId: string | null = null;
 
   constructor(scene: THREE.Scene, renderer: THREE.WebGLRenderer) {
-    this.scene = scene;
-    this.renderer = renderer;
+    this.api = createEnvironment({ scene, renderer });
   }
 
   get skyMode(): SkyMode {
@@ -24,9 +51,12 @@ export class EnvironmentController {
     if (this.disposed) {
       return null;
     }
-    const appliedId = await applySky(this.scene, this.renderer, choice);
-    this.lastAppliedSkyId = appliedId ?? null;
-    return appliedId;
+    const target = canonicalSkyMode(choice);
+    await this.api.applySkyMode(target);
+    this.lastAppliedSkyId = choice ?? target;
+    this.currentSkyMode = target;
+    this.api.setMode('procedural');
+    return this.lastAppliedSkyId;
   }
 
   setMode(mode: SkyMode): void {
@@ -36,6 +66,9 @@ export class EnvironmentController {
     this.currentSkyMode = mode;
     if (mode === 'procedural') {
       this.lastAppliedSkyId = null;
+      this.api.setMode('procedural');
+    } else {
+      this.api.setMode('image');
     }
   }
 
@@ -44,40 +77,23 @@ export class EnvironmentController {
     this.disposed = true;
     this.currentSkyMode = 'procedural';
     this.lastAppliedSkyId = null;
-    const environment = this.scene.environment as THREE.Texture | null;
-    const background = this.scene.background;
-    const backgroundTexture =
-      background instanceof THREE.Texture || background instanceof THREE.CubeTexture
-        ? background
-        : null;
-    disposeAll(environment, backgroundTexture);
-    this.scene.environment = null;
-    this.scene.background = null;
+    this.api.dispose();
   }
 }
 
-export type EnvironmentControllerArgs = {
-  scene: THREE.Scene;
-  renderer: THREE.WebGLRenderer;
-};
+export type EnvironmentControllerArgs = EnvDeps;
 
-export function createEnvironmentController({
-  scene,
-  renderer,
-}: EnvironmentControllerArgs): EnvironmentController {
+export function createEnvironmentController({ scene, renderer }: EnvironmentControllerArgs): EnvironmentController {
   return new EnvironmentController(scene, renderer);
 }
 
-// Optional registry for external sky images discovered at build time
 let _externalSkyImages: Array<{ id: string; url: string; tags?: string[] }> = [];
 
-/** Register external equirectangular sky JPGs (optional). No-ops if array is empty. */
 export function registerExternalSkyImages(images: Array<{ id: string; url: string; tags?: string[] }>) {
   if (!Array.isArray(images)) return;
   _externalSkyImages = images.filter((i) => i && typeof i.id === 'string' && typeof i.url === 'string');
 }
 
-/** Apply a single equirectangular sky image as background+environment (optional utility). */
 export async function applySkyImage(
   scene: THREE.Scene,
   renderer: THREE.WebGLRenderer,
@@ -87,13 +103,22 @@ export async function applySkyImage(
   const loader = new THREE.TextureLoader();
   const pmrem = new THREE.PMREMGenerator(renderer);
   pmrem.compileEquirectangularShader();
-  const tex: THREE.Texture = await new Promise((resolve, reject) =>
-    loader.load(url, resolve, undefined, reject)
-  );
+  const tex: THREE.Texture = await new Promise((resolve, reject) => loader.load(url, resolve, undefined, reject));
   tex.mapping = THREE.EquirectangularReflectionMapping;
-
-  // Build PMREM for env; keep the texture as background
   const envRT = pmrem.fromEquirectangular(tex);
+  pmrem.dispose();
+  const previousBackground = scene.background;
+  const previousEnvironment = scene.environment as THREE.Texture | THREE.CubeTexture | null;
   scene.background = tex;
   scene.environment = envRT.texture;
+  disposeAll(previousEnvironment);
+  if (
+    previousBackground &&
+    previousBackground !== tex &&
+    (previousBackground instanceof THREE.Texture || previousBackground instanceof THREE.CubeTexture)
+  ) {
+    disposeAll(previousBackground);
+  }
 }
+
+export { createEnvironment, type EnvAPI, type EnvDeps } from './envCore.ts';

--- a/src/environment/envCore.ts
+++ b/src/environment/envCore.ts
@@ -1,0 +1,165 @@
+import * as THREE from 'three';
+import { applySky } from '../scene/sky.ts';
+import { disposeAll } from '../utils/disposable.ts';
+
+export type EnvDeps = {
+  scene: THREE.Scene;
+  renderer: THREE.WebGLRenderer;
+};
+
+export type EnvAPI = {
+  applySkyMode(mode: 'dawn' | 'day' | 'dusk' | 'night'): Promise<void>;
+  applySkyImage(url: string): Promise<void>;
+  setMode(mode: 'procedural' | 'image'): void;
+  dispose(): void;
+};
+
+type ImageState = {
+  background: THREE.Texture | null;
+  environment: THREE.Texture | THREE.CubeTexture | null;
+  renderTarget: THREE.WebGLRenderTarget | null;
+};
+
+const EMPTY_IMAGE_STATE: ImageState = {
+  background: null,
+  environment: null,
+  renderTarget: null,
+};
+
+function cloneImageState(state: ImageState): ImageState {
+  return {
+    background: state.background,
+    environment: state.environment,
+    renderTarget: state.renderTarget,
+  };
+}
+
+function disposeImageState(state: ImageState) {
+  disposeAll(state.background, state.environment, state.renderTarget);
+}
+
+function normalizeSkyMode(mode: 'dawn' | 'day' | 'dusk' | 'night'): 'dawn' | 'day' | 'dusk' | 'night' {
+  switch (mode) {
+    case 'dawn':
+    case 'day':
+    case 'dusk':
+    case 'night':
+    default:
+      return mode;
+  }
+}
+
+export function createEnvironment({ scene, renderer }: EnvDeps): EnvAPI {
+  if (!scene || !renderer) {
+    throw new Error('[env] createEnvironment requires a scene and renderer.');
+  }
+
+  let disposed = false;
+  let mode: 'procedural' | 'image' = 'procedural';
+  let imageState: ImageState = { ...EMPTY_IMAGE_STATE };
+
+  const ensureActive = () => {
+    if (disposed) {
+      return false;
+    }
+    return true;
+  };
+
+  return {
+    async applySkyMode(nextMode) {
+      if (!ensureActive()) {
+        return;
+      }
+
+      const previousImage = cloneImageState(imageState);
+      imageState = { ...EMPTY_IMAGE_STATE };
+
+      try {
+        const normalized = normalizeSkyMode(nextMode);
+        await applySky(scene, renderer, normalized);
+        mode = 'procedural';
+      } finally {
+        disposeImageState(previousImage);
+      }
+    },
+
+    async applySkyImage(url: string) {
+      if (!ensureActive() || !url) {
+        return;
+      }
+
+      const loader = new THREE.TextureLoader();
+      const pmrem = new THREE.PMREMGenerator(renderer);
+      pmrem.compileEquirectangularShader();
+
+      let texture: THREE.Texture | null = null;
+      try {
+        texture = await new Promise<THREE.Texture>((resolve, reject) =>
+          loader.load(url, resolve, undefined, reject)
+        );
+      } catch (error) {
+        pmrem.dispose();
+        throw error;
+      }
+
+      if (!texture) {
+        pmrem.dispose();
+        return;
+      }
+
+      texture.mapping = THREE.EquirectangularReflectionMapping;
+
+      const renderTarget = pmrem.fromEquirectangular(texture);
+      pmrem.dispose();
+
+      const previousBackground = scene.background;
+      const previousEnvironment = scene.environment as THREE.Texture | THREE.CubeTexture | null;
+      const previousImage = cloneImageState(imageState);
+
+      scene.background = texture;
+      scene.environment = renderTarget.texture;
+
+      imageState = {
+        background: texture,
+        environment: renderTarget.texture,
+        renderTarget,
+      };
+      mode = 'image';
+
+      disposeAll(previousEnvironment);
+      if (
+        previousBackground &&
+        previousBackground !== texture &&
+        (previousBackground instanceof THREE.Texture || previousBackground instanceof THREE.CubeTexture)
+      ) {
+        disposeAll(previousBackground);
+      }
+
+      disposeImageState(previousImage);
+    },
+
+    setMode(next) {
+      if (!ensureActive()) {
+        return;
+      }
+      mode = next === 'image' ? 'image' : 'procedural';
+    },
+
+    dispose() {
+      if (disposed) {
+        return;
+      }
+      disposed = true;
+      disposeImageState(imageState);
+      imageState = { ...EMPTY_IMAGE_STATE };
+      const environment = scene.environment as THREE.Texture | THREE.CubeTexture | null;
+      const background = scene.background;
+      disposeAll(environment);
+      if (background instanceof THREE.Texture || background instanceof THREE.CubeTexture) {
+        disposeAll(background);
+      }
+      scene.environment = null;
+      scene.background = null;
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- extract a standalone environment core factory that manages sky modes without entry-point side effects
- update initializeAthens to lazy-load the new environment API, guard initial sky application, and keep sky/image selection async
- ensure CI runs the import-cycle checker and align smoke tests with the new environment factory

## Testing
- npm run build
- npx tsx scripts/check-cycles.ts

------
https://chatgpt.com/codex/tasks/task_b_68dd11b257188327bef672c2e8fa4c7a