### PR TITLE
Ensure consistent keyboard movement and look controls

### DIFF
--- a/src/config/hotkeys.ts
+++ b/src/config/hotkeys.ts
@@ -108,25 +108,23 @@ const movementActions = {
     id: 'movement.moveForward',
     title: 'Move Forward',
     default: 'KeyW',
-    fallback: ['w', 'z']
+    fallback: ['z']
   }),
   moveBackward: createAction(HotkeyCategoryId.Movement, {
     id: 'movement.moveBackward',
     title: 'Move Backward',
-    default: 'KeyS',
-    fallback: ['s']
+    default: 'KeyS'
   }),
   moveLeft: createAction(HotkeyCategoryId.Movement, {
     id: 'movement.moveLeft',
     title: 'Move Left',
     default: 'KeyA',
-    fallback: ['a', 'q']
+    fallback: ['q']
   }),
   moveRight: createAction(HotkeyCategoryId.Movement, {
     id: 'movement.moveRight',
     title: 'Move Right',
-    default: 'KeyD',
-    fallback: ['d']
+    default: 'KeyD'
   }),
   run: createAction(HotkeyCategoryId.Movement, {
     id: 'movement.run',
@@ -525,6 +523,24 @@ for (const def of actionRegistry.values()) {
   for (const code of def.codes) {
     relevantKeys.add(code);
   }
+}
+
+const CORE_RELEVANT_CODES = [
+  'KeyW',
+  'KeyA',
+  'KeyS',
+  'KeyD',
+  'ArrowLeft',
+  'ArrowRight',
+  'ArrowUp',
+  'ArrowDown',
+  'ShiftLeft',
+  'ShiftRight',
+  'Space'
+];
+
+for (const code of CORE_RELEVANT_CODES) {
+  relevantKeys.add(code);
 }
 
 export const RELEVANT_KEYS = relevantKeys;

--- a/src/entry/initializeAthens.js
+++ b/src/entry/initializeAthens.js
@@ -34,19 +34,6 @@ import { createNavMeshPathfinder } from '../navmesh/pathfinder.js';
 import { loadWorldWithColliders } from '../physics/collisionWorld.ts';
 import { CharacterController } from '../controls/CharacterController.ts';
 import { getInput } from '../controls/input.ts';
-
-const __hotkeyHealthcheckEnabled =
-  typeof process === 'undefined' || process?.env?.NODE_ENV !== 'production';
-
-if (__hotkeyHealthcheckEnabled) {
-  try {
-    const sampleKeys = Array.from(RELEVANT_KEYS).slice(0, 10);
-    console.log('[Hotkeys] sample:', sampleKeys);
-    console.log('[Hotkeys] forward action codes:', HOTKEY_IDS?.movement?.forward);
-  } catch (error) {
-    console.warn('[Hotkeys] Failed to log hotkey healthcheck.', error);
-  }
-}
 import {
   LANDMARK_ALIASES,
   KNOWN_LANDMARK_KEYS,
@@ -72,6 +59,10 @@ import { installSkyDev } from '../dev/skyDebugHooks.js';
 import { setExternalGroundTexture } from '../materials/groundGrass.js';
 // SKYSYS_END
 import { withTimeout as withBootTimeout } from '../boot/withTimeout.ts';
+
+if (typeof process === 'undefined' || process?.env?.NODE_ENV !== 'production') {
+  console.log('[hotkeys] sample:', [...RELEVANT_KEYS].slice(0, 8));
+}
 
 // CHAR_MAIN_HEIGHT_START
 // Height scaling for the main character is no longer required.

--- a/src/input/keyboard.js
+++ b/src/input/keyboard.js
@@ -7,16 +7,60 @@ import {
 
 const INV_SQRT2 = 1 / Math.sqrt(2);
 
-const pairedAxisBindings = new Map();
-let runningBinding = null;
+const DEV_FALLBACK_CODES = [
+  'KeyW',
+  'KeyA',
+  'KeyS',
+  'KeyD',
+  'ArrowLeft',
+  'ArrowRight',
+  'ArrowUp',
+  'ArrowDown',
+  'ShiftLeft',
+  'ShiftRight',
+  'Space'
+];
+
+const axisCodeBindings = new Map();
+const runningActionCodes = new Set();
 let hasWarnedForRelevantKeyFallback = false;
+
+const createCodeSet = (actionId) => {
+  const set = new Set();
+  if (!actionId) {
+    return set;
+  }
+  const codes = getActionCodes(actionId);
+  if (!Array.isArray(codes)) {
+    return set;
+  }
+  for (const code of codes) {
+    if (typeof code === 'string' && code) {
+      set.add(code);
+    }
+  }
+  return set;
+};
 
 for (const binding of HOTKEY_AXIS_METADATA) {
   if (!binding) continue;
   if (binding.type === 'paired') {
-    pairedAxisBindings.set(binding.axis, binding);
+    axisCodeBindings.set(binding.axis, {
+      positive: createCodeSet(binding.positive),
+      negative: createCodeSet(binding.negative)
+    });
   } else if (binding.type === 'binary' && binding.axis === 'running') {
-    runningBinding = binding;
+    for (const actionId of binding.actions ?? []) {
+      const codes = getActionCodes(actionId);
+      if (!Array.isArray(codes)) {
+        continue;
+      }
+      for (const code of codes) {
+        if (typeof code === 'string' && code) {
+          runningActionCodes.add(code);
+        }
+      }
+    }
   }
 }
 
@@ -66,27 +110,51 @@ export function createKeyboard(target = typeof window !== 'undefined' ? window :
     typeof process === 'undefined' || process?.env?.NODE_ENV !== 'production';
 
   let activeRelevantKeys = RELEVANT_KEYS;
-  if (!RELEVANT_KEYS.size && isDevEnvironment) {
-    activeRelevantKeys = new Set([
-      'KeyW',
-      'KeyA',
-      'KeyS',
-      'KeyD',
-      'ArrowLeft',
-      'ArrowRight',
-      'ArrowUp',
-      'ArrowDown',
-      'ShiftLeft',
-      'ShiftRight',
-      'Space'
-    ]);
+  if (!(activeRelevantKeys instanceof Set)) {
+    activeRelevantKeys = new Set(activeRelevantKeys ? [...activeRelevantKeys] : []);
+  }
+  if ((!activeRelevantKeys || activeRelevantKeys.size === 0) && isDevEnvironment) {
+    activeRelevantKeys = new Set(DEV_FALLBACK_CODES);
     if (!hasWarnedForRelevantKeyFallback) {
-      console.warn('[Hotkeys] Falling back to default relevant key allowlist.');
+      console.warn('[hotkeys] empty RELEVANT_KEYS; enabling dev fallback');
       hasWarnedForRelevantKeyFallback = true;
     }
   }
 
   const resolveActionCodes = (actionId) => getActionCodes(actionId);
+
+  const shouldPreventDefault = (event, normalizedCode) => {
+    if (!normalizedCode || !PREVENT_DEFAULT_CODES.has(normalizedCode)) {
+      return false;
+    }
+    if (!event) {
+      return false;
+    }
+    if (!target || target === window) {
+      return true;
+    }
+    const eventTarget = event.target;
+    if (eventTarget) {
+      if (eventTarget === target) {
+        return true;
+      }
+      if (typeof target.contains === 'function' && target.contains(eventTarget)) {
+        return true;
+      }
+    }
+    if (typeof document !== 'undefined') {
+      const activeElement = document.activeElement;
+      if (activeElement) {
+        if (activeElement === target) {
+          return true;
+        }
+        if (typeof target.contains === 'function' && target.contains(activeElement)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  };
 
   const getActionState = (actionId) => {
     const codes = resolveActionCodes(actionId);
@@ -122,20 +190,32 @@ export function createKeyboard(target = typeof window !== 'undefined' ? window :
     return false;
   };
 
-  const updateAxisFromBinding = (axisId) => {
-    const binding = pairedAxisBindings.get(axisId);
+  const hasAnyPressed = (codes) => {
+    if (!codes || typeof codes.size !== 'number' || codes.size === 0) {
+      return false;
+    }
+    for (const code of codes) {
+      if (pressed.has(code)) {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  const axisValueFromCodes = (axisId) => {
+    const binding = axisCodeBindings.get(axisId);
     if (!binding) {
       return 0;
     }
-    const positive = isActionDown(binding.positive) ? 1 : 0;
-    const negative = isActionDown(binding.negative) ? 1 : 0;
+    const positive = hasAnyPressed(binding.positive) ? 1 : 0;
+    const negative = hasAnyPressed(binding.negative) ? 1 : 0;
     return positive - negative;
   };
 
   const handleKeyDown = (event) => {
     const code = normalizeCode(event);
 
-    if (code && PREVENT_DEFAULT_CODES.has(code)) {
+    if (shouldPreventDefault(event, code)) {
       if (typeof event.preventDefault === 'function') {
         event.preventDefault();
       }
@@ -147,11 +227,13 @@ export function createKeyboard(target = typeof window !== 'undefined' ? window :
     if (!code || !activeRelevantKeys.has(code)) {
       return;
     }
+
     if (!pressed.has(code)) {
       justPressed.add(code);
+      pressed.add(code);
+      updateState();
+      return;
     }
-    pressed.add(code);
-    updateState();
   };
 
   const handleKeyUp = (event) => {
@@ -160,8 +242,9 @@ export function createKeyboard(target = typeof window !== 'undefined' ? window :
     if (!code || !activeRelevantKeys.has(code)) {
       return;
     }
-    pressed.delete(code);
-    updateState();
+    if (pressed.delete(code)) {
+      updateState();
+    }
   };
 
   if (target && target.addEventListener) {
@@ -174,8 +257,8 @@ export function createKeyboard(target = typeof window !== 'undefined' ? window :
   const isDown = (code) => pressed.has(code);
 
   const updateState = () => {
-    axisState.x = updateAxisFromBinding('x');
-    axisState.z = updateAxisFromBinding('z');
+    axisState.x = axisValueFromCodes('x');
+    axisState.z = axisValueFromCodes('z');
 
     const combinedMagnitude = Math.abs(axisState.x) + Math.abs(axisState.z);
     if (combinedMagnitude > 1) {
@@ -185,12 +268,10 @@ export function createKeyboard(target = typeof window !== 'undefined' ? window :
 
     axisState.turn = 0;
 
-    axisState.lookX = updateAxisFromBinding('lookX');
-    axisState.lookY = updateAxisFromBinding('lookY');
+    axisState.lookX = axisValueFromCodes('lookX');
+    axisState.lookY = axisValueFromCodes('lookY');
 
-    axisState.running = Boolean(
-      runningBinding?.actions?.some((actionId) => isActionDown(actionId))
-    );
+    axisState.running = hasAnyPressed(runningActionCodes);
 
     lookState.x = axisState.lookX;
     lookState.y = axisState.lookY;

--- a/tests/keyboard-controls.test.js
+++ b/tests/keyboard-controls.test.js
@@ -11,6 +11,7 @@ const createMockTarget = () => {
 
   return {
     listeners,
+    tagName: 'CANVAS',
     addEventListener(type, handler) {
       listeners.set(type, handler);
     },
@@ -18,133 +19,128 @@ const createMockTarget = () => {
       if (listeners.get(type) === handler) {
         listeners.delete(type);
       }
+    },
+    contains(node) {
+      return node === this;
     }
   };
 };
 
-test('keyboard respects event.code when provided', () => {
+const focusEvent = (target, event) => ({ target, ...event });
+
+test('WASD movement updates axes and shift enables running', () => {
   const target = createMockTarget();
   const keyboard = createKeyboard(target);
   const keydown = target.listeners.get('keydown');
   const keyup = target.listeners.get('keyup');
 
-  keydown({ code: 'KeyW', key: 'w' });
+  keydown(focusEvent(target, { code: 'KeyW', key: 'w' }));
   assert.strictEqual(keyboard.isDown('KeyW'), true);
   assert.strictEqual(keyboard.isActionDown(HOTKEY_IDS.movement.forward), true);
-  assert.strictEqual(keyboard.getActionState(HOTKEY_IDS.movement.forward).isDown, true);
   assert.strictEqual(keyboard.axis.z, 1);
 
-  keyup({ code: 'KeyW', key: 'w' });
-  assert.strictEqual(keyboard.isDown('KeyW'), false);
-  assert.strictEqual(keyboard.isActionDown(HOTKEY_IDS.movement.forward), false);
-  assert.strictEqual(keyboard.axis.z, 0);
+  keydown(focusEvent(target, { code: 'KeyA', key: 'a' }));
+  assert.strictEqual(keyboard.axis.x, -1);
+  assert.strictEqual(keyboard.isActionDown(HOTKEY_IDS.movement.left), true);
 
-  keyboard.dispose();
-});
-
-test('keyboard normalizes events without code to maintain controls', () => {
-  const target = createMockTarget();
-  const keyboard = createKeyboard(target);
-  const keydown = target.listeners.get('keydown');
-  const keyup = target.listeners.get('keyup');
-
-  keydown({ key: 'w', code: '' });
-  assert.strictEqual(keyboard.isDown('KeyW'), true);
-  assert.strictEqual(keyboard.isActionDown(HOTKEY_IDS.movement.forward), true);
-  assert.strictEqual(keyboard.getActionState(HOTKEY_IDS.movement.forward).isDown, true);
-  assert.strictEqual(keyboard.axis.z, 1);
-
-  keydown({ key: 'Shift', code: 'Unidentified' });
+  keydown(
+    focusEvent(target, {
+      code: 'Unidentified',
+      key: 'Shift'
+    })
+  );
   assert.strictEqual(keyboard.axis.running, true);
   assert.strictEqual(keyboard.isActionDown(HOTKEY_IDS.movement.run), true);
 
-  keydown({ key: 'ArrowLeft', code: 'Unidentified' });
-  assert.strictEqual(keyboard.isDown('ArrowLeft'), true);
-  assert.strictEqual(keyboard.getActionState(HOTKEY_IDS.look.left).isDown, true);
-  assert.strictEqual(keyboard.look.x, -1);
-  assert.strictEqual(keyboard.axis.lookX, -1);
-
-  keyup({ key: 'ArrowLeft', code: '' });
-
-  keydown({ key: 'ArrowRight', code: undefined });
-  assert.strictEqual(keyboard.axis.lookX, 1);
-  assert.strictEqual(keyboard.look.x, 1);
-
-  keyup({ key: 'ArrowRight', code: '' });
-
-  keydown({ key: 'ArrowUp', code: undefined });
-  assert.strictEqual(keyboard.look.y, 1);
-  assert.strictEqual(keyboard.axis.lookY, 1);
-
-  keyup({ key: 'ArrowUp', code: '' });
-
-  keydown({ key: 'ArrowDown', code: undefined });
-  assert.strictEqual(keyboard.look.y, -1);
-  assert.strictEqual(keyboard.axis.lookY, -1);
-
-  keyup({ key: 'ArrowRight', code: '' });
-  keyup({ key: 'ArrowDown', code: '' });
-  keyup({ key: 'Shift', code: '' });
-  keyup({ key: 'w', code: '' });
-
-  assert.strictEqual(keyboard.isDown('KeyW'), false);
-  assert.strictEqual(keyboard.isActionDown(HOTKEY_IDS.movement.forward), false);
-  assert.strictEqual(keyboard.axis.z, 0);
+  keyup(focusEvent(target, { code: 'Unidentified', key: 'Shift' }));
   assert.strictEqual(keyboard.axis.running, false);
-  assert.strictEqual(keyboard.look.x, 0);
-  assert.strictEqual(keyboard.look.y, 0);
-  assert.strictEqual(keyboard.axis.lookX, 0);
-  assert.strictEqual(keyboard.axis.lookY, 0);
+
+  keyup(focusEvent(target, { code: 'KeyA', key: 'a' }));
+  assert.strictEqual(keyboard.axis.x, 0);
+
+  keyup(focusEvent(target, { code: 'KeyW', key: 'w' }));
+  assert.strictEqual(keyboard.axis.z, 0);
 
   keyboard.dispose();
 });
 
-test('keyboard maps azerty movement aliases without triggering descend', () => {
+test('Azerty fallbacks map to WASD movement', () => {
   const target = createMockTarget();
   const keyboard = createKeyboard(target);
   const keydown = target.listeners.get('keydown');
   const keyup = target.listeners.get('keyup');
 
-  keydown({ key: 'z' });
+  keydown(focusEvent(target, { key: 'z' }));
   assert.strictEqual(keyboard.isDown('KeyW'), true);
-  assert.strictEqual(keyboard.isActionDown(HOTKEY_IDS.movement.forward), true);
   assert.strictEqual(keyboard.axis.z, 1);
 
-  keyup({ key: 'z' });
+  keyup(focusEvent(target, { key: 'z' }));
   assert.strictEqual(keyboard.axis.z, 0);
 
-  keydown({ key: 'q' });
+  keydown(focusEvent(target, { key: 'q' }));
   assert.strictEqual(keyboard.isDown('KeyA'), true);
-  assert.strictEqual(keyboard.isActionDown(HOTKEY_IDS.movement.left), true);
   assert.strictEqual(keyboard.axis.x, -1);
-  assert.strictEqual(keyboard.isDown('KeyQ'), false);
 
-  keyup({ key: 'q' });
-
+  keyup(focusEvent(target, { key: 'q' }));
   assert.strictEqual(keyboard.axis.x, 0);
 
   keyboard.dispose();
 });
 
-test('keyboard normalizes diagonal movement speed', () => {
+test('Diagonal movement normalizes to unit speed', () => {
   const target = createMockTarget();
   const keyboard = createKeyboard(target);
   const keydown = target.listeners.get('keydown');
   const keyup = target.listeners.get('keyup');
 
-  keydown({ code: 'KeyW', key: 'w' });
-  keydown({ code: 'KeyD', key: 'd' });
+  keydown(focusEvent(target, { code: 'KeyW', key: 'w' }));
+  keydown(focusEvent(target, { code: 'KeyD', key: 'd' }));
 
   assert.ok(Math.abs(keyboard.axis.z - Math.SQRT1_2) < EPSILON);
   assert.ok(Math.abs(keyboard.axis.x - Math.SQRT1_2) < EPSILON);
 
-  keyup({ code: 'KeyW', key: 'w' });
-  keyup({ code: 'KeyD', key: 'd' });
+  keyup(focusEvent(target, { code: 'KeyD', key: 'd' }));
+  keyup(focusEvent(target, { code: 'KeyW', key: 'w' }));
 
   keyboard.dispose();
 });
 
-test('keyboard prevents default browser actions for space and arrow keys', () => {
+test('Arrow keys drive look axes', () => {
+  const target = createMockTarget();
+  const keyboard = createKeyboard(target);
+  const keydown = target.listeners.get('keydown');
+  const keyup = target.listeners.get('keyup');
+
+  keydown(focusEvent(target, { key: 'ArrowLeft', code: 'Unidentified' }));
+  assert.strictEqual(keyboard.axis.lookX, -1);
+  assert.strictEqual(keyboard.look.x, -1);
+
+  keyup(focusEvent(target, { key: 'ArrowLeft', code: 'Unidentified' }));
+  assert.strictEqual(keyboard.axis.lookX, 0);
+
+  keydown(focusEvent(target, { key: 'ArrowRight', code: 'ArrowRight' }));
+  assert.strictEqual(keyboard.axis.lookX, 1);
+
+  keyup(focusEvent(target, { key: 'ArrowRight', code: 'ArrowRight' }));
+  assert.strictEqual(keyboard.axis.lookX, 0);
+
+  keydown(focusEvent(target, { key: 'ArrowUp', code: 'ArrowUp' }));
+  assert.strictEqual(keyboard.axis.lookY, 1);
+  assert.strictEqual(keyboard.look.y, 1);
+
+  keyup(focusEvent(target, { key: 'ArrowUp', code: 'ArrowUp' }));
+  assert.strictEqual(keyboard.axis.lookY, 0);
+
+  keydown(focusEvent(target, { key: 'ArrowDown', code: 'ArrowDown' }));
+  assert.strictEqual(keyboard.axis.lookY, -1);
+
+  keyup(focusEvent(target, { key: 'ArrowDown', code: 'ArrowDown' }));
+  assert.strictEqual(keyboard.axis.lookY, 0);
+
+  keyboard.dispose();
+});
+
+test('Space and arrow keys prevent default when canvas is focused', () => {
   const target = createMockTarget();
   const keyboard = createKeyboard(target);
   const keydown = target.listeners.get('keydown');
@@ -152,37 +148,41 @@ test('keyboard prevents default browser actions for space and arrow keys', () =>
 
   let spacePrevented = 0;
   let spaceStopped = 0;
-  keydown({
-    code: 'Space',
-    key: ' ',
-    preventDefault() {
-      spacePrevented += 1;
-    },
-    stopPropagation() {
-      spaceStopped += 1;
-    }
-  });
+  keydown(
+    focusEvent(target, {
+      code: 'Space',
+      key: ' ',
+      preventDefault() {
+        spacePrevented += 1;
+      },
+      stopPropagation() {
+        spaceStopped += 1;
+      }
+    })
+  );
   assert.strictEqual(spacePrevented, 1);
   assert.strictEqual(spaceStopped, 1);
 
-  keyup({ code: 'Space', key: ' ' });
+  keyup(focusEvent(target, { code: 'Space', key: ' ' }));
 
   let arrowPrevented = 0;
   let arrowStopped = 0;
-  keydown({
-    code: 'ArrowDown',
-    key: 'ArrowDown',
-    preventDefault() {
-      arrowPrevented += 1;
-    },
-    stopPropagation() {
-      arrowStopped += 1;
-    }
-  });
+  keydown(
+    focusEvent(target, {
+      code: 'ArrowUp',
+      key: 'ArrowUp',
+      preventDefault() {
+        arrowPrevented += 1;
+      },
+      stopPropagation() {
+        arrowStopped += 1;
+      }
+    })
+  );
   assert.strictEqual(arrowPrevented, 1);
   assert.strictEqual(arrowStopped, 1);
 
-  keyup({ code: 'ArrowDown', key: 'ArrowDown' });
+  keyup(focusEvent(target, { code: 'ArrowUp', key: 'ArrowUp' }));
 
   keyboard.dispose();
 });


### PR DESCRIPTION
## Summary
- lock movement to WASD with AZERTY fallbacks and arrows for camera look while ensuring the relevant key set always includes the core controls
- rebuild the keyboard adapter to normalize event codes, recompute axes (including look and run), and add a guarded dev fallback plus preventDefault handling when focused
- log a hotkey sample during dev startup and expand hotkey tests to cover movement, AZERTY, diagonal normalization, look axes, and preventDefault behavior

## Testing
- npm test *(fails: npm: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_b_68ddaa1e70748327b1dc27c7bac6ca41