### PR TITLE
Remove placeholder footstep audio assets

### DIFF
--- a/public/assets/audio/README.md
+++ b/public/assets/audio/README.md
@@ -1,6 +1,14 @@
 # Audio Assets
 
-This directory contains ambient audio clips that are served at runtime. Most
-production builds source proprietary recordings outside of git; the repository
-ships with a single "ambience_day.mp3" track to guarantee that ambient playback
-functions in open-source builds and automated tests.
+This directory contains ambient and footstep audio clips that are served at runtime. Most
+production builds source proprietary recordings outside of git; the repository omits those
+footstep clips so downstream deployments can supply the correct assets without bloating
+the history with large binaries.
+
+The tracked files are:
+
+- `ambience_day.mp3` – ambient backing track used as a default.
+
+All other audio content is expected to be supplied by downstream deployments. When adding
+footstep clips locally, prefer short, low-bitrate MP3 files to keep bundle sizes small and
+avoid committing them to the repository.

--- a/scripts/verify-footsteps.mjs
+++ b/scripts/verify-footsteps.mjs
@@ -1,0 +1,44 @@
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { readFile } from 'node:fs/promises';
+
+import createFootsteps from '../src/audio/footsteps.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const projectRoot = join(__dirname, '..');
+
+const loads = [];
+
+const audio = {
+  getListener() {
+    return null;
+  },
+  getMasterVolume() {
+    return 1;
+  },
+  isContextSuspended() {
+    return false;
+  },
+  async load(name, rel) {
+    const absolute = join(projectRoot, 'public', 'assets', 'audio', rel);
+    const data = await readFile(absolute);
+    loads.push({ name, rel, size: data.byteLength });
+    return { buffer: { byteLength: data.byteLength } };
+  }
+};
+
+const footsteps = createFootsteps(audio, {
+  dirt: 'ambience_day.mp3',
+  stone: 'ambience_day.mp3'
+});
+
+footsteps.setIntervalBySpeed(3);
+await new Promise((resolve) => setTimeout(resolve, 600));
+await footsteps.onStep('dirt');
+await new Promise((resolve) => setTimeout(resolve, 600));
+await footsteps.onStep('stone');
+
+footsteps.dispose();
+
+console.log(JSON.stringify(loads, null, 2));


### PR DESCRIPTION
## Summary
- remove the placeholder dirt and stone footstep audio clips from the tracked assets
- update the audio documentation and gitignore allowlist to reflect the slimmer repository
- adjust the verification harness to reuse the ambient clip for both footstep surfaces

## Testing
- node scripts/verify-footsteps.mjs

------
https://chatgpt.com/codex/tasks/task_b_68de6ac1a2a08327a8fa90eca9a52932