### PR TITLE
Ensure follow camera updates while walking

### DIFF
--- a/src/entry/initializeAthens.js
+++ b/src/entry/initializeAthens.js
@@ -1755,9 +1755,7 @@ if (readyPromise && typeof readyPromise.then === 'function') {
         skippedLargeDt: Boolean(skippedLargeDt)
       });
 
-      if (!WALKING_ENABLED || !walkingController) {
-        followCamera?.update?.(keyboard, delta);
-      }
+      followCamera?.update?.(keyboard, delta);
 
       const activePlayer = findPlayerObject() || playerObject;
       if (activePlayer?.position && !isFiniteVec3(activePlayer.position)) {


### PR DESCRIPTION
## Summary
- run the follow camera update even when the walking controller is active so keyboard look inputs still rotate the camera

## Testing
- npm run test -- --help *(fails: npm command not available in container)*

------
https://chatgpt.com/codex/tasks/task_b_68ddd11a7bc483278a6376fd98057275