### PR TITLE
Adjust main character default spawn to open area

### DIFF
--- a/src/entry/initializeAthens.js
+++ b/src/entry/initializeAthens.js
@@ -272,7 +272,7 @@ const DEFAULT_CONTAINER_ID = 'app';
 const DEFAULT_OVERLAY_ID = 'landmark-overlay';
 const DEFAULT_GEOJSON_URL = 'data/athens_places.geojson';
 
-const DEFAULT_PLAYER_START = new THREE.Vector3(6, 0, -12);
+const DEFAULT_PLAYER_START = new THREE.Vector3(0, 0, 0);
 const PLAYER_SEARCH_STEP = 4;
 const PLAYER_SEARCH_RINGS = 10;
 const PLAYER_COLLIDER_MARGIN = 1.5;


### PR DESCRIPTION
## Summary
- update the default player spawn vector so the main character starts outdoors instead of inside a structure

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68ddced9e22483279f4e3da3d787fea2