### PR TITLE
Improve hotkey reliability across builds

### DIFF
--- a/src/config/hotkeys.ts
+++ b/src/config/hotkeys.ts
@@ -231,8 +231,8 @@ const devToolActions = {
   captureScreenshot: createAction(HotkeyCategoryId.DevTools, {
     id: 'dev.captureScreenshot',
     title: 'Capture Screenshot',
-    default: 'KeyP',
-    fallback: ['p']
+    default: 'F10',
+    fallback: [['f10', 'F10']]
   }),
   landmarkNext: createAction(HotkeyCategoryId.DevTools, {
     id: 'dev.landmark.next',

--- a/src/entry/initializeAthens.js
+++ b/src/entry/initializeAthens.js
@@ -14,7 +14,7 @@ import { collectRoadPoints } from '../roads/collectRoadPoints.js';
 import { createNpcSystem } from '../npc/npcSystem.js';
 import { createMainCharacter } from '../npc/mainCharacter.js';
 import { createKeyboard } from '../input/keyboard.js';
-import { HOTKEY_IDS, getHotkeyDisplayEntries } from '../config/hotkeys.ts';
+import { RELEVANT_KEYS, HOTKEY_IDS, getHotkeyDisplayEntries } from '../config/hotkeys.ts';
 import { createFollowCamera } from '../camera/followCamera.js';
 import { seedCameraBehindPlayer } from '../camera/seedCameraBehindPlayer.js';
 import { createPlayerController } from '../player/playerController.js';
@@ -34,6 +34,19 @@ import { createNavMeshPathfinder } from '../navmesh/pathfinder.js';
 import { loadWorldWithColliders } from '../physics/collisionWorld.ts';
 import { CharacterController } from '../controls/CharacterController.ts';
 import { getInput } from '../controls/input.ts';
+
+const __hotkeyHealthcheckEnabled =
+  typeof process === 'undefined' || process?.env?.NODE_ENV !== 'production';
+
+if (__hotkeyHealthcheckEnabled) {
+  try {
+    const sampleKeys = Array.from(RELEVANT_KEYS).slice(0, 10);
+    console.log('[Hotkeys] sample:', sampleKeys);
+    console.log('[Hotkeys] forward action codes:', HOTKEY_IDS?.movement?.forward);
+  } catch (error) {
+    console.warn('[Hotkeys] Failed to log hotkey healthcheck.', error);
+  }
+}
 import {
   LANDMARK_ALIASES,
   KNOWN_LANDMARK_KEYS,
@@ -1435,12 +1448,15 @@ if (readyPromise && typeof readyPromise.then === 'function') {
   const keyboard = createKeyboard();
   registerDisposables(keyboard);
 
-  const actionBindings = bindHotkeyActions({
-    [HOTKEY_IDS.debug.toggleStats]: () => toggleStatsPanel(),
-    [HOTKEY_IDS.debug.toggleSound]: () => toggleAmbientMuted(),
-    [HOTKEY_IDS.debug.toggleSky]: () => toggleSkySuppressed(),
-    [HOTKEY_IDS.debug.toggleSanityGeometry]: () => sanityGeometry?.toggle?.()
-  });
+  const actionBindings = bindHotkeyActions(
+    {
+      [HOTKEY_IDS.debug.toggleStats]: () => toggleStatsPanel(),
+      [HOTKEY_IDS.debug.toggleSound]: () => toggleAmbientMuted(),
+      [HOTKEY_IDS.debug.toggleSky]: () => toggleSkySuppressed(),
+      [HOTKEY_IDS.debug.toggleSanityGeometry]: () => sanityGeometry?.toggle?.()
+    },
+    { scope: 'gameplay' }
+  );
   registerDisposables(actionBindings);
   const controller = createPlayerController(playerObject, keyboard, {
     walkSpeed: Number.isFinite(movementConfig?.walkSpeed) ? movementConfig.walkSpeed : 4,

--- a/src/input/keyboard.js
+++ b/src/input/keyboard.js
@@ -9,6 +9,7 @@ const INV_SQRT2 = 1 / Math.sqrt(2);
 
 const pairedAxisBindings = new Map();
 let runningBinding = null;
+let hasWarnedForRelevantKeyFallback = false;
 
 for (const binding of HOTKEY_AXIS_METADATA) {
   if (!binding) continue;
@@ -52,6 +53,29 @@ export function createKeyboard(target = typeof window !== 'undefined' ? window :
   };
   const lookState = { x: 0, y: 0 };
   let frameJustPressed = new Set();
+
+  let activeRelevantKeys = RELEVANT_KEYS;
+  if (!RELEVANT_KEYS.size) {
+    activeRelevantKeys = new Set([
+      'KeyW',
+      'KeyA',
+      'KeyS',
+      'KeyD',
+      'ArrowLeft',
+      'ArrowRight',
+      'ArrowUp',
+      'ArrowDown',
+      'ShiftLeft',
+      'ShiftRight',
+      'Space'
+    ]);
+    const shouldWarn =
+      typeof process === 'undefined' || process?.env?.NODE_ENV !== 'production';
+    if (shouldWarn && !hasWarnedForRelevantKeyFallback) {
+      console.warn('[Hotkeys] Falling back to default relevant key allowlist.');
+      hasWarnedForRelevantKeyFallback = true;
+    }
+  }
 
   const resolveActionCodes = (actionId) => getActionCodes(actionId);
 
@@ -111,7 +135,7 @@ export function createKeyboard(target = typeof window !== 'undefined' ? window :
       }
     }
 
-    if (!code || !RELEVANT_KEYS.has(code)) {
+    if (!code || !activeRelevantKeys.has(code)) {
       return;
     }
     if (!pressed.has(code)) {
@@ -124,7 +148,7 @@ export function createKeyboard(target = typeof window !== 'undefined' ? window :
   const handleKeyUp = (event) => {
     const code = normalizeCode(event);
 
-    if (!code || !RELEVANT_KEYS.has(code)) {
+    if (!code || !activeRelevantKeys.has(code)) {
       return;
     }
     pressed.delete(code);


### PR DESCRIPTION
## Summary
- add a development-only hotkey healthcheck during Athens initialization
- bind core debug hotkeys at boot while moving the dev screenshot shortcut off KeyP
- provide a keyboard fallback allowlist when hotkey metadata fails to populate

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68dd2b3b4a0c8327a47fc43c3adcd3a6