### PR TITLE
Align service worker probe with base URL helper

### DIFF
--- a/src/entry/block-remote-guard.js
+++ b/src/entry/block-remote-guard.js
@@ -1,4 +1,5 @@
 import { USE_REMOTE } from '../config/flags';
+import { buildBaseRelativeUrl } from '../utils/baseUrl.ts';
 import { logger } from '../utils/logger.ts';
 
 if (typeof window !== 'undefined' && !USE_REMOTE) {
@@ -32,8 +33,13 @@ if (typeof window !== 'undefined' && !USE_REMOTE) {
     }
 
     try {
-      const base = (import.meta?.env?.BASE_URL ?? window.__ATHENS_BASE__ ?? '/');
-      const swUrl = new URL(`${base}service-worker.js`, window.location.href).toString();
+      const globalScope = typeof globalThis !== 'undefined' ? globalThis : undefined;
+      const globalEnv =
+        globalScope && typeof globalScope === 'object' && globalScope !== null
+          ? globalScope.__ATHENS_SW_ENV__
+          : undefined;
+      const importEnv = typeof import.meta !== 'undefined' ? import.meta.env : undefined;
+      const swUrl = buildBaseRelativeUrl('service-worker.js', { importEnv, globalEnv });
 
       Promise.resolve()
         .then(() =>

--- a/tests/base-url-helper.test.ts
+++ b/tests/base-url-helper.test.ts
@@ -19,3 +19,20 @@ test('buildBaseRelativeUrl prefixes assets with the GitHub Pages base', () => {
     }
   }
 });
+
+test('buildBaseRelativeUrl resolves the service worker relative to the base', () => {
+  const scoped = globalThis as Record<string, unknown>;
+  const previous = scoped.__ATHENS_BASE__;
+
+  try {
+    scoped.__ATHENS_BASE__ = '/Athens/';
+    const url = buildBaseRelativeUrl('service-worker.js');
+    assert.equal(url, '/Athens/service-worker.js');
+  } finally {
+    if (typeof previous === 'undefined') {
+      delete scoped.__ATHENS_BASE__;
+    } else {
+      scoped.__ATHENS_BASE__ = previous;
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- update the remote guard service worker probe to reuse the shared base URL helper
- add a regression test covering service worker resolution when BASE_URL is /Athens/

## Testing
- npm test *(fails: existing keyboard control suite assertions unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_b_68ddc175606c832794ea7b4dd1cb9e3c