### PR TITLE
Adjust character controller spawn hover alignment

### DIFF
--- a/src/controls/CharacterController.ts
+++ b/src/controls/CharacterController.ts
@@ -64,6 +64,7 @@ export interface CharacterControllerOptions {
   stepOffset?: number;
   autoUpdateCamera?: boolean;
   safePosition?: { x: number; y: number; z: number } | THREE.Vector3;
+  visualHoverOffset?: number;
   flight?: CharacterFlightOptions;
 }
 
@@ -89,6 +90,7 @@ export class CharacterController {
   private readonly _halfSegment = new THREE.Vector3();
   private readonly safePosition = { x: DEFAULT_PLAYER.x, y: DEFAULT_PLAYER.y, z: DEFAULT_PLAYER.z };
   private readonly autoUpdateCamera: boolean;
+  private readonly visualHoverOffset: number;
   private attachedObject: THREE.Object3D | null = null;
   private readonly attachedOffset = new THREE.Vector3();
   private flightEnabled = true;
@@ -139,6 +141,12 @@ export class CharacterController {
     }
     if (Number.isFinite(options.stepOffset)) {
       this.stepOffset = Math.max(options.stepOffset ?? this.stepOffset, 0);
+    }
+
+    if (Number.isFinite(options.visualHoverOffset)) {
+      this.visualHoverOffset = options.visualHoverOffset ?? 0;
+    } else {
+      this.visualHoverOffset = 0;
     }
 
     const safe = options.safePosition;
@@ -501,6 +509,10 @@ export class CharacterController {
     sanitizeVec3(this.attachedOffset, this.safePosition);
     this.attachedOffset.sub(center);
     sanitizeVec3(this.attachedOffset, _zeroVector);
+
+    if (this.visualHoverOffset !== 0) {
+      this.attachedOffset.y -= this.visualHoverOffset;
+    }
 
     this.syncAttachedObject();
   }

--- a/src/entry/initializeAthens.js
+++ b/src/entry/initializeAthens.js
@@ -1531,6 +1531,7 @@ export async function initializeAthens(options = {}) {
     damping: Number.isFinite(movementConfig?.acceleration) ? movementConfig.acceleration : undefined,
     autoUpdateCamera: true,
     safePosition: SAFE_PLAYER_FALLBACK,
+    visualHoverOffset: CHARACTER_HOVER,
     flight: {
       horizontalSpeed: Number.isFinite(flightConfig.horizontalSpeed)
         ? Math.max(flightConfig.horizontalSpeed, 0)

--- a/tests/spawn-hover.test.js
+++ b/tests/spawn-hover.test.js
@@ -1,5 +1,8 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
+import * as THREE from 'three';
+
+import { CharacterController } from '../src/controls/CharacterController.ts';
 
 test('CHARACTER_HOVER scales with character height', () => {
   // This test verifies that CHARACTER_HOVER is calculated based on CHARACTER_HEIGHT
@@ -61,4 +64,35 @@ test('spawn hover consistency requirement', () => {
   // the spawn search keeps the collider at CHARACTER_HOVER × scale above ground,
   // and the subsequent snap also uses CHARACTER_HOVER × scale,
   // preventing large characters from intersecting the terrain.
+});
+
+test('character controller compensates for spawn hover', () => {
+  const CHARACTER_HEIGHT = 1.7;
+  const CHARACTER_HOVER = Math.min(0.1, Math.max(0.03, CHARACTER_HEIGHT * 0.03));
+  const sampledGroundY = 0;
+
+  const halfHeight = CHARACTER_HEIGHT * 0.5;
+  const playerMesh = new THREE.Mesh(new THREE.BoxGeometry(0.5, CHARACTER_HEIGHT, 0.5));
+  playerMesh.position.set(0, sampledGroundY + halfHeight + CHARACTER_HOVER, 0);
+
+  const camera = new THREE.PerspectiveCamera();
+  const controllerStart = new THREE.Vector3(0, sampledGroundY + halfHeight, 0);
+  const controller = new CharacterController(camera, controllerStart.clone(), {
+    height: CHARACTER_HEIGHT,
+    autoUpdateCamera: false,
+    visualHoverOffset: CHARACTER_HOVER
+  });
+
+  controller.attach(playerMesh);
+  playerMesh.updateMatrixWorld(true);
+
+  const box = new THREE.Box3().setFromObject(playerMesh);
+  assert.ok(
+    Math.abs(box.min.y - sampledGroundY) < 1e-6,
+    'player mesh should rest on the ground after attach'
+  );
+  assert.ok(
+    Math.abs(controller.position.y - controllerStart.y) < 1e-6,
+    'controller center should remain unchanged when compensating hover'
+  );
 });


### PR DESCRIPTION
## Summary
- add a visualHoverOffset option to the character controller and adjust attachments to drop meshes by the hover amount
- initialize the main character controller with the configured CHARACTER_HOVER offset
- cover the spawn hover compensation with a regression test ensuring the mesh rests on the ground

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68df227822908327be6c66a013c27be4