### PR TITLE
Improve keyboard look axes and integrate dev flight toggle

### DIFF
--- a/src/config/movement.ts
+++ b/src/config/movement.ts
@@ -64,9 +64,9 @@ export const FLIGHT = {
 } as const;
 
 export const movementConfig: MovementConfig = {
-  walkSpeed: 14,
-  runMultiplier: 2,
-  acceleration: 20,
+  walkSpeed: 18,
+  runMultiplier: 2.5,
+  acceleration: 24,
   safePosition: { x: 0, y: 1, z: -230 },
   character: {
     height: 1.7,

--- a/src/dev/flyBypass.js
+++ b/src/dev/flyBypass.js
@@ -41,9 +41,48 @@ export function installFlyBypass({ state, input }){
   window.dev = window.dev || {};
   let on = false;
   let isFlying = false;
-  function toggle(){ isFlying = !isFlying; on = isFlying; if (isFlying) state.position.y += 0.5; }
+
+  function applyState() {
+    const active = Boolean(isFlying);
+    state.isFlying = active;
+    if (typeof state.setFlying === 'function') {
+      state.setFlying(active);
+    }
+  }
+
+  function toggle() {
+    isFlying = !isFlying;
+    on = isFlying;
+    if (
+      isFlying &&
+      typeof state.setFlying !== 'function' &&
+      state?.position &&
+      Number.isFinite(state.position.y)
+    ) {
+      state.position.y += 0.5;
+    }
+    applyState();
+  }
+
   window.dev.fly = {
-    on(){ isFlying = on = true; }, off(){ isFlying = on = false; }, toggle,
+    on() {
+      on = true;
+      isFlying = true;
+      if (
+        typeof state.setFlying !== 'function' &&
+        state?.position &&
+        Number.isFinite(state.position.y)
+      ) {
+        state.position.y += 0.5;
+      }
+      applyState();
+    },
+    off() {
+      on = false;
+      isFlying = false;
+      applyState();
+    },
+    toggle
   };
 
   const toggleCodes = new Set();
@@ -117,6 +156,13 @@ export function installFlyBypass({ state, input }){
   return {
     tick(dt){
       if (!on) return;
+      const controllerManaged = typeof state.setFlying === 'function';
+      if (controllerManaged) {
+        if (state.velocity) {
+          state.velocity.y = 0;
+        }
+        return;
+      }
       const up =
         input?.held?.(ASCEND_ACTION) ||
         input?.held?.('flyUp') ||

--- a/src/entry/initializeAthens.js
+++ b/src/entry/initializeAthens.js
@@ -1564,7 +1564,9 @@ if (readyPromise && typeof readyPromise.then === 'function') {
   const flyBypassVelocity = { y: 0 };
   const flyBypassState = {
     position: playerObject?.position || flyBypassFallbackPosition,
-    velocity: flyBypassVelocity
+    velocity: flyBypassVelocity,
+    isFlying: false,
+    setFlying: null
   };
 
   // Controls & camera
@@ -1593,6 +1595,12 @@ if (readyPromise && typeof readyPromise.then === 'function') {
   });
   controller.setGroundMeshes(groundMeshes);
   controller.setColliders?.(colliders);
+
+  flyBypassState.setFlying = (active) => {
+    const desired = Boolean(active);
+    controller?.setFlyingActive?.(desired);
+    flyBypassState.isFlying = controller?.isFlying?.() ?? desired;
+  };
 
   if (globalWindow && typeof globalWindow.__athensDebug === 'object' && globalWindow.__athensDebug) {
     globalWindow.__athensDebug.controller = WALKING_ENABLED && walkingController
@@ -1878,6 +1886,10 @@ if (readyPromise && typeof readyPromise.then === 'function') {
         } else {
           controller?.update?.(delta, camera);
         }
+      }
+
+      if (controller) {
+        flyBypassState.isFlying = controller.isFlying?.() ?? flyBypassState.isFlying;
       }
 
       ui?.update?.(delta, {

--- a/src/input/keyboard.js
+++ b/src/input/keyboard.js
@@ -5,8 +5,6 @@ import {
   getActionCodes
 } from '../config/hotkeys.ts';
 
-const INV_SQRT2 = 1 / Math.sqrt(2);
-
 const DEV_FALLBACK_CODES = [
   'KeyW',
   'KeyA',
@@ -241,6 +239,15 @@ export function createKeyboard(target = typeof window !== 'undefined' ? window :
   const handleKeyUp = (event) => {
     const code = normalizeCode(event);
 
+    if (shouldPreventDefault(event, code)) {
+      if (typeof event.preventDefault === 'function') {
+        event.preventDefault();
+      }
+      if (typeof event.stopPropagation === 'function') {
+        event.stopPropagation();
+      }
+    }
+
     if (!code || !activeRelevantKeys.has(code)) {
       return;
     }
@@ -259,19 +266,24 @@ export function createKeyboard(target = typeof window !== 'undefined' ? window :
   const isDown = (code) => pressed.has(code);
 
   const updateState = () => {
-    axisState.x = axisValueFromCodes('x');
-    axisState.z = axisValueFromCodes('z');
+    const axisX = axisValueFromCodes('x');
+    const axisZ = axisValueFromCodes('z');
+    axisState.x = axisX;
+    axisState.z = axisZ;
 
-    const combinedMagnitude = Math.abs(axisState.x) + Math.abs(axisState.z);
-    if (combinedMagnitude > 1) {
-      axisState.x *= INV_SQRT2;
-      axisState.z *= INV_SQRT2;
+    const magnitudeSq = axisState.x * axisState.x + axisState.z * axisState.z;
+    if (magnitudeSq > 1) {
+      const invMagnitude = 1 / Math.sqrt(magnitudeSq);
+      axisState.x *= invMagnitude;
+      axisState.z *= invMagnitude;
     }
 
     axisState.turn = 0;
 
-    axisState.lookX = axisValueFromCodes('lookX');
-    axisState.lookY = axisValueFromCodes('lookY');
+    const lookX = axisValueFromCodes('lookX');
+    const lookY = axisValueFromCodes('lookY');
+    axisState.lookX = Math.max(-1, Math.min(1, lookX));
+    axisState.lookY = Math.max(-1, Math.min(1, lookY));
 
     axisState.running = hasAnyPressed(runningActionCodes);
 

--- a/src/player/playerController.js
+++ b/src/player/playerController.js
@@ -505,6 +505,23 @@ export function createPlayerController(
     setKeyboard,
     setGroundMeshes,
     setColliders,
+    setFlyingActive(active) {
+      if (active) {
+        if (!isFlying) {
+          enterFlight();
+        }
+      } else if (isFlying) {
+        exitFlight();
+      }
+    },
+    toggleFlight() {
+      if (isFlying) {
+        exitFlight();
+      } else {
+        enterFlight();
+      }
+      logger.info(`[playerController] Fly ${isFlying ? 'ON' : 'OFF'}`);
+    },
     setGroundSnapSkipRef(nextRef) {
       groundSnapSkip = typeof nextRef === 'object' ? nextRef : null;
     },


### PR DESCRIPTION
## Summary
- tune movement config for quicker walk, run, and acceleration
- update the keyboard adapter to normalise axes, expose arrow-key look input, and prevent default browser scrolling
- connect the dev fly toggle to the controller so flight mode handles vertical input internally

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68de6c603d948327b7fe51f08cb6c743