### PR TITLE
Adjust sanity geometry debug hotkey

### DIFF
--- a/src/config/hotkeys.ts
+++ b/src/config/hotkeys.ts
@@ -220,8 +220,8 @@ const debugActions = {
   toggleSanityGeometry: createAction(HotkeyCategoryId.Debug, {
     id: 'debug.toggleSanityGeometry',
     title: 'Toggle Sanity Geometry',
-    default: 'KeyS',
-    fallback: ['s']
+    default: 'KeyG',
+    fallback: ['g']
   })
 } as const;
 


### PR DESCRIPTION
## Summary
- change the debug toggle sanity geometry hotkey to use KeyG instead of KeyS
- update fallback mapping to match the new default key

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de4394a8b883249ed4ab90dcf5b2bf