### PR TITLE
Refresh movement hotkeys from manifest overrides

### DIFF
--- a/src/controls/__tests__/input.test.ts
+++ b/src/controls/__tests__/input.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import getInput, { __inputTest } from '../input.ts';
+import { ACTION_CODES, HOTKEY_IDS } from '../../config/hotkeys.ts';
 
 test('input adapter maps movement hotkeys to axes', () => {
   __inputTest.reset();
@@ -57,4 +58,31 @@ test('input adapter respects configured sprint and jump aliases', () => {
   const cleared = getInput();
   assert.strictEqual(cleared.jump, false);
   assert.strictEqual(cleared.sprint, false);
+});
+
+test('input adapter reflects manifest overrides for movement actions', () => {
+  __inputTest.reset();
+
+  const forwardAction = HOTKEY_IDS.movement.forward;
+  const originalCodes = ACTION_CODES.get(forwardAction);
+
+  try {
+    ACTION_CODES.set(forwardAction, ['KeyI']);
+
+    __inputTest.press('KeyI');
+    let input = getInput();
+    assert.strictEqual(input.forward, 1);
+
+    __inputTest.release('KeyI');
+    __inputTest.press('KeyW');
+    input = getInput();
+    assert.strictEqual(input.forward, 0);
+  } finally {
+    if (originalCodes) {
+      ACTION_CODES.set(forwardAction, originalCodes);
+    } else {
+      ACTION_CODES.delete(forwardAction);
+    }
+    __inputTest.reset();
+  }
 });

--- a/src/controls/input.ts
+++ b/src/controls/input.ts
@@ -11,22 +11,63 @@ type KeyboardEventLike = { code?: string; key?: string; repeat?: boolean };
 
 const activeKeys = new Set<string>();
 
-const POSITIVE_FORWARD = createActionCodeSet(HOTKEY_IDS.movement.forward);
-const NEGATIVE_FORWARD = createActionCodeSet(HOTKEY_IDS.movement.backward);
-const POSITIVE_RIGHT = createActionCodeSet(HOTKEY_IDS.movement.right);
-const NEGATIVE_RIGHT = createActionCodeSet(HOTKEY_IDS.movement.left);
-const JUMP_KEYS = createActionCodeSet(HOTKEY_IDS.flight.ascend);
-const SPRINT_KEYS = createActionCodeSet(HOTKEY_IDS.movement.run);
+type MovementActionCodes = {
+  forwardPositive: readonly string[];
+  forwardNegative: readonly string[];
+  rightPositive: readonly string[];
+  rightNegative: readonly string[];
+  jump: readonly string[];
+  sprint: readonly string[];
+};
+
 const RELEVANT_KEY_SET: Set<string> | undefined =
   RELEVANT_KEYS && typeof RELEVANT_KEYS.has === 'function' ? RELEVANT_KEYS : undefined;
 
-function createActionCodeSet(actionId: string | undefined): Set<string> {
+const dynamicRelevantCodes = new Set<string>();
+
+function resolveActionCodes(actionId: string | undefined): string[] {
   if (!actionId) {
-    return new Set();
+    return [];
   }
 
   const codes = getActionCodes(actionId);
-  return new Set(codes);
+  const resolved: string[] = [];
+  if (Array.isArray(codes)) {
+    for (const code of codes) {
+      if (typeof code === 'string' && code) {
+        resolved.push(code);
+      }
+    }
+  }
+
+  return resolved;
+}
+
+function updateDynamicRelevance(codes: MovementActionCodes) {
+  if (!RELEVANT_KEY_SET) {
+    return;
+  }
+
+  dynamicRelevantCodes.clear();
+  for (const group of Object.values(codes)) {
+    for (const code of group) {
+      dynamicRelevantCodes.add(code);
+    }
+  }
+}
+
+function refreshMovementCodes(): MovementActionCodes {
+  const codes: MovementActionCodes = {
+    forwardPositive: resolveActionCodes(HOTKEY_IDS.movement.forward),
+    forwardNegative: resolveActionCodes(HOTKEY_IDS.movement.backward),
+    rightPositive: resolveActionCodes(HOTKEY_IDS.movement.right),
+    rightNegative: resolveActionCodes(HOTKEY_IDS.movement.left),
+    jump: resolveActionCodes(HOTKEY_IDS.flight.ascend),
+    sprint: resolveActionCodes(HOTKEY_IDS.movement.run)
+  };
+
+  updateDynamicRelevance(codes);
+  return codes;
 }
 
 let listenersAttached = false;
@@ -35,6 +76,8 @@ function normalizeCode(event: KeyboardEventLike): string {
   if (!event) {
     return '';
   }
+
+  refreshMovementCodes();
 
   const code = event.code;
   if (typeof code === 'string' && code && code !== 'Unidentified') {
@@ -60,7 +103,7 @@ function isRelevant(code: string): boolean {
   }
 
   if (RELEVANT_KEY_SET) {
-    return RELEVANT_KEY_SET.has(code);
+    return RELEVANT_KEY_SET.has(code) || dynamicRelevantCodes.has(code);
   }
 
   return true;
@@ -106,13 +149,13 @@ function ensureListeners() {
   }
 }
 
-function axisValue(positive: Set<string>, negative: Set<string>) {
+function axisValue(positive: Iterable<string>, negative: Iterable<string>) {
   const pos = hasAnyKey(positive) ? 1 : 0;
   const neg = hasAnyKey(negative) ? 1 : 0;
   return pos - neg;
 }
 
-function hasAnyKey(codes: Set<string>) {
+function hasAnyKey(codes: Iterable<string>) {
   for (const code of codes) {
     if (activeKeys.has(code)) {
       return true;
@@ -124,11 +167,13 @@ function hasAnyKey(codes: Set<string>) {
 export function getInput(): CharacterInput {
   ensureListeners();
 
+  const movementCodes = refreshMovementCodes();
+
   return {
-    forward: axisValue(POSITIVE_FORWARD, NEGATIVE_FORWARD),
-    right: axisValue(POSITIVE_RIGHT, NEGATIVE_RIGHT),
-    jump: hasAnyKey(JUMP_KEYS),
-    sprint: hasAnyKey(SPRINT_KEYS)
+    forward: axisValue(movementCodes.forwardPositive, movementCodes.forwardNegative),
+    right: axisValue(movementCodes.rightPositive, movementCodes.rightNegative),
+    jump: hasAnyKey(movementCodes.jump),
+    sprint: hasAnyKey(movementCodes.sprint)
   };
 }
 


### PR DESCRIPTION
## Summary
- refresh movement, jump, and sprint action code lookups from the current hotkey manifest before computing input axes
- extend the relevance guard with dynamically collected movement action codes so customized bindings are honored
- add a unit test that exercises a manifest override for the forward movement hotkey

## Testing
- npm test -- src/controls/__tests__/input.test.ts

------
https://chatgpt.com/codex/tasks/task_b_68ddb26d76388327a5df3ed2f7b16b83