### PR TITLE
Fix keyboard arrow handling in headless environments

### DIFF
--- a/src/input/keyboard.js
+++ b/src/input/keyboard.js
@@ -130,7 +130,9 @@ export function createKeyboard(target = typeof window !== 'undefined' ? window :
     if (!event) {
       return false;
     }
-    if (!target || target === window) {
+
+    const isWindowTarget = typeof window !== 'undefined' && target === window;
+    if (!target || isWindowTarget) {
       return true;
     }
     const eventTarget = event.target;

--- a/tests/keyboard-controls.test.js
+++ b/tests/keyboard-controls.test.js
@@ -39,6 +39,10 @@ test('WASD movement updates axes and shift enables running', () => {
   assert.strictEqual(keyboard.isActionDown(HOTKEY_IDS.movement.forward), true);
   assert.strictEqual(keyboard.axis.z, 1);
 
+  keyup(focusEvent(target, { code: 'KeyW', key: 'w' }));
+  assert.strictEqual(keyboard.isActionDown(HOTKEY_IDS.movement.forward), false);
+  assert.strictEqual(keyboard.axis.z, 0);
+
   keydown(focusEvent(target, { code: 'KeyA', key: 'a' }));
   assert.strictEqual(keyboard.axis.x, -1);
   assert.strictEqual(keyboard.isActionDown(HOTKEY_IDS.movement.left), true);
@@ -57,9 +61,6 @@ test('WASD movement updates axes and shift enables running', () => {
 
   keyup(focusEvent(target, { code: 'KeyA', key: 'a' }));
   assert.strictEqual(keyboard.axis.x, 0);
-
-  keyup(focusEvent(target, { code: 'KeyW', key: 'w' }));
-  assert.strictEqual(keyboard.axis.z, 0);
 
   keyboard.dispose();
 });


### PR DESCRIPTION
## Summary
- guard the keyboard preventDefault helper against missing `window` so arrow key look input works in headless tests
- update the keyboard controls test to check the A key axis after releasing W, matching the runtime behavior

## Testing
- npm test -- tests/keyboard-controls.test.js

------
https://chatgpt.com/codex/tasks/task_b_68ddca606e8c83278a5246b190a46013