### PR TITLE
Refresh movement hotkeys dynamically

### DIFF
--- a/src/controls/__tests__/input.test.ts
+++ b/src/controls/__tests__/input.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import getInput, { __inputTest } from '../input.ts';
-import { ACTION_CODES, HOTKEY_IDS } from '../../config/hotkeys.ts';
+import { ACTION_CODES, HOTKEY_IDS, RELEVANT_KEYS } from '../../config/hotkeys.ts';
 
 test('input adapter maps movement hotkeys to axes', () => {
   __inputTest.reset();
@@ -65,9 +65,14 @@ test('input adapter reflects manifest overrides for movement actions', () => {
 
   const forwardAction = HOTKEY_IDS.movement.forward;
   const originalCodes = ACTION_CODES.get(forwardAction);
+  const relevantKeySet = RELEVANT_KEYS instanceof Set ? RELEVANT_KEYS : undefined;
+  const hadCustomKey = relevantKeySet?.has('KeyI') ?? false;
 
   try {
     ACTION_CODES.set(forwardAction, ['KeyI']);
+
+    getInput();
+    assert.ok(RELEVANT_KEYS instanceof Set && RELEVANT_KEYS.has('KeyI'));
 
     __inputTest.press('KeyI');
     let input = getInput();
@@ -82,6 +87,9 @@ test('input adapter reflects manifest overrides for movement actions', () => {
       ACTION_CODES.set(forwardAction, originalCodes);
     } else {
       ACTION_CODES.delete(forwardAction);
+    }
+    if (relevantKeySet && !hadCustomKey) {
+      relevantKeySet.delete('KeyI');
     }
     __inputTest.reset();
   }

--- a/src/controls/input.ts
+++ b/src/controls/input.ts
@@ -21,9 +21,7 @@ type MovementActionCodes = {
 };
 
 const RELEVANT_KEY_SET: Set<string> | undefined =
-  RELEVANT_KEYS && typeof RELEVANT_KEYS.has === 'function' ? RELEVANT_KEYS : undefined;
-
-const dynamicRelevantCodes = new Set<string>();
+  RELEVANT_KEYS instanceof Set ? RELEVANT_KEYS : undefined;
 
 function resolveActionCodes(actionId: string | undefined): string[] {
   if (!actionId) {
@@ -43,15 +41,14 @@ function resolveActionCodes(actionId: string | undefined): string[] {
   return resolved;
 }
 
-function updateDynamicRelevance(codes: MovementActionCodes) {
+function mergeRelevantKeys(codes: MovementActionCodes) {
   if (!RELEVANT_KEY_SET) {
     return;
   }
 
-  dynamicRelevantCodes.clear();
   for (const group of Object.values(codes)) {
     for (const code of group) {
-      dynamicRelevantCodes.add(code);
+      RELEVANT_KEY_SET.add(code);
     }
   }
 }
@@ -66,7 +63,7 @@ function refreshMovementCodes(): MovementActionCodes {
     sprint: resolveActionCodes(HOTKEY_IDS.movement.run)
   };
 
-  updateDynamicRelevance(codes);
+  mergeRelevantKeys(codes);
   return codes;
 }
 
@@ -103,7 +100,7 @@ function isRelevant(code: string): boolean {
   }
 
   if (RELEVANT_KEY_SET) {
-    return RELEVANT_KEY_SET.has(code) || dynamicRelevantCodes.has(code);
+    return RELEVANT_KEY_SET.has(code);
   }
 
   return true;


### PR DESCRIPTION
## Summary
- refresh movement input bindings from the hotkey manifest on every query and merge the codes into the relevant-key allowlist
- extend the keyboard input test to simulate manifest overrides and assert custom bindings are recognized while cleaning up the allowlist after the test

## Testing
- npm test *(fails: keyboard-controls tests already fail in the base branch because they expect a browser `window` object and non-normalized diagonal movement)*

------
https://chatgpt.com/codex/tasks/task_b_68ddc26069b083279f945782c4bfd381