### PR TITLE
Disable automatic camera sync in CharacterController

### DIFF
--- a/src/controls/CharacterController.ts
+++ b/src/controls/CharacterController.ts
@@ -60,6 +60,7 @@ export interface CharacterControllerOptions {
   jumpSpeed?: number;
   damping?: number;
   stepOffset?: number;
+  autoUpdateCamera?: boolean;
   safePosition?: { x: number; y: number; z: number } | THREE.Vector3;
   flight?: CharacterFlightOptions;
 }
@@ -85,6 +86,7 @@ export class CharacterController {
   private readonly _position = new THREE.Vector3();
   private readonly _halfSegment = new THREE.Vector3();
   private readonly safePosition = { x: DEFAULT_PLAYER.x, y: DEFAULT_PLAYER.y, z: DEFAULT_PLAYER.z };
+  private readonly autoUpdateCamera: boolean;
   private attachedObject: THREE.Object3D | null = null;
   private flightEnabled = true;
   private flightToggleDown = false;
@@ -98,6 +100,7 @@ export class CharacterController {
     options: CharacterControllerOptions = {}
   ) {
     this.camera = camera;
+    this.autoUpdateCamera = Boolean(options.autoUpdateCamera);
 
     const height = Number.isFinite(options.height)
       ? Math.max(options.height ?? 0, EPSILON * 2)
@@ -169,7 +172,9 @@ export class CharacterController {
     }
 
     this.sanitizeCapsule();
-    this.updateCameraPosition();
+    if (this.autoUpdateCamera) {
+      this.updateCameraPosition();
+    }
   }
 
   get position(): THREE.Vector3 {
@@ -209,7 +214,9 @@ export class CharacterController {
     }
 
     this.sanitizeCapsule();
-    this.updateCameraPosition();
+    if (this.autoUpdateCamera) {
+      this.updateCameraPosition();
+    }
     this.syncAttachedObject();
   }
 
@@ -458,7 +465,9 @@ export class CharacterController {
     }
 
     this.sanitizeCapsule();
-    this.updateCameraPosition();
+    if (this.autoUpdateCamera) {
+      this.updateCameraPosition();
+    }
     this.syncAttachedObject();
   }
 
@@ -492,7 +501,9 @@ export class CharacterController {
     this.capsule.start.copy(_capsuleCenter).sub(this._halfSegment);
     this.capsule.end.copy(_capsuleCenter).add(this._halfSegment);
     this.sanitizeCapsule();
-    this.updateCameraPosition();
+    if (this.autoUpdateCamera) {
+      this.updateCameraPosition();
+    }
     this.syncAttachedObject();
   }
 }

--- a/src/controls/__tests__/character-controller-camera.test.ts
+++ b/src/controls/__tests__/character-controller-camera.test.ts
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import * as THREE from 'three';
+
+import { CharacterController } from '../CharacterController.ts';
+import { createFollowCamera } from '../../camera/followCamera.js';
+import type { CharacterControllerWorld } from '../CharacterController.ts';
+
+const NO_INPUT = Object.freeze({ forward: 0, right: 0, jump: false, sprint: false });
+
+function createWorld(): CharacterControllerWorld {
+  return {} as CharacterControllerWorld;
+}
+
+test('follow camera retains offset after controller update', () => {
+  const camera = new THREE.PerspectiveCamera();
+  const start = new THREE.Vector3(0, 1, 0);
+  const controller = new CharacterController(camera, start);
+
+  const avatar = new THREE.Object3D();
+  controller.attach(avatar);
+  controller.setPosition(start.clone());
+
+  const offset = new THREE.Vector3(1, 2, -3);
+  const followCamera = createFollowCamera(camera, avatar, { offset, lerp: 1 });
+  followCamera.syncImmediate?.();
+
+  const expectedOffset = offset.clone();
+  const initialOffset = camera.position.clone().sub(avatar.position);
+  assert.ok(initialOffset.distanceTo(expectedOffset) < 1e-6, 'initial camera offset should match');
+
+  controller.velocity.set(0.6, 0, 0.4);
+  controller.update(1 / 60, NO_INPUT, createWorld());
+
+  const alignmentDelta = controller.position.clone().sub(avatar.position);
+  assert.ok(alignmentDelta.length() < 1e-6, 'attached object should remain aligned with controller');
+
+  followCamera.update?.(undefined, 0);
+  const updatedOffset = camera.position.clone().sub(avatar.position);
+  assert.ok(
+    updatedOffset.distanceTo(expectedOffset) < 1e-5,
+    'follow camera should retain configured offset after controller tick'
+  );
+});


### PR DESCRIPTION
## Summary
- add an `autoUpdateCamera` option to the character controller and disable camera syncing by default
- ensure attached objects continue to follow the capsule while allowing opt-in camera updates
- add a follow camera regression test that verifies the configured offset survives a controller tick

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68def0b655d083279c30901103b0f0de