### PR TITLE
Fix forward movement axis mapping for keyboard controls

### DIFF
--- a/src/config/hotkeys.ts
+++ b/src/config/hotkeys.ts
@@ -554,8 +554,8 @@ export const HOTKEY_AXIS_METADATA: AxisBinding[] = [
   {
     type: 'paired',
     axis: 'z',
-    positive: movementActions.moveBackward.id,
-    negative: movementActions.moveForward.id,
+    positive: movementActions.moveForward.id,
+    negative: movementActions.moveBackward.id,
     normalizeWith: ['x']
   },
   {

--- a/tests/keyboard-controls.test.js
+++ b/tests/keyboard-controls.test.js
@@ -30,7 +30,7 @@ test('keyboard respects event.code when provided', () => {
   assert.strictEqual(keyboard.isDown('KeyW'), true);
   assert.strictEqual(keyboard.isActionDown(HOTKEY_IDS.movement.forward), true);
   assert.strictEqual(keyboard.getActionState(HOTKEY_IDS.movement.forward).isDown, true);
-  assert.strictEqual(keyboard.axis.z, -1);
+  assert.strictEqual(keyboard.axis.z, 1);
 
   keyup({ code: 'KeyW', key: 'w' });
   assert.strictEqual(keyboard.isDown('KeyW'), false);
@@ -50,7 +50,7 @@ test('keyboard normalizes events without code to maintain controls', () => {
   assert.strictEqual(keyboard.isDown('KeyW'), true);
   assert.strictEqual(keyboard.isActionDown(HOTKEY_IDS.movement.forward), true);
   assert.strictEqual(keyboard.getActionState(HOTKEY_IDS.movement.forward).isDown, true);
-  assert.strictEqual(keyboard.axis.z, -1);
+  assert.strictEqual(keyboard.axis.z, 1);
 
   keydown({ key: 'Shift', code: 'Unidentified' });
   assert.strictEqual(keyboard.axis.running, true);
@@ -92,7 +92,7 @@ test('keyboard maps azerty movement aliases without triggering descend', () => {
   keydown({ key: 'z' });
   assert.strictEqual(keyboard.isDown('KeyW'), true);
   assert.strictEqual(keyboard.isActionDown(HOTKEY_IDS.movement.forward), true);
-  assert.strictEqual(keyboard.axis.z, -1);
+  assert.strictEqual(keyboard.axis.z, 1);
 
   keyup({ key: 'z' });
   assert.strictEqual(keyboard.axis.z, 0);


### PR DESCRIPTION
## Summary
- correct the forward/backward axis bindings so forward inputs map to positive motion
- update keyboard control tests to reflect the corrected axis orientation

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68dd1e3755488327b8521a463e2df370