### PR TITLE
Add procedural sky controller and enable HDR sky loading

### DIFF
--- a/src/entry/__tests__/boot-smoke.test.ts
+++ b/src/entry/__tests__/boot-smoke.test.ts
@@ -212,6 +212,33 @@ async function stubThree(): Promise<ThreeModule> {
   return THREE;
 }
 
+function mockSkyModule(THREE: ThreeModule) {
+  mock.module('three/examples/jsm/objects/Sky.js', () => {
+    class SkyStub extends THREE.Object3D {
+      material: any;
+      geometry: THREE.BufferGeometry;
+
+      constructor() {
+        super();
+        this.material = {
+          uniforms: {
+            turbidity: { value: 0 },
+            rayleigh: { value: 0 },
+            mieCoefficient: { value: 0 },
+            mieDirectionalG: { value: 0 },
+            sunPosition: { value: new THREE.Vector3() },
+            up: { value: new THREE.Vector3(0, 1, 0) },
+          },
+          dispose: () => {},
+        };
+        this.geometry = new THREE.BufferGeometry();
+      }
+    }
+
+    return { Sky: SkyStub };
+  });
+}
+
 async function stubEnvironmentModule() {
   const environmentModule = await import('../../environment/envCore.ts');
   mock.method(environmentModule, 'createEnvironment', () => ({
@@ -401,6 +428,87 @@ test('environment modules import without runtime side effects', async () => {
   await import('../../scene/sky.ts');
 
   assert.strictEqual(loaderCount, 0);
+  mock.restoreAll();
+});
+
+test('applySkyMode uses procedural sky environment', async () => {
+  mock.restoreAll();
+  const THREE = await import('three');
+  mockSkyModule(THREE);
+
+  mock.method(THREE, 'WebGLRenderer', function WebGLRenderer(this: any) {
+    this.domElement = new FakeCanvas();
+    this.dispose = () => {};
+    this.render = () => {};
+    this.getContext = () => ({ getExtension: () => null });
+    return this;
+  });
+
+  let pmremCalls = 0;
+  mock.method(THREE, 'PMREMGenerator', function PMREMGenerator(this: any) {
+    this.fromScene = () => {
+      pmremCalls += 1;
+      const texture = new THREE.Texture();
+      texture.dispose = () => {};
+      return { texture, dispose: () => {} } as any;
+    };
+    this.dispose = () => {};
+    return this;
+  });
+
+  const { createEnvironment } = await import('../../environment/envCore.ts');
+  const scene = new THREE.Scene();
+  const renderer = new THREE.WebGLRenderer();
+  const env = createEnvironment({ scene, renderer });
+
+  await env.applySkyMode('day');
+
+  assert.ok(scene.environment instanceof THREE.Texture);
+  assert.ok(scene.background instanceof THREE.Color);
+  assert.ok(pmremCalls > 0);
+
+  mock.restoreAll();
+});
+
+test('applySkyMode disposes previous procedural textures', async () => {
+  mock.restoreAll();
+  const THREE = await import('three');
+  mockSkyModule(THREE);
+
+  mock.method(THREE, 'WebGLRenderer', function WebGLRenderer(this: any) {
+    this.domElement = new FakeCanvas();
+    this.dispose = () => {};
+    this.render = () => {};
+    this.getContext = () => ({ getExtension: () => null });
+    return this;
+  });
+
+  let disposeCount = 0;
+  mock.method(THREE, 'PMREMGenerator', function PMREMGenerator(this: any) {
+    this.fromScene = () => {
+      const texture = new THREE.Texture();
+      texture.dispose = () => {
+        disposeCount += 1;
+      };
+      return { texture, dispose: () => {} } as any;
+    };
+    this.dispose = () => {};
+    return this;
+  });
+
+  const { createEnvironment } = await import('../../environment/envCore.ts');
+  const scene = new THREE.Scene();
+  const renderer = new THREE.WebGLRenderer();
+  const env = createEnvironment({ scene, renderer });
+
+  await env.applySkyMode('day');
+  const firstTexture = scene.environment as THREE.Texture | null;
+  await new Promise((resolve) => setTimeout(resolve, 220));
+  await env.applySkyMode('dusk');
+
+  assert.notStrictEqual(scene.environment, firstTexture);
+  assert.ok(disposeCount >= 1);
+
   mock.restoreAll();
 });
 

--- a/src/environment/envCore.ts
+++ b/src/environment/envCore.ts
@@ -1,6 +1,6 @@
 import * as THREE from 'three';
-import { applySky } from '../scene/sky.ts';
 import { disposeAll } from '../utils/disposable.ts';
+import { createProceduralSky, type SkyTime } from '../scene/proceduralSky.ts';
 
 export type EnvDeps = {
   scene: THREE.Scene;
@@ -8,7 +8,7 @@ export type EnvDeps = {
 };
 
 export type EnvAPI = {
-  applySkyMode(mode: 'dawn' | 'day' | 'dusk' | 'night'): Promise<void>;
+  applySkyMode(mode: SkyTime): Promise<void>;
   applySkyImage(url: string): Promise<void>;
   setMode(mode: 'procedural' | 'image'): void;
   dispose(): void;
@@ -38,7 +38,7 @@ function disposeImageState(state: ImageState) {
   disposeAll(state.background, state.environment, state.renderTarget);
 }
 
-function normalizeSkyMode(mode: 'dawn' | 'day' | 'dusk' | 'night'): 'dawn' | 'day' | 'dusk' | 'night' {
+function normalizeSkyMode(mode: SkyTime): SkyTime {
   switch (mode) {
     case 'dawn':
     case 'day':
@@ -56,6 +56,8 @@ export function createEnvironment({ scene, renderer }: EnvDeps): EnvAPI {
 
   let disposed = false;
   let imageState: ImageState = { ...EMPTY_IMAGE_STATE };
+  let procedural = null as ReturnType<typeof createProceduralSky> | null;
+  let _currentMode: 'procedural' | 'image' = 'procedural';
 
   const ensureActive = () => {
     if (disposed) {
@@ -75,7 +77,28 @@ export function createEnvironment({ scene, renderer }: EnvDeps): EnvAPI {
 
       try {
         const normalized = normalizeSkyMode(nextMode);
-        await applySky(scene, renderer, normalized);
+        if (!procedural) {
+          procedural = createProceduralSky(renderer);
+        }
+        procedural.setMode(normalized);
+        const previousBackground = scene.background;
+        const previousEnvironment = scene.environment as THREE.Texture | THREE.CubeTexture | null;
+        await procedural.applyTo(scene);
+        _currentMode = 'procedural';
+        if (
+          previousEnvironment &&
+          previousEnvironment !== scene.environment &&
+          (previousEnvironment instanceof THREE.Texture || previousEnvironment instanceof THREE.CubeTexture)
+        ) {
+          disposeAll(previousEnvironment);
+        }
+        if (
+          previousBackground &&
+          previousBackground !== scene.background &&
+          (previousBackground instanceof THREE.Texture || previousBackground instanceof THREE.CubeTexture)
+        ) {
+          disposeAll(previousBackground);
+        }
       } finally {
         disposeImageState(previousImage);
       }
@@ -133,6 +156,7 @@ export function createEnvironment({ scene, renderer }: EnvDeps): EnvAPI {
       }
 
       disposeImageState(previousImage);
+      _currentMode = 'image';
     },
 
     setMode(next) {
@@ -140,8 +164,7 @@ export function createEnvironment({ scene, renderer }: EnvDeps): EnvAPI {
         return;
       }
       if (next === 'image' || next === 'procedural') {
-        // Mode tracking has been removed; keep branch to satisfy lint and
-        // preserve the public signature.
+        _currentMode = next;
       }
     },
 
@@ -160,6 +183,9 @@ export function createEnvironment({ scene, renderer }: EnvDeps): EnvAPI {
       }
       scene.environment = null;
       scene.background = null;
+      procedural?.dispose();
+      procedural = null;
+      _currentMode = 'procedural';
     },
   };
 }

--- a/src/scene/proceduralSky.ts
+++ b/src/scene/proceduralSky.ts
@@ -1,0 +1,224 @@
+import * as THREE from 'three';
+import { Sky } from 'three/examples/jsm/objects/Sky.js';
+import { disposeAll } from '../utils/disposable.ts';
+
+export type SkyTime = 'dawn' | 'day' | 'dusk' | 'night';
+
+const { clamp, degToRad, radToDeg, lerp } = THREE.MathUtils;
+
+const MIN_PMREM_INTERVAL_MS = 180; // ~5.5 Hz refresh ceiling
+
+const SKY_BACKGROUND_COLORS: Record<SkyTime, number> = {
+  dawn: 0xffcfa3,
+  day: 0x87ceeb,
+  dusk: 0xffb37a,
+  night: 0x050b1a,
+};
+
+const NIGHT_COLOR = new THREE.Color(SKY_BACKGROUND_COLORS.night);
+const DAWN_COLOR = new THREE.Color(SKY_BACKGROUND_COLORS.dawn);
+const DAY_COLOR = new THREE.Color(SKY_BACKGROUND_COLORS.day);
+const DUSK_COLOR = new THREE.Color(SKY_BACKGROUND_COLORS.dusk);
+
+const MODE_PRESETS: Record<SkyTime, {
+  elevation: number;
+  azimuth: number;
+  turbidity: number;
+  rayleigh: number;
+  mieCoefficient: number;
+  mieDirectionalG: number;
+  background: THREE.Color;
+}> = {
+  dawn: {
+    elevation: 10,
+    azimuth: 145,
+    turbidity: 8,
+    rayleigh: 2.2,
+    mieCoefficient: 0.006,
+    mieDirectionalG: 0.7,
+    background: DAWN_COLOR.clone(),
+  },
+  day: {
+    elevation: 55,
+    azimuth: 180,
+    turbidity: 2.2,
+    rayleigh: 3.2,
+    mieCoefficient: 0.003,
+    mieDirectionalG: 0.8,
+    background: DAY_COLOR.clone(),
+  },
+  dusk: {
+    elevation: 8,
+    azimuth: 215,
+    turbidity: 9,
+    rayleigh: 2.1,
+    mieCoefficient: 0.0065,
+    mieDirectionalG: 0.72,
+    background: DUSK_COLOR.clone(),
+  },
+  night: {
+    elevation: -8,
+    azimuth: 180,
+    turbidity: 1.2,
+    rayleigh: 0.3,
+    mieCoefficient: 0.001,
+    mieDirectionalG: 0.9,
+    background: NIGHT_COLOR.clone(),
+  },
+};
+
+function buildTimePreset(hours01: number) {
+  const clamped = clamp(Number.isFinite(hours01) ? hours01 : 0, 0, 1);
+  const angle = clamped * Math.PI * 2;
+  const dayStrength = clamp(Math.sin(angle - Math.PI / 2), -1, 1);
+  const elevation = clamp(dayStrength * 70, -15, 85);
+  const azimuth = ((radToDeg(angle) + 180) % 360 + 360) % 360;
+  const daylight = Math.max(dayStrength, 0);
+  const duskBlend = clamp(1 - Math.abs(clamped - 0.5) * 4, 0, 1);
+
+  const turbidity = lerp(10, 2.5, clamp(daylight * 1.2, 0, 1));
+  const rayleigh = lerp(0.6, 3.25, clamp(daylight * 1.1, 0, 1));
+  const mieCoefficient = lerp(0.01, 0.0025, clamp(daylight * 1.2, 0, 1));
+  const mieDirectionalG = lerp(0.7, 0.88, clamp(daylight * 1.1, 0, 1));
+
+  const background = new THREE.Color();
+  if (daylight <= 0.0001) {
+    background.copy(NIGHT_COLOR);
+  } else {
+    const warmEdge = new THREE.Color().lerpColors(DAWN_COLOR, DUSK_COLOR, clamp(clamped * 2, 0, 1));
+    const blend = lerp(0, 1, clamp(daylight + duskBlend * 0.5, 0, 1));
+    background.lerpColors(NIGHT_COLOR, warmEdge, clamp(duskBlend, 0, 1));
+    background.lerp(DAY_COLOR, clamp(daylight, 0, 1));
+    background.lerp(DAY_COLOR, blend * 0.5);
+  }
+
+  return {
+    elevation,
+    azimuth,
+    turbidity,
+    rayleigh,
+    mieCoefficient,
+    mieDirectionalG,
+    background,
+  };
+}
+
+export function createProceduralSky(renderer: THREE.WebGLRenderer) {
+  const internalScene = new THREE.Scene();
+  const sky = new Sky();
+  sky.scale.setScalar(450000);
+  sky.frustumCulled = false;
+  internalScene.add(sky);
+
+  const sun = new THREE.Vector3();
+  const pmrem = new THREE.PMREMGenerator(renderer);
+  if (typeof pmrem.compileCubemapShader === 'function') {
+    try { pmrem.compileCubemapShader(); } catch {}
+  }
+  if (typeof pmrem.compileEquirectangularShader === 'function') {
+    try { pmrem.compileEquirectangularShader(); } catch {}
+  }
+
+  const uniforms = sky.material.uniforms;
+  const background = MODE_PRESETS.day.background.clone();
+
+  let disposed = false;
+  let lastMode: SkyTime = 'day';
+  let envTarget: THREE.WebGLRenderTarget | null = null;
+  let needsRebuild = true;
+  let lastPmremTime = -Infinity;
+
+  const applyPreset = (preset: {
+    elevation: number;
+    azimuth: number;
+    turbidity: number;
+    rayleigh: number;
+    mieCoefficient: number;
+    mieDirectionalG: number;
+    background: THREE.Color;
+  }) => {
+    if (!preset) return;
+    const theta = degToRad(90 - clamp(preset.elevation, -90, 90));
+    const phi = degToRad(((preset.azimuth % 360) + 360) % 360);
+
+    sun.setFromSphericalCoords(1, theta, phi);
+    uniforms.sunPosition.value.copy(sun);
+    uniforms.turbidity.value = preset.turbidity;
+    uniforms.rayleigh.value = preset.rayleigh;
+    uniforms.mieCoefficient.value = preset.mieCoefficient;
+    uniforms.mieDirectionalG.value = preset.mieDirectionalG;
+    background.copy(preset.background);
+    needsRebuild = true;
+  };
+
+  applyPreset(MODE_PRESETS.day);
+
+  const rebuildEnvironment = (now: number) => {
+    if (!needsRebuild && envTarget && now - lastPmremTime < MIN_PMREM_INTERVAL_MS) {
+      return;
+    }
+    if (now - lastPmremTime < MIN_PMREM_INTERVAL_MS && envTarget) {
+      return;
+    }
+    const previous = envTarget;
+    envTarget = pmrem.fromScene(internalScene);
+    lastPmremTime = now;
+    needsRebuild = false;
+    if (previous) {
+      disposeAll(previous.texture, previous);
+    }
+  };
+
+  return {
+    setMode(mode: SkyTime) {
+      if (disposed) return;
+      const next = MODE_PRESETS[mode] ?? MODE_PRESETS.day;
+      lastMode = mode;
+      applyPreset(next);
+    },
+    setTime(hours01: number) {
+      if (disposed) return;
+      const preset = buildTimePreset(hours01);
+      applyPreset(preset);
+    },
+    update(_dt: number) {},
+    async applyTo(scene: THREE.Scene) {
+      if (disposed) return;
+      const now = typeof performance !== 'undefined' && performance.now ? performance.now() : Date.now();
+      rebuildEnvironment(now);
+      if (!envTarget) {
+        // Ensure at least one environment texture exists
+        rebuildEnvironment(now + MIN_PMREM_INTERVAL_MS);
+      }
+      if (!envTarget) {
+        return;
+      }
+      scene.environment = envTarget.texture;
+      scene.background = background.clone();
+      if (typeof window !== 'undefined') {
+        const debug = (window as typeof window & { __athensDebug?: any }).__athensDebug;
+        if (debug && typeof debug === 'object') {
+          debug.proceduralSky = {
+            mode: lastMode,
+            turbidity: uniforms.turbidity.value,
+            rayleigh: uniforms.rayleigh.value,
+            mieCoefficient: uniforms.mieCoefficient.value,
+            mieDirectionalG: uniforms.mieDirectionalG.value,
+            sun: sun.clone(),
+          };
+        }
+      }
+    },
+    dispose() {
+      if (disposed) return;
+      disposed = true;
+      disposeAll(envTarget?.texture, envTarget);
+      envTarget = null;
+      pmrem.dispose();
+      disposeAll(sky.material, (sky as any).geometry);
+      internalScene.clear();
+    },
+  };
+}
+
+export const SKY_PROCEDURAL_BACKGROUNDS = SKY_BACKGROUND_COLORS;

--- a/src/scene/sky.ts
+++ b/src/scene/sky.ts
@@ -1,7 +1,9 @@
 import * as THREE from 'three';
+import { RGBELoader } from 'three/examples/jsm/loaders/RGBELoader.js';
 import { assetUrl } from '../utils/assetUrl.ts';
 import { logger } from '../utils/logger';
 import { disposeAll } from '../utils/disposable.ts';
+import { SKY_PROCEDURAL_BACKGROUNDS, type SkyTime } from './proceduralSky.ts';
 
 export type SkyChoice =
   | {
@@ -122,6 +124,11 @@ function setTextureColorSpace(tex: THREE.Texture | THREE.CubeTexture) {
     (THREE as any).SRGBColorSpace ?? (tex as any).colorSpace ?? (THREE as any).sRGBEncoding;
 }
 
+function setHdrColorSpace(tex: THREE.Texture) {
+  (tex as any).colorSpace =
+    (THREE as any).LinearSRGBColorSpace ?? (tex as any).colorSpace ?? (THREE as any).LinearEncoding;
+}
+
 function setRendererColorSpace(renderer: THREE.WebGLRenderer) {
   (renderer as any).outputColorSpace =
     (THREE as any).SRGBColorSpace ?? (renderer as any).outputColorSpace;
@@ -162,19 +169,45 @@ export async function applySky(
     return null;
   }
 
+  const preferHdrVariant = (choice: SkyChoice) => {
+    if (!choice || choice.type !== 'equirect') {
+      return choice;
+    }
+    const normalizedId = normalize(choice.id);
+    const hdrCandidate = SKY_CHOICES.find((candidate) => {
+      if (candidate === choice || candidate.type !== 'equirect') {
+        return false;
+      }
+      if (!candidate.file?.toLowerCase().endsWith('.hdr')) {
+        return false;
+      }
+      const candidateId = normalize(candidate.id);
+      if (candidateId === normalizedId) {
+        return true;
+      }
+      return candidate.aliases?.some((alias) => normalize(alias) === normalizedId) ?? false;
+    });
+    if (hdrCandidate) {
+      return hdrCandidate;
+    }
+    return choice;
+  };
+
+  const resolvedPick = preferHdrVariant(pick);
+
   let appliedId: string | null = null;
 
   try {
-    if (pick.type === 'cube' && pick.dir && pick.faces) {
+    if (resolvedPick.type === 'cube' && resolvedPick.dir && resolvedPick.faces) {
       const loader = new THREE.CubeTextureLoader();
       const order = [
-        pick.faces.px,
-        pick.faces.nx,
-        pick.faces.py,
-        pick.faces.ny,
-        pick.faces.pz,
-        pick.faces.nz
-      ].map((n) => resolveSkyPath(n, pick.dir));
+        resolvedPick.faces.px,
+        resolvedPick.faces.nx,
+        resolvedPick.faces.py,
+        resolvedPick.faces.ny,
+        resolvedPick.faces.pz,
+        resolvedPick.faces.nz
+      ].map((n) => resolveSkyPath(n, resolvedPick.dir));
 
       const tex = await new Promise<THREE.CubeTexture>((resolve, reject) =>
         loader.load(order, resolve, undefined, reject)
@@ -193,39 +226,87 @@ export async function applySky(
       if (typeof window !== 'undefined') {
         const debug = (window as typeof window & { __athensDebug?: any }).__athensDebug;
         if (debug && typeof debug === 'object') {
-          debug.sky = { type: 'cube', id: pick.id, files: order };
+          debug.sky = { type: 'cube', id: resolvedPick.id, files: order };
         }
       }
-      appliedId = pick.id;
-    } else if (pick.type === 'equirect' && pick.file) {
-      const loader = new THREE.TextureLoader();
-      const url = resolveSkyPath(pick.file);
+      appliedId = resolvedPick.id;
+    } else if (resolvedPick.type === 'equirect' && resolvedPick.file) {
+      const url = resolveSkyPath(resolvedPick.file);
+      const lowerUrl = url.toLowerCase();
+      const isHdr = lowerUrl.endsWith('.hdr');
 
-      const tex = await new Promise<THREE.Texture>((resolve, reject) =>
-        loader.load(url, resolve, undefined, reject)
-      );
-
-      tex.mapping = THREE.EquirectangularReflectionMapping;
-      setTextureColorSpace(tex);
-
-      scene.background = tex;
-      disposeExistingEnvironment(scene);
-
-      const pmrem = new THREE.PMREMGenerator(renderer);
-      const env = pmrem.fromEquirectangular(tex).texture;
-      scene.environment = env;
-      pmrem.dispose();
-
-      if (typeof window !== 'undefined') {
-        const debug = (window as typeof window & { __athensDebug?: any }).__athensDebug;
-        if (debug && typeof debug === 'object') {
-          debug.sky = { type: 'equirect', id: pick.id, file: url };
+      if (isHdr) {
+        const loader = new RGBELoader();
+        const dataType = (THREE as any).HalfFloatType ?? (THREE as any).FloatType;
+        if (typeof loader.setDataType === 'function' && dataType) {
+          loader.setDataType(dataType);
         }
+
+        const tex = await new Promise<THREE.Texture>((resolve, reject) =>
+          loader.load(url, resolve, undefined, reject)
+        );
+
+        tex.mapping = THREE.EquirectangularReflectionMapping;
+        setHdrColorSpace(tex);
+
+        disposeExistingEnvironment(scene);
+
+        const pmrem = new THREE.PMREMGenerator(renderer);
+        const env = pmrem.fromEquirectangular(tex).texture;
+        pmrem.dispose();
+
+        tex.dispose();
+
+        scene.environment = env;
+
+        const normalizedId = normalize(resolvedPick.id);
+        const fallbackKey: SkyTime =
+          normalizedId === 'dawn'
+            ? 'dawn'
+            : normalizedId === 'dusk'
+            ? 'dusk'
+            : normalizedId === 'night'
+            ? 'night'
+            : 'day';
+        const fallbackColor = SKY_PROCEDURAL_BACKGROUNDS[fallbackKey];
+        scene.background = new THREE.Color(fallbackColor);
+
+        if (typeof window !== 'undefined') {
+          const debug = (window as typeof window & { __athensDebug?: any }).__athensDebug;
+          if (debug && typeof debug === 'object') {
+            debug.sky = { type: 'hdr', id: resolvedPick.id, file: url };
+          }
+        }
+        appliedId = resolvedPick.id;
+      } else {
+        const loader = new THREE.TextureLoader();
+
+        const tex = await new Promise<THREE.Texture>((resolve, reject) =>
+          loader.load(url, resolve, undefined, reject)
+        );
+
+        tex.mapping = THREE.EquirectangularReflectionMapping;
+        setTextureColorSpace(tex);
+
+        scene.background = tex;
+        disposeExistingEnvironment(scene);
+
+        const pmrem = new THREE.PMREMGenerator(renderer);
+        const env = pmrem.fromEquirectangular(tex).texture;
+        scene.environment = env;
+        pmrem.dispose();
+
+        if (typeof window !== 'undefined') {
+          const debug = (window as typeof window & { __athensDebug?: any }).__athensDebug;
+          if (debug && typeof debug === 'object') {
+            debug.sky = { type: 'equirect', id: resolvedPick.id, file: url };
+          }
+        }
+        appliedId = resolvedPick.id;
       }
-      appliedId = pick.id;
     } else {
       logger.warn(
-        `[sky] Choice "${pick.id}" is missing required properties for type "${pick.type}".`
+        `[sky] Choice "${resolvedPick.id}" is missing required properties for type "${resolvedPick.type}".`
       );
       return null;
     }


### PR DESCRIPTION
## Summary
- add a procedural sky controller that builds PMREM environments without a new render loop
- hook the environment core into the procedural sky, prefer HDR assets, and keep LDR fallback behaviour
- extend boot smoke tests to cover the procedural pathway and disposal handling

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68dd3129b0f083278639fa106f520dcc