### PR TITLE
Align walking input with hotkey config

### DIFF
--- a/src/controls/__tests__/input.test.ts
+++ b/src/controls/__tests__/input.test.ts
@@ -3,7 +3,7 @@ import test from 'node:test';
 
 import getInput, { __inputTest } from '../input.ts';
 
-test('input adapter maps WASD keys to movement axes', () => {
+test('input adapter maps movement hotkeys to axes', () => {
   __inputTest.reset();
 
   __inputTest.press('KeyW');
@@ -23,19 +23,16 @@ test('input adapter maps WASD keys to movement axes', () => {
   assert.strictEqual(input.right, 0);
 });
 
-test('input adapter respects arrow keys and sprint/jump modifiers', () => {
+test('input adapter ignores look hotkeys for walking movement', () => {
   __inputTest.reset();
 
   __inputTest.press('ArrowDown');
   __inputTest.press('ArrowRight');
-  __inputTest.press('Space');
-  __inputTest.press('ShiftLeft');
-
   const input = getInput();
-  assert.strictEqual(input.forward, -1);
-  assert.strictEqual(input.right, 1);
-  assert.strictEqual(input.jump, true);
-  assert.strictEqual(input.sprint, true);
+  assert.strictEqual(input.forward, 0);
+  assert.strictEqual(input.right, 0);
+  assert.strictEqual(input.jump, false);
+  assert.strictEqual(input.sprint, false);
 
   __inputTest.reset();
   const reset = getInput();
@@ -43,4 +40,21 @@ test('input adapter respects arrow keys and sprint/jump modifiers', () => {
   assert.strictEqual(reset.right, 0);
   assert.strictEqual(reset.jump, false);
   assert.strictEqual(reset.sprint, false);
+});
+
+test('input adapter respects configured sprint and jump aliases', () => {
+  __inputTest.reset();
+
+  __inputTest.press('KeyE');
+  __inputTest.press('ShiftRight');
+
+  const input = getInput();
+  assert.strictEqual(input.jump, true);
+  assert.strictEqual(input.sprint, true);
+
+  __inputTest.release('KeyE');
+  __inputTest.release('ShiftRight');
+  const cleared = getInput();
+  assert.strictEqual(cleared.jump, false);
+  assert.strictEqual(cleared.sprint, false);
 });

--- a/src/controls/input.ts
+++ b/src/controls/input.ts
@@ -1,33 +1,33 @@
+import {
+  HOTKEY_IDS,
+  KEY_FALLBACK_MAP,
+  RELEVANT_KEYS,
+  getActionCodes
+} from '../config/hotkeys.ts';
+
 import type { CharacterInput } from './CharacterController.ts';
 
 type KeyboardEventLike = { code?: string; key?: string; repeat?: boolean };
 
 const activeKeys = new Set<string>();
 
-const POSITIVE_FORWARD = new Set(['KeyW', 'ArrowUp']);
-const NEGATIVE_FORWARD = new Set(['KeyS', 'ArrowDown']);
-const POSITIVE_RIGHT = new Set(['KeyD', 'ArrowRight']);
-const NEGATIVE_RIGHT = new Set(['KeyA', 'ArrowLeft']);
-const JUMP_KEYS = new Set(['Space']);
-const SPRINT_KEYS = new Set(['ShiftLeft', 'ShiftRight']);
+const POSITIVE_FORWARD = createActionCodeSet(HOTKEY_IDS.movement.forward);
+const NEGATIVE_FORWARD = createActionCodeSet(HOTKEY_IDS.movement.backward);
+const POSITIVE_RIGHT = createActionCodeSet(HOTKEY_IDS.movement.right);
+const NEGATIVE_RIGHT = createActionCodeSet(HOTKEY_IDS.movement.left);
+const JUMP_KEYS = createActionCodeSet(HOTKEY_IDS.flight.ascend);
+const SPRINT_KEYS = createActionCodeSet(HOTKEY_IDS.movement.run);
+const RELEVANT_KEY_SET: Set<string> | undefined =
+  RELEVANT_KEYS && typeof RELEVANT_KEYS.has === 'function' ? RELEVANT_KEYS : undefined;
 
-const KEY_ALIAS: Record<string, string> = {
-  w: 'KeyW',
-  W: 'KeyW',
-  s: 'KeyS',
-  S: 'KeyS',
-  a: 'KeyA',
-  A: 'KeyA',
-  d: 'KeyD',
-  D: 'KeyD',
-  ArrowUp: 'ArrowUp',
-  ArrowDown: 'ArrowDown',
-  ArrowLeft: 'ArrowLeft',
-  ArrowRight: 'ArrowRight',
-  ' ': 'Space',
-  Space: 'Space',
-  Shift: 'ShiftLeft'
-};
+function createActionCodeSet(actionId: string | undefined): Set<string> {
+  if (!actionId) {
+    return new Set();
+  }
+
+  const codes = getActionCodes(actionId);
+  return new Set(codes);
+}
 
 let listenersAttached = false;
 
@@ -38,15 +38,32 @@ function normalizeCode(event: KeyboardEventLike): string {
 
   const code = event.code;
   if (typeof code === 'string' && code && code !== 'Unidentified') {
-    return code;
+    return isRelevant(code) ? code : '';
   }
 
   const key = event.key;
   if (typeof key === 'string' && key) {
-    return KEY_ALIAS[key] || KEY_ALIAS[key.toUpperCase()] || '';
+    const fallbackKey = key.toLowerCase();
+    const fallbackCode = KEY_FALLBACK_MAP.get(fallbackKey);
+
+    if (fallbackCode && isRelevant(fallbackCode)) {
+      return fallbackCode;
+    }
   }
 
   return '';
+}
+
+function isRelevant(code: string): boolean {
+  if (!code) {
+    return false;
+  }
+
+  if (RELEVANT_KEY_SET) {
+    return RELEVANT_KEY_SET.has(code);
+  }
+
+  return true;
 }
 
 function setKeyState(code: string, isDown: boolean) {


### PR DESCRIPTION
## Summary
- derive walking movement, sprint, and jump bindings from the centralized hotkey manifest
- normalize keyboard events using the shared fallback map so alternate layouts resolve correctly
- update walking input tests to cover configured movement, look, and modifier bindings

## Testing
- `npm test -- src/controls/__tests__/input.test.ts`


------
https://chatgpt.com/codex/tasks/task_b_68dd8059d504832784c5dfbd87766a16