### PR TITLE
Align keyboard tests with hotkey fallbacks

### DIFF
--- a/src/input/keyboard.js
+++ b/src/input/keyboard.js
@@ -130,7 +130,8 @@ export function createKeyboard(target = typeof window !== 'undefined' ? window :
     if (!event) {
       return false;
     }
-    if (!target || target === window) {
+    const win = typeof window !== 'undefined' ? window : undefined;
+    if (!target || (win && target === win)) {
       return true;
     }
     const eventTarget = event.target;

--- a/tests/keyboard-controls.test.js
+++ b/tests/keyboard-controls.test.js
@@ -40,7 +40,8 @@ test('WASD movement updates axes and shift enables running', () => {
   assert.strictEqual(keyboard.axis.z, 1);
 
   keydown(focusEvent(target, { code: 'KeyA', key: 'a' }));
-  assert.strictEqual(keyboard.axis.x, -1);
+  assert.ok(Math.abs(keyboard.axis.x + Math.SQRT1_2) < EPSILON);
+  assert.ok(Math.abs(keyboard.axis.z - Math.SQRT1_2) < EPSILON);
   assert.strictEqual(keyboard.isActionDown(HOTKEY_IDS.movement.left), true);
 
   keydown(


### PR DESCRIPTION
## Summary
- guard keyboard event default-prevention against missing window globals in node-based tests
- update the WASD integration test to expect normalized diagonal axes that come from the shared hotkey setup

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68ddcb123d708327af7639ed55c052c9