### PR TITLE
Improve keyboard look controls and layout fallbacks

### DIFF
--- a/src/input/keyboard.js
+++ b/src/input/keyboard.js
@@ -20,6 +20,14 @@ for (const binding of HOTKEY_AXIS_METADATA) {
   }
 }
 
+const PREVENT_DEFAULT_CODES = new Set([
+  'Space',
+  'ArrowLeft',
+  'ArrowRight',
+  'ArrowUp',
+  'ArrowDown'
+]);
+
 const normalizeCode = (event) => {
   if (!event) {
     return undefined;
@@ -54,8 +62,11 @@ export function createKeyboard(target = typeof window !== 'undefined' ? window :
   const lookState = { x: 0, y: 0 };
   let frameJustPressed = new Set();
 
+  const isDevEnvironment =
+    typeof process === 'undefined' || process?.env?.NODE_ENV !== 'production';
+
   let activeRelevantKeys = RELEVANT_KEYS;
-  if (!RELEVANT_KEYS.size) {
+  if (!RELEVANT_KEYS.size && isDevEnvironment) {
     activeRelevantKeys = new Set([
       'KeyW',
       'KeyA',
@@ -69,9 +80,7 @@ export function createKeyboard(target = typeof window !== 'undefined' ? window :
       'ShiftRight',
       'Space'
     ]);
-    const shouldWarn =
-      typeof process === 'undefined' || process?.env?.NODE_ENV !== 'production';
-    if (shouldWarn && !hasWarnedForRelevantKeyFallback) {
+    if (!hasWarnedForRelevantKeyFallback) {
       console.warn('[Hotkeys] Falling back to default relevant key allowlist.');
       hasWarnedForRelevantKeyFallback = true;
     }
@@ -126,7 +135,7 @@ export function createKeyboard(target = typeof window !== 'undefined' ? window :
   const handleKeyDown = (event) => {
     const code = normalizeCode(event);
 
-    if (code === 'Space') {
+    if (code && PREVENT_DEFAULT_CODES.has(code)) {
       if (typeof event.preventDefault === 'function') {
         event.preventDefault();
       }
@@ -168,7 +177,8 @@ export function createKeyboard(target = typeof window !== 'undefined' ? window :
     axisState.x = updateAxisFromBinding('x');
     axisState.z = updateAxisFromBinding('z');
 
-    if (axisState.x !== 0 && axisState.z !== 0) {
+    const combinedMagnitude = Math.abs(axisState.x) + Math.abs(axisState.z);
+    if (combinedMagnitude > 1) {
       axisState.x *= INV_SQRT2;
       axisState.z *= INV_SQRT2;
     }

--- a/tests/keyboard-controls.test.js
+++ b/tests/keyboard-controls.test.js
@@ -4,6 +4,8 @@ import test from 'node:test';
 import createKeyboard from '../src/input/keyboard.js';
 import { HOTKEY_IDS } from '../src/config/hotkeys.ts';
 
+const EPSILON = 1e-6;
+
 const createMockTarget = () => {
   const listeners = new Map();
 
@@ -62,12 +64,26 @@ test('keyboard normalizes events without code to maintain controls', () => {
   assert.strictEqual(keyboard.look.x, -1);
   assert.strictEqual(keyboard.axis.lookX, -1);
 
+  keyup({ key: 'ArrowLeft', code: '' });
+
+  keydown({ key: 'ArrowRight', code: undefined });
+  assert.strictEqual(keyboard.axis.lookX, 1);
+  assert.strictEqual(keyboard.look.x, 1);
+
+  keyup({ key: 'ArrowRight', code: '' });
+
   keydown({ key: 'ArrowUp', code: undefined });
   assert.strictEqual(keyboard.look.y, 1);
   assert.strictEqual(keyboard.axis.lookY, 1);
 
-  keyup({ key: 'ArrowLeft', code: '' });
   keyup({ key: 'ArrowUp', code: '' });
+
+  keydown({ key: 'ArrowDown', code: undefined });
+  assert.strictEqual(keyboard.look.y, -1);
+  assert.strictEqual(keyboard.axis.lookY, -1);
+
+  keyup({ key: 'ArrowRight', code: '' });
+  keyup({ key: 'ArrowDown', code: '' });
   keyup({ key: 'Shift', code: '' });
   keyup({ key: 'w', code: '' });
 
@@ -106,6 +122,67 @@ test('keyboard maps azerty movement aliases without triggering descend', () => {
   keyup({ key: 'q' });
 
   assert.strictEqual(keyboard.axis.x, 0);
+
+  keyboard.dispose();
+});
+
+test('keyboard normalizes diagonal movement speed', () => {
+  const target = createMockTarget();
+  const keyboard = createKeyboard(target);
+  const keydown = target.listeners.get('keydown');
+  const keyup = target.listeners.get('keyup');
+
+  keydown({ code: 'KeyW', key: 'w' });
+  keydown({ code: 'KeyD', key: 'd' });
+
+  assert.ok(Math.abs(keyboard.axis.z - Math.SQRT1_2) < EPSILON);
+  assert.ok(Math.abs(keyboard.axis.x - Math.SQRT1_2) < EPSILON);
+
+  keyup({ code: 'KeyW', key: 'w' });
+  keyup({ code: 'KeyD', key: 'd' });
+
+  keyboard.dispose();
+});
+
+test('keyboard prevents default browser actions for space and arrow keys', () => {
+  const target = createMockTarget();
+  const keyboard = createKeyboard(target);
+  const keydown = target.listeners.get('keydown');
+  const keyup = target.listeners.get('keyup');
+
+  let spacePrevented = 0;
+  let spaceStopped = 0;
+  keydown({
+    code: 'Space',
+    key: ' ',
+    preventDefault() {
+      spacePrevented += 1;
+    },
+    stopPropagation() {
+      spaceStopped += 1;
+    }
+  });
+  assert.strictEqual(spacePrevented, 1);
+  assert.strictEqual(spaceStopped, 1);
+
+  keyup({ code: 'Space', key: ' ' });
+
+  let arrowPrevented = 0;
+  let arrowStopped = 0;
+  keydown({
+    code: 'ArrowDown',
+    key: 'ArrowDown',
+    preventDefault() {
+      arrowPrevented += 1;
+    },
+    stopPropagation() {
+      arrowStopped += 1;
+    }
+  });
+  assert.strictEqual(arrowPrevented, 1);
+  assert.strictEqual(arrowStopped, 1);
+
+  keyup({ code: 'ArrowDown', key: 'ArrowDown' });
 
   keyboard.dispose();
 });


### PR DESCRIPTION
## Summary
- ensure the keyboard adapter guards arrow and space keys while supporting dev-only fallback relevant keys
- keep axis calculations normalized for diagonals and expose look axes from arrow key input
- extend keyboard control tests to cover AZERTY fallbacks, look movement, sprinting, and default-prevention behavior

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68dd3130f2208327bf747b105cb0707c