### PR TITLE
Implement manifest-driven debug toggles

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ Development builds now launch straight into the main experience at `/`. For trou
 
 - Open `/dev/` while running the dev server to use the standalone bootstrap page without interfering with Vite's module proxy.
 - Press `S` to toggle the "sanity geometry" helper if the scene looks empty.
+- Press `M` to mute or resume the ambience audio.
+- Press `P` to show or hide the FPS panel (also available via `window.toggleStatsVisibility()` in the console).
 - Press `K` to toggle the sky background if you need to inspect lighting without the skybox.
-- Call `window.toggleStatsVisibility()` in the browser console to show or hide the FPS panel (visible automatically on localhost).
 - Watch the console for boot milestones (asset base detection, renderer sizing) and initialization errors.
 
 ## Entry points

--- a/src/audio/ambient.ts
+++ b/src/audio/ambient.ts
@@ -168,6 +168,19 @@ export async function playAmbient(id: string, fadeSeconds = 1.0) {
   }
 }
 
+export function stopAmbient() {
+  if (!R.current) {
+    return;
+  }
+  try {
+    R.current.stop();
+  } catch (error) {
+    logger.warn('[ambient] Failed to stop ambient track', error);
+  }
+  R.current = undefined;
+  R.fading = false;
+}
+
 export async function initAmbient(camera: THREE.Camera) {
   if (!camera) return;
   attachAudioListenerTo(camera);
@@ -194,6 +207,7 @@ export async function initAmbient(camera: THREE.Camera) {
 
 export const AmbientAPI = {
   play: (trackId: string) => playAmbient(trackId),
+  stop: () => stopAmbient(),
   list: () => AMBIENT_TRACKS.map((t) => t.id)
 };
 

--- a/src/config/hotkeys.ts
+++ b/src/config/hotkeys.ts
@@ -175,16 +175,16 @@ const flightActions = {
   descend: createAction(HotkeyCategoryId.Flight, {
     id: 'flight.descend',
     title: 'Descend',
-    default: 'KeyQ',
-    aliasCodes: ['KeyC', 'ControlLeft', 'ControlRight'],
-    fallback: ['q', ['c', 'KeyC'], 'control', 'ctrl']
+    default: 'ShiftLeft',
+    aliasCodes: ['ShiftRight', 'KeyQ', 'KeyC', 'ControlLeft', 'ControlRight'],
+    fallback: ['shift', ['q', 'KeyQ'], ['c', 'KeyC'], 'control', 'ctrl']
   }),
   toggle: createAction(HotkeyCategoryId.Flight, {
     id: 'flight.toggle',
     title: 'Toggle Flight',
-    default: 'KeyF',
-    aliasCodes: ['KeyX'],
-    fallback: ['f', ['x', 'KeyX']]
+    default: 'KeyX',
+    aliasCodes: ['KeyF'],
+    fallback: ['x', ['f', 'KeyF']]
   }),
   nudgeUp: createAction(HotkeyCategoryId.Flight, {
     id: 'flight.nudgeUp',
@@ -204,8 +204,26 @@ const debugActions = {
   toggleStats: createAction(HotkeyCategoryId.Debug, {
     id: 'debug.toggleStats',
     title: 'Toggle Stats Overlay',
-    default: 'KeyY',
-    fallback: ['y']
+    default: 'KeyP',
+    fallback: ['p']
+  }),
+  toggleSound: createAction(HotkeyCategoryId.Debug, {
+    id: 'debug.toggleSound',
+    title: 'Toggle Ambience Audio',
+    default: 'KeyM',
+    fallback: ['m']
+  }),
+  toggleSky: createAction(HotkeyCategoryId.Debug, {
+    id: 'debug.toggleSky',
+    title: 'Toggle Sky',
+    default: 'KeyK',
+    fallback: ['k']
+  }),
+  toggleSanityGeometry: createAction(HotkeyCategoryId.Debug, {
+    id: 'debug.toggleSanityGeometry',
+    title: 'Toggle Sanity Geometry',
+    default: 'KeyS',
+    fallback: ['s']
   })
 } as const;
 
@@ -261,6 +279,246 @@ export const HOTKEY_MANIFEST = {
   debug: debugActions,
   devTools: devToolActions
 } as const;
+
+type HotkeyManifestEntry = {
+  id: string;
+  title: string;
+  codes: string[];
+  default: string;
+  scope: HotkeyScope;
+};
+
+type HotkeyDisplayContext = 'hud' | 'docs';
+
+type HotkeyDisplayConfig = {
+  id: string;
+  actions: string[];
+  description: string;
+  contexts: HotkeyDisplayContext[];
+  order?: number;
+  includeAliases?: boolean;
+};
+
+type HotkeyDisplayEntry = {
+  id: string;
+  description: string;
+  label: string;
+  codes: string[];
+  actions: string[];
+  order: number;
+};
+
+const CODE_LABEL_OVERRIDES = new Map<string, string>([
+  ['ArrowUp', '↑'],
+  ['ArrowDown', '↓'],
+  ['ArrowLeft', '←'],
+  ['ArrowRight', '→'],
+  ['ShiftLeft', 'Shift'],
+  ['ShiftRight', 'Shift'],
+  ['ControlLeft', 'Ctrl'],
+  ['ControlRight', 'Ctrl'],
+  ['AltLeft', 'Alt'],
+  ['AltRight', 'Alt'],
+  ['Space', 'Space'],
+  ['Escape', 'Esc'],
+  ['Backquote', '`']
+]);
+
+function formatKeyCode(code: string): string {
+  if (typeof code !== 'string' || code === '') {
+    return '';
+  }
+  const override = CODE_LABEL_OVERRIDES.get(code);
+  if (override) {
+    return override;
+  }
+  if (code.startsWith('Key') && code.length === 4) {
+    return code.slice(3);
+  }
+  if (code.startsWith('Digit') && code.length >= 6) {
+    return code.slice(5);
+  }
+  if (code.endsWith('Arrow')) {
+    return code.replace('Arrow', '');
+  }
+  if (code.endsWith('Left') || code.endsWith('Right')) {
+    return code.replace(/Left|Right$/, '');
+  }
+  return code;
+}
+
+function uniquePreserveOrder<T>(values: T[]): T[] {
+  const result: T[] = [];
+  const seen = new Set<T>();
+  for (const value of values) {
+    if (!seen.has(value)) {
+      seen.add(value);
+      result.push(value);
+    }
+  }
+  return result;
+}
+
+const HOTKEY_DISPLAY_CONFIG: HotkeyDisplayConfig[] = [
+  {
+    id: 'movement.move',
+    actions: [
+      movementActions.moveForward.id,
+      movementActions.moveLeft.id,
+      movementActions.moveBackward.id,
+      movementActions.moveRight.id
+    ],
+    description: 'Move',
+    contexts: ['hud', 'docs'],
+    order: 10
+  },
+  {
+    id: 'look.orbit',
+    actions: [
+      lookActions.lookLeft.id,
+      lookActions.lookRight.id,
+      lookActions.lookUp.id,
+      lookActions.lookDown.id
+    ],
+    description: 'Orbit Camera',
+    contexts: ['hud'],
+    order: 20
+  },
+  {
+    id: 'movement.run',
+    actions: [movementActions.run.id],
+    description: 'Hold to Run',
+    contexts: ['hud'],
+    order: 30
+  },
+  {
+    id: 'flight.toggle',
+    actions: [flightActions.toggle.id],
+    description: 'Toggle Flight',
+    contexts: ['hud'],
+    order: 40
+  },
+  {
+    id: 'flight.vertical',
+    actions: [flightActions.ascend.id, flightActions.descend.id],
+    description: 'Fly Up / Down',
+    contexts: ['hud'],
+    order: 50
+  },
+  {
+    id: 'debug.toggleSound',
+    actions: [debugActions.toggleSound.id],
+    description: 'Toggle Sound',
+    contexts: ['hud', 'docs'],
+    order: 60
+  },
+  {
+    id: 'debug.toggleStats',
+    actions: [debugActions.toggleStats.id],
+    description: 'Toggle FPS Panel',
+    contexts: ['hud', 'docs'],
+    order: 70
+  },
+  {
+    id: 'debug.toggleSky',
+    actions: [debugActions.toggleSky.id],
+    description: 'Toggle Sky',
+    contexts: ['hud', 'docs'],
+    order: 80
+  },
+  {
+    id: 'debug.toggleSanityGeometry',
+    actions: [debugActions.toggleSanityGeometry.id],
+    description: 'Toggle Sanity Geometry',
+    contexts: ['docs'],
+    order: 90
+  }
+];
+
+function resolveManifestMap(manifest?: HotkeyManifestEntry[]): Map<string, HotkeyManifestEntry> {
+  const map = new Map<string, HotkeyManifestEntry>();
+  if (Array.isArray(manifest)) {
+    for (const entry of manifest) {
+      if (entry && typeof entry.id === 'string') {
+        map.set(entry.id, entry);
+      }
+    }
+  }
+  return map;
+}
+
+function resolveCodesForAction(
+  actionId: string,
+  manifestMap: Map<string, HotkeyManifestEntry>,
+  includeAliases = false
+): string[] {
+  const manifestEntry = manifestMap.get(actionId);
+  if (manifestEntry) {
+    if (includeAliases) {
+      return manifestEntry.codes ?? [];
+    }
+    if (manifestEntry.default) {
+      return [manifestEntry.default];
+    }
+  }
+  const definition = getActionDefinition(actionId);
+  if (!definition) {
+    return [];
+  }
+  if (includeAliases) {
+    return definition.codes;
+  }
+  return definition.default ? [definition.default] : definition.codes.slice(0, 1);
+}
+
+function buildDisplayEntry(
+  config: HotkeyDisplayConfig,
+  manifestMap: Map<string, HotkeyManifestEntry>
+): HotkeyDisplayEntry | null {
+  const codes: string[] = [];
+  for (const actionId of config.actions) {
+    const actionCodes = resolveCodesForAction(actionId, manifestMap, config.includeAliases);
+    for (const code of actionCodes) {
+      if (typeof code === 'string' && code) {
+        codes.push(code);
+      }
+    }
+  }
+  if (!codes.length) {
+    return null;
+  }
+  const formatted = uniquePreserveOrder(codes.map((code) => formatKeyCode(code)).filter(Boolean));
+  if (!formatted.length) {
+    return null;
+  }
+  return {
+    id: config.id,
+    description: config.description,
+    label: formatted.join(' / '),
+    codes: formatted,
+    actions: [...config.actions],
+    order: typeof config.order === 'number' ? config.order : 0
+  };
+}
+
+export function getHotkeyDisplayEntries(
+  context: HotkeyDisplayContext,
+  manifest?: HotkeyManifestEntry[]
+): HotkeyDisplayEntry[] {
+  const normalizedContext = String(context) as HotkeyDisplayContext;
+  const manifestMap = resolveManifestMap(manifest);
+  const entries: HotkeyDisplayEntry[] = [];
+  for (const config of HOTKEY_DISPLAY_CONFIG) {
+    if (!config.contexts.includes(normalizedContext)) {
+      continue;
+    }
+    const entry = buildDisplayEntry(config, manifestMap);
+    if (entry) {
+      entries.push(entry);
+    }
+  }
+  return entries.sort((a, b) => a.order - b.order);
+}
 
 const relevantKeys = new Set<string>();
 for (const def of actionRegistry.values()) {
@@ -341,7 +599,10 @@ export const HOTKEY_IDS = Object.freeze({
   },
   debug: {
     toggleInspector: debugActions.toggleInspector.id,
-    toggleStats: debugActions.toggleStats.id
+    toggleStats: debugActions.toggleStats.id,
+    toggleSound: debugActions.toggleSound.id,
+    toggleSky: debugActions.toggleSky.id,
+    toggleSanityGeometry: debugActions.toggleSanityGeometry.id
   },
   devTools: {
     captureScreenshot: devToolActions.captureScreenshot.id,
@@ -371,3 +632,5 @@ export function getActionsByScope(scope: HotkeyScope): HotkeyActionDefinition[] 
 
 export type { HotkeyActionDefinition };
 export type { HotkeyScope };
+export type { HotkeyManifestEntry };
+export type { HotkeyDisplayEntry };

--- a/src/config/movement.ts
+++ b/src/config/movement.ts
@@ -73,8 +73,8 @@ export const movementConfig: MovementConfig = {
     scale: 1
   },
   flight: {
-    toggleKey: 'KeyF',
-    toggleKeys: ['KeyF', 'KeyX'],
+    toggleKey: 'KeyX',
+    toggleKeys: ['KeyX', 'KeyF'],
     horizontalSpeed: FLIGHT.horizontalSpeed,
     verticalSpeed: FLIGHT.verticalSpeed,
     verticalAcceleration: 20,

--- a/src/debug/sanityGeometry.js
+++ b/src/debug/sanityGeometry.js
@@ -1,0 +1,118 @@
+import * as THREE from 'three';
+import { disposeAll } from '../utils/disposable.ts';
+
+function buildSanityGeometry() {
+  const group = new THREE.Group();
+  group.name = 'DevSanityGeometry';
+
+  const box = new THREE.Mesh(
+    new THREE.BoxGeometry(60, 60, 60),
+    new THREE.MeshStandardMaterial({
+      color: '#f87171',
+      transparent: true,
+      opacity: 0.4,
+      metalness: 0.1,
+      roughness: 0.6
+    })
+  );
+  box.position.set(0, 30, 0);
+  box.castShadow = true;
+  group.add(box);
+
+  const boxEdges = new THREE.LineSegments(
+    new THREE.EdgesGeometry(new THREE.BoxGeometry(60, 60, 60)),
+    new THREE.LineBasicMaterial({ color: '#f8fafc' })
+  );
+  boxEdges.position.copy(box.position);
+  group.add(boxEdges);
+
+  const plane = new THREE.Mesh(
+    new THREE.PlaneGeometry(260, 260, 10, 10),
+    new THREE.MeshBasicMaterial({ color: '#38bdf8', wireframe: true })
+  );
+  plane.rotation.x = -Math.PI / 2;
+  plane.position.y = 0.02;
+  group.add(plane);
+
+  return group;
+}
+
+function disposeSanityGeometry(group) {
+  if (!group) {
+    return;
+  }
+  group.traverse((child) => {
+    if (child.isMesh || child.isLineSegments) {
+      disposeAll(child.geometry);
+      const { material } = child;
+      if (Array.isArray(material)) {
+        material.forEach((mat) => disposeAll(mat));
+      } else {
+        disposeAll(material);
+      }
+    }
+  });
+}
+
+export function createSanityGeometryController(scene) {
+  if (!scene || typeof scene.add !== 'function') {
+    return {
+      show() {
+        return false;
+      },
+      hide() {
+        return false;
+      },
+      toggle() {
+        return false;
+      },
+      isVisible() {
+        return false;
+      },
+      dispose() {}
+    };
+  }
+
+  let sanityGeometry = null;
+
+  function show() {
+    if (sanityGeometry) {
+      return true;
+    }
+    sanityGeometry = buildSanityGeometry();
+    scene.add(sanityGeometry);
+    return true;
+  }
+
+  function hide() {
+    if (!sanityGeometry) {
+      return false;
+    }
+    scene.remove(sanityGeometry);
+    disposeSanityGeometry(sanityGeometry);
+    disposeAll(sanityGeometry);
+    sanityGeometry = null;
+    return false;
+  }
+
+  function toggle(forceVisible) {
+    if (typeof forceVisible === 'boolean') {
+      return forceVisible ? show() : !hide();
+    }
+    return sanityGeometry ? hide() : show();
+  }
+
+  function isVisible() {
+    return Boolean(sanityGeometry);
+  }
+
+  return {
+    show,
+    hide,
+    toggle,
+    isVisible,
+    dispose() {
+      hide();
+    }
+  };
+}

--- a/src/entry/initializeAthens.js
+++ b/src/entry/initializeAthens.js
@@ -14,11 +14,13 @@ import { collectRoadPoints } from '../roads/collectRoadPoints.js';
 import { createNpcSystem } from '../npc/npcSystem.js';
 import { createMainCharacter } from '../npc/mainCharacter.js';
 import { createKeyboard } from '../input/keyboard.js';
-import { HOTKEY_IDS } from '../config/hotkeys.ts';
+import { HOTKEY_IDS, getHotkeyDisplayEntries } from '../config/hotkeys.ts';
 import { createFollowCamera } from '../camera/followCamera.js';
 import { seedCameraBehindPlayer } from '../camera/seedCameraBehindPlayer.js';
 import { createPlayerController } from '../player/playerController.js';
 import { installFlyBypass } from '../dev/flyBypass.js';
+import { bindHotkeyActions } from '../input/bindHotkeyActions.js';
+import { registerScopedHotkeys } from '../input/hotkeyScopes.js';
 import { createGameLoop } from '../engine/loop.js';
 import { movementConfig } from '../config/movement.ts';
 import { markGround, collectGround } from '../physics/groundRegistry.js';
@@ -50,6 +52,7 @@ import {
 } from '../utils/sanitize.ts';
 import { CUSTOM_AMBIENT_TRACKS } from '../audio/customAmbientTracks.generated.ts';
 import { initAmbient, AmbientAPI, AMBIENT_TRACKS, registerExternalAmbientTracks } from '../audio/ambient.ts';
+import { createSanityGeometryController } from '../debug/sanityGeometry.js';
 // SKYSYS_START
 import { SKY_JPGS, GROUND_JPGS } from '../assets/skyGround.generated.ts';
 import { installSkyDev } from '../dev/skyDebugHooks.js';
@@ -223,6 +226,15 @@ const registerGlobalStatsHelpers = () => {
     updateStatsVisibility();
     return statsVisible;
   };
+};
+
+const toggleStatsPanel = () => {
+  if (typeof window !== 'undefined' && typeof window.toggleStatsVisibility === 'function') {
+    return window.toggleStatsVisibility();
+  }
+  statsVisible = !statsVisible;
+  updateStatsVisibility();
+  return statsVisible;
 };
 
 const statsReady = (async () => {
@@ -566,6 +578,8 @@ export async function initializeAthens(options = {}) {
   camera.lookAt(initialLookTarget);
   scene.add(camera);
 
+  const sanityGeometry = createSanityGeometryController(scene);
+
 // Ensure we can actually see distant background
   if (camera.far < 50000) { camera.far = 50000; camera.updateProjectionMatrix(); }
 
@@ -625,6 +639,7 @@ export async function initializeAthens(options = {}) {
 
   let lastAppliedSkyMode = 'day';
   let environmentMode = 'day';
+  let skySuppressed = false;
 
   // Register discovered assets (safe no-ops if arrays are empty)
   try {
@@ -658,7 +673,7 @@ export async function initializeAthens(options = {}) {
   };
   let beforeUnloadCleanup = null;
 
-  registerDisposables(renderer, environmentManager);
+  registerDisposables(renderer, environmentManager, sanityGeometry);
 
   if (typeof window !== 'undefined') {
     window.scene = window.scene || scene;
@@ -810,7 +825,7 @@ export async function initializeAthens(options = {}) {
     setPhase('env-ready');
   } catch {}
 
-  const ambientMuted = searchParams ? searchParams.get('mute') === '1' : false;
+  let ambientMuted = searchParams ? searchParams.get('mute') === '1' : false;
   const ambientOverrideSelected = searchParams ? searchParams.has('amb') : false;
   const ambientTrackIds = new Set(AMBIENT_TRACKS.map((track) => track.id));
   const defaultAmbientTrack = AMBIENT_TRACKS.length > 0 ? AMBIENT_TRACKS[0].id : null;
@@ -847,6 +862,29 @@ export async function initializeAthens(options = {}) {
       AmbientAPI.play(trackId).catch(() => {});
     }
     return trackId;
+  };
+
+  const setAmbientMuted = (muted) => {
+    const next = Boolean(muted);
+    if (ambientMuted === next) {
+      return ambientMuted;
+    }
+    ambientMuted = next;
+    if (ambientMuted) {
+      try {
+        AmbientAPI.stop?.();
+      } catch (error) {
+        logger.warn('[Athens] Failed to stop ambient audio.', error);
+      }
+    } else {
+      applyAmbientForMode(environmentMode, true);
+    }
+    return ambientMuted;
+  };
+
+  const toggleAmbientMuted = () => {
+    setAmbientMuted(!ambientMuted);
+    return ambientMuted;
   };
 
   ensureLights(scene);
@@ -913,6 +951,28 @@ export async function initializeAthens(options = {}) {
     dispose() {
       environmentManager.dispose();
     }
+  };
+
+  const setSkySuppressedState = (hidden) => {
+    const next = Boolean(hidden);
+    if (skySuppressed === next) {
+      return skySuppressed;
+    }
+    skySuppressed = next;
+    if (skySuppressed) {
+      scene.background = null;
+      scene.environment = null;
+    } else {
+      const target = lastAppliedSkyMode || resolveSkyMode(environmentMode);
+      environmentManager.setMode('procedural');
+      environmentManager.applySkyMode(target).catch(() => {});
+    }
+    return skySuppressed;
+  };
+
+  const toggleSkySuppressed = () => {
+    setSkySuppressedState(!skySuppressed);
+    return skySuppressed;
   };
   registerDisposables(environmentController);
 
@@ -1210,6 +1270,25 @@ export async function initializeAthens(options = {}) {
 
   const ui = createOriginalUi({ container, overlayCanvas, environmentController });
   ui?.setTimeLabel?.(formatEnvironmentLabel(environmentController?.mode) || 'High Noon');
+  const applyHudInstructions = (manifest) => {
+    const entries = getHotkeyDisplayEntries('hud', manifest);
+    const mapped = entries.map((entry) => ({
+      id: entry.id,
+      label: entry.label,
+      description: entry.description
+    }));
+    ui?.setHotkeyInstructions?.(mapped);
+  };
+  applyHudInstructions();
+  const hudHotkeys = registerScopedHotkeys('gameplay', {
+    onActivate(manifest) {
+      applyHudInstructions(manifest);
+    },
+    onDeactivate() {
+      ui?.setHotkeyInstructions?.([]);
+    }
+  });
+  registerDisposables(hudHotkeys);
   registerDisposables(ui);
 
   // Roads built from collected points (use extended/shared materials if available)
@@ -1355,6 +1434,14 @@ if (readyPromise && typeof readyPromise.then === 'function') {
   const cameraSeedConfig = cameraSettings?.seed ?? {};
   const keyboard = createKeyboard();
   registerDisposables(keyboard);
+
+  const actionBindings = bindHotkeyActions({
+    [HOTKEY_IDS.debug.toggleStats]: () => toggleStatsPanel(),
+    [HOTKEY_IDS.debug.toggleSound]: () => toggleAmbientMuted(),
+    [HOTKEY_IDS.debug.toggleSky]: () => toggleSkySuppressed(),
+    [HOTKEY_IDS.debug.toggleSanityGeometry]: () => sanityGeometry?.toggle?.()
+  });
+  registerDisposables(actionBindings);
   const controller = createPlayerController(playerObject, keyboard, {
     walkSpeed: Number.isFinite(movementConfig?.walkSpeed) ? movementConfig.walkSpeed : 4,
     runMultiplier: Number.isFinite(movementConfig?.runMultiplier) ? movementConfig.runMultiplier : 1.7,
@@ -1825,6 +1912,20 @@ if (readyPromise && typeof readyPromise.then === 'function') {
     ui,
     collisionWorld,
     walkingController,
+    sanityGeometry,
+    toggleSound(muted) {
+      if (typeof muted === 'boolean') {
+        return setAmbientMuted(muted);
+      }
+      return toggleAmbientMuted();
+    },
+    toggleSky(hidden) {
+      if (typeof hidden === 'boolean') {
+        return setSkySuppressedState(hidden);
+      }
+      return toggleSkySuppressed();
+    },
+    toggleStats: () => toggleStatsPanel(),
     async setEnvironmentMode(mode, envOptions = {}) {
       const result = await environmentController?.setMode?.(mode, envOptions);
       const label = formatEnvironmentLabel(result || mode);
@@ -1869,6 +1970,10 @@ if (readyPromise && typeof readyPromise.then === 'function') {
     window.__athens.ui = context.ui;
     window.__athens.controller = WALKING_ENABLED && walkingController ? walkingController : controller;
     window.__athens.collisionWorld = collisionWorld;
+    window.__athens.toggleSound = context.toggleSound;
+    window.__athens.toggleSky = context.toggleSky;
+    window.__athens.toggleStats = context.toggleStats;
+    window.__athens.sanityGeometry = sanityGeometry;
   }
 
   return context;

--- a/src/input/bindHotkeyActions.js
+++ b/src/input/bindHotkeyActions.js
@@ -1,0 +1,140 @@
+import { getActionCodes } from '../config/hotkeys.ts';
+import { logger } from '../utils/logger.ts';
+import { registerScopedHotkeys } from './hotkeyScopes.js';
+import { resolveEventCode, shouldIgnoreKeyEvent } from './keyEventUtils.js';
+
+function normalizeHandlers(actionHandlers = {}) {
+  const map = new Map();
+  if (!actionHandlers || typeof actionHandlers !== 'object') {
+    return map;
+  }
+  for (const [actionId, handler] of Object.entries(actionHandlers)) {
+    if (typeof handler === 'function' && typeof actionId === 'string' && actionId) {
+      map.set(actionId, handler);
+    }
+  }
+  return map;
+}
+
+export function bindHotkeyActions(actionHandlers, { scope = 'gameplay' } = {}) {
+  if (typeof window === 'undefined') {
+    return {
+      dispose() {}
+    };
+  }
+
+  const handlers = normalizeHandlers(actionHandlers);
+  if (!handlers.size) {
+    return {
+      dispose() {}
+    };
+  }
+
+  const codeToHandlers = new Map();
+  let keydownListener = null;
+  let active = false;
+
+  function rebuild(manifest) {
+    codeToHandlers.clear();
+    const manifestMap = new Map();
+    if (Array.isArray(manifest)) {
+      for (const entry of manifest) {
+        if (entry && typeof entry.id === 'string') {
+          manifestMap.set(entry.id, entry);
+        }
+      }
+    }
+
+    for (const [actionId, handler] of handlers.entries()) {
+      const manifestEntry = manifestMap.get(actionId);
+      const codes = Array.isArray(manifestEntry?.codes) && manifestEntry.codes.length
+        ? manifestEntry.codes
+        : getActionCodes(actionId);
+      for (const code of codes) {
+        if (typeof code !== 'string' || code === '') {
+          continue;
+        }
+        const existing = codeToHandlers.get(code);
+        if (existing) {
+          existing.push({ id: actionId, handler });
+        } else {
+          codeToHandlers.set(code, [{ id: actionId, handler }]);
+        }
+      }
+    }
+  }
+
+  function handleKeydown(event) {
+    if (!active || event?.repeat) {
+      return;
+    }
+    if (shouldIgnoreKeyEvent(event)) {
+      return;
+    }
+    const resolved = resolveEventCode(event);
+    if (!resolved) {
+      return;
+    }
+    const mapped = codeToHandlers.get(resolved);
+    if (!mapped || !mapped.length) {
+      return;
+    }
+    let handled = false;
+    for (const entry of mapped) {
+      try {
+        const result = entry.handler({ actionId: entry.id, event });
+        if (result !== false) {
+          handled = true;
+        }
+      } catch (error) {
+        logger.warn('[Athens][Hotkeys] Action handler failed.', error);
+      }
+    }
+    if (handled) {
+      event.preventDefault?.();
+      event.stopImmediatePropagation?.();
+    }
+  }
+
+  function bindListener() {
+    if (keydownListener || typeof window === 'undefined') {
+      return;
+    }
+    keydownListener = handleKeydown;
+    window.addEventListener('keydown', keydownListener, true);
+  }
+
+  function unbindListener() {
+    if (keydownListener && typeof window !== 'undefined') {
+      window.removeEventListener('keydown', keydownListener, true);
+    }
+    keydownListener = null;
+  }
+
+  const session = registerScopedHotkeys(scope, {
+    onActivate(manifest) {
+      active = true;
+      rebuild(manifest);
+      bindListener();
+    },
+    onDeactivate() {
+      active = false;
+      codeToHandlers.clear();
+      unbindListener();
+    }
+  });
+
+  session.activate?.();
+
+  return {
+    dispose() {
+      unbindListener();
+      codeToHandlers.clear();
+      if (typeof session.dispose === 'function') {
+        session.dispose();
+      } else if (typeof session.deactivate === 'function') {
+        session.deactivate();
+      }
+    }
+  };
+}

--- a/src/input/keyEventUtils.js
+++ b/src/input/keyEventUtils.js
@@ -1,0 +1,28 @@
+import { KEY_FALLBACK_MAP } from '../config/hotkeys.ts';
+
+export function resolveEventCode(event) {
+  const code = typeof event?.code === 'string' && event.code !== 'Unidentified' ? event.code : '';
+  if (code) {
+    return code;
+  }
+  const key = typeof event?.key === 'string' ? event.key.toLowerCase() : '';
+  if (!key) {
+    return '';
+  }
+  return KEY_FALLBACK_MAP.get(key) || '';
+}
+
+export function shouldIgnoreKeyEvent(event) {
+  const target = event?.target;
+  if (!target || typeof target !== 'object') {
+    return false;
+  }
+  if (target.isContentEditable) {
+    return true;
+  }
+  if (typeof HTMLElement !== 'undefined' && target instanceof HTMLElement) {
+    const tag = target.tagName ? target.tagName.toLowerCase() : '';
+    return tag === 'input' || tag === 'textarea' || tag === 'select';
+  }
+  return false;
+}

--- a/src/player/playerController.js
+++ b/src/player/playerController.js
@@ -60,7 +60,7 @@ const SAFE_POSITION = {
 const ZERO_VECTOR = { x: 0, y: 0, z: 0 };
 
 const flightOptions = movementConfig?.flight ?? {};
-const FLIGHT_TOGGLE_KEY = typeof flightOptions.toggleKey === 'string' ? flightOptions.toggleKey : 'KeyF';
+const FLIGHT_TOGGLE_KEY = typeof flightOptions.toggleKey === 'string' ? flightOptions.toggleKey : 'KeyX';
 const defaultToggleKeys = (() => {
   const configured = Array.isArray(flightOptions.toggleKeys) && flightOptions.toggleKeys.length
     ? flightOptions.toggleKeys

--- a/src/ui/originalUi.js
+++ b/src/ui/originalUi.js
@@ -284,30 +284,48 @@ export function createOriginalUi({
     return badge;
   };
 
-  const appendInstruction = (keys, description) => {
-    if (instructionRow.childNodes.length) {
-      const divider = doc.createElement('span');
-      divider.textContent = '|';
-      applyStyles(divider, { opacity: '0.65' });
-      instructionRow.appendChild(divider);
+  let hotkeyInstructions = [];
+
+  const renderInstructions = () => {
+    while (instructionRow.firstChild) {
+      instructionRow.removeChild(instructionRow.firstChild);
     }
-    const keyLabel = Array.isArray(keys) ? keys.join(' / ') : keys;
-    instructionRow.appendChild(createKeyBadge(keyLabel));
-    const text = doc.createElement('span');
-    text.textContent = ` ${description}`;
-    applyStyles(text, { opacity: '0.85' });
-    instructionRow.appendChild(text);
+    if (!hotkeyInstructions.length) {
+      return;
+    }
+    const fragment = doc.createDocumentFragment();
+    hotkeyInstructions.forEach((entry, index) => {
+      if (index > 0) {
+        const divider = doc.createElement('span');
+        divider.textContent = '|';
+        applyStyles(divider, { opacity: '0.65' });
+        fragment.appendChild(divider);
+      }
+      fragment.appendChild(createKeyBadge(entry.label));
+      const text = doc.createElement('span');
+      text.textContent = ` ${entry.description}`;
+      applyStyles(text, { opacity: '0.85' });
+      fragment.appendChild(text);
+    });
+    instructionRow.appendChild(fragment);
   };
 
-  appendInstruction('WASD', 'Move');
-  appendInstruction('Arrows', 'Orbit Camera');
-  appendInstruction('Shift', 'Hold to Run');
-  appendInstruction('E', 'Interact');
-  appendInstruction('X', 'Toggle Flight');
-  appendInstruction(['Space', 'Shift'], 'Fly Up / Down');
-  appendInstruction('M', 'Sound');
-  appendInstruction('P', 'FPS');
-  appendInstruction('K', 'Toggle Sky');
+  const setHotkeyInstructions = (instructions = []) => {
+    if (!Array.isArray(instructions)) {
+      hotkeyInstructions = [];
+      renderInstructions();
+      return;
+    }
+    hotkeyInstructions = instructions
+      .filter((entry) => entry && typeof entry.label === 'string' && entry.label && typeof entry.description === 'string')
+      .map((entry) => ({
+        label: entry.label,
+        description: entry.description
+      }));
+    renderInstructions();
+  };
+
+  setHotkeyInstructions();
 
   const hudRight = doc.createElement('div');
   applyStyles(hudRight, {
@@ -440,6 +458,7 @@ export function createOriginalUi({
     setCurrentLocation(value) {
       currentLocationEl.textContent = value || '';
     },
+    setHotkeyInstructions,
     update(deltaSeconds, state) {
       updateStatus(deltaSeconds, state);
     },


### PR DESCRIPTION
## Summary
- expand the hotkey manifest with debug toggles and display metadata, and drive the HUD instructions from manifest data
- hook gameplay hotkeys into the ambient audio, stats overlay, sky visibility, and sanity geometry helpers with a shared binder
- add a reusable sanity geometry controller and update the README to reflect the supported debug hotkeys

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68dd194b910c8327aef2b5ab8a3572ed