### PR TITLE
Replace main character height enforcement with local placement logic

### DIFF
--- a/src/entry/initializeAthens.js
+++ b/src/entry/initializeAthens.js
@@ -1407,20 +1407,30 @@ export async function initializeAthens(options = {}) {
   }
 
 // CHAR_MAIN_HEIGHT_START
-const enforceMainCharacterHeight = () => __enforceMainCharacterHeight(scene, options);
+const ensureMainCharacterPlacement = () => {
+  const resolvedPlayer = mainCharacter?.object3d || findPlayerObject() || null;
+  if (!resolvedPlayer) {
+    return null;
+  }
+  placeAtSpawn(resolvedPlayer);
+  sanitizeVec3(resolvedPlayer.position, SAFE_PLAYER_FALLBACK);
+  playerObject = resolvedPlayer;
+  return resolvedPlayer;
+};
+
 const readyPromise = mainCharacter?.ready;
 
 if (readyPromise && typeof readyPromise.then === 'function') {
   readyPromise
     .then(() => {
-      enforceMainCharacterHeight();
+      ensureMainCharacterPlacement();
     })
     .catch((error) => {
-      logger.warn('[Athens][MainCharacter] Failed to load character before enforcing height.', error);
-      enforceMainCharacterHeight();
+      logger.warn('[Athens][MainCharacter] Failed to load character before resolving placement.', error);
+      ensureMainCharacterPlacement();
     });
 } else {
-  enforceMainCharacterHeight();
+  ensureMainCharacterPlacement();
 }
 
   // CHAR_MAIN_HEIGHT_END


### PR DESCRIPTION
## Summary
- remove the dependency on the deleted `__enforceMainCharacterHeight` helper
- introduce a local placement helper that reuses `placeAtSpawn` and keeps the resolved player sanitized

## Testing
- npm test *(fails: keyboard-controls suite expects a browser `window` in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68ddc56ea10883278f2bdf1ad6c1b02d