### PR TITLE
Fix collisionWorld initialization order

### DIFF
--- a/src/entry/initializeAthens.js
+++ b/src/entry/initializeAthens.js
@@ -683,6 +683,7 @@ export async function initializeAthens(options = {}) {
 
   let globalWindow = null;
   let searchParams = null;
+  let collisionWorld = { colliderMesh: null, bvh: null };
   if (typeof window !== 'undefined') {
     globalWindow = window;
     searchParams = new URLSearchParams(globalWindow.location.search);
@@ -1161,7 +1162,6 @@ export async function initializeAthens(options = {}) {
   const colliderMeshes = collectColliders(scene);
   const colliders = buildAABBs(colliderMeshes);
 
-  let collisionWorld = { colliderMesh: null, bvh: null };
   if (WALKING_ENABLED) {
     const collisionWorldUrl =
       options?.collisionWorldUrl ??


### PR DESCRIPTION
## Summary
- initialize the collision world state before exposing debug globals to avoid TDZ errors

## Testing
- npm test -- src/entry/__tests__/boot-smoke.test.ts *(fails: TypeError: Cannot redefine property: TextureLoader / WebGLRenderer)*

------
https://chatgpt.com/codex/tasks/task_b_68dd16c88fd88327b265bc5b4d7a8df7