### PR TITLE
Fix spawn hover readiness for main character

### DIFF
--- a/src/controls/CharacterController.ts
+++ b/src/controls/CharacterController.ts
@@ -496,7 +496,7 @@ export class CharacterController {
     return this._isRunning;
   }
 
-  public attach(object: THREE.Object3D | null) {
+  public attach(object: THREE.Object3D | null, options: { visualHoverOffset?: number } = {}) {
     this.attachedObject = object ?? null;
     if (!this.attachedObject?.position) {
       this.attachedOffset.set(0, 0, 0);
@@ -510,8 +510,12 @@ export class CharacterController {
     this.attachedOffset.sub(center);
     sanitizeVec3(this.attachedOffset, _zeroVector);
 
-    if (this.visualHoverOffset !== 0) {
-      this.attachedOffset.y -= this.visualHoverOffset;
+    const hoverOffset = Number.isFinite(options?.visualHoverOffset)
+      ? options.visualHoverOffset || 0
+      : this.visualHoverOffset;
+
+    if (hoverOffset !== 0) {
+      this.attachedOffset.y -= hoverOffset;
     }
 
     this.syncAttachedObject();

--- a/src/entry/initializeAthens.js
+++ b/src/entry/initializeAthens.js
@@ -531,6 +531,35 @@ function findSafePlayerSpawn({
   return _spawnCandidate.clone();
 }
 
+async function waitForSpawnPrerequisites({
+  collectGroundMeshes,
+  collisionWorldRef,
+  requireBvh,
+  pollIntervalMs = 50,
+  timeoutMs = 3000
+} = {}) {
+  const pollInterval = Number.isFinite(pollIntervalMs) && pollIntervalMs > 0 ? pollIntervalMs : 50;
+  const hasTimeout = Number.isFinite(timeoutMs) && timeoutMs > 0;
+  const start = Date.now();
+
+  while (true) {
+    const groundMeshes = typeof collectGroundMeshes === 'function' ? collectGroundMeshes() : [];
+    const hasGround = Array.isArray(groundMeshes) && groundMeshes.length > 0;
+    const world = typeof collisionWorldRef === 'function' ? collisionWorldRef() : null;
+    const hasBvh = !requireBvh || Boolean(world?.bvh);
+
+    if (hasGround && hasBvh) {
+      return groundMeshes;
+    }
+
+    if (hasTimeout && Date.now() - start >= timeoutMs) {
+      return groundMeshes;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, pollInterval));
+  }
+}
+
 function ensureContainerElement(options = {}) {
   if (typeof document === 'undefined') {
     throw new Error('initializeAthens requires a browser document.');
@@ -1172,10 +1201,7 @@ export async function initializeAthens(options = {}) {
 
   // Ground registry + snapping
   markGround(scene);
-  const groundMeshes = collectGround(scene);
-  if (!groundMeshes.length) {
-    logger.warn('[npc] no ground meshes');
-  }
+  let groundMeshes = collectGround(scene);
   // PLACER_START
   const landmarkSequence = [...KNOWN_LANDMARK_KEYS];
   const devLandmarkOptions = options?.dev?.landmarkPlacer;
@@ -1336,12 +1362,6 @@ export async function initializeAthens(options = {}) {
     scene.userData.landmarkPlacer = landmarkPlacer;
   }
   // PLACER_END
-  if (cityRoot && groundMeshes.length) {
-    const snapOpts = { hover: 0.03, fromY: 300 };
-    snapChildrenToGround(cityRoot, groundMeshes, snapOpts);
-    snapGroupToGround(cityRoot, groundMeshes, snapOpts);
-  }
-
   markColliders(scene);
   const colliderMeshes = collectColliders(scene);
   const colliders = buildAABBs(colliderMeshes);
@@ -1355,6 +1375,23 @@ export async function initializeAthens(options = {}) {
     } catch (error) {
       logger.warn('[Athens][CollisionWorld] Failed to load collision world.', error);
     }
+  }
+
+  groundMeshes = await waitForSpawnPrerequisites({
+    collectGroundMeshes: () => collectGround(scene),
+    collisionWorldRef: () => collisionWorld,
+    requireBvh: Boolean(collisionWorldUrl),
+    pollIntervalMs: 50,
+    timeoutMs: 3000
+  });
+  if (!groundMeshes.length) {
+    logger.warn('[npc] no ground meshes');
+  }
+
+  if (cityRoot && groundMeshes.length) {
+    const snapOpts = { hover: 0.03, fromY: 300 };
+    snapChildrenToGround(cityRoot, groundMeshes, snapOpts);
+    snapGroupToGround(cityRoot, groundMeshes, snapOpts);
   }
 
   const mainCharacterOptions = options.mainCharacter ?? options.mainCharacterConfig ?? null;
@@ -1546,7 +1583,7 @@ export async function initializeAthens(options = {}) {
         : undefined
     }
   });
-  controller.attach(playerObject ?? null);
+  controller.attach(playerObject ?? null, { visualHoverOffset: CHARACTER_HOVER });
   if (playerObject?.position) {
     controller.setPosition(playerObject.position);
   }
@@ -1560,7 +1597,7 @@ const ensureMainCharacterPlacement = () => {
   placeAtSpawn(resolvedPlayer);
   sanitizeVec3(resolvedPlayer.position, SAFE_PLAYER_FALLBACK);
   playerObject = resolvedPlayer;
-  controller.attach(resolvedPlayer);
+  controller.attach(resolvedPlayer, { visualHoverOffset: CHARACTER_HOVER });
   controller.setPosition(resolvedPlayer.position);
   return resolvedPlayer;
 };
@@ -1800,7 +1837,7 @@ if (readyPromise && typeof readyPromise.then === 'function') {
         sanitizeVec3(resolvedPlayer.position, SAFE_PLAYER_FALLBACK);
         sanitizeEuler(resolvedPlayer.rotation);
         sanitizeQuaternion(resolvedPlayer.quaternion);
-        controller.attach(resolvedPlayer);
+        controller.attach(resolvedPlayer, { visualHoverOffset: CHARACTER_HOVER });
         controller.setPosition(resolvedPlayer.position);
         followCamera.setTarget?.(resolvedPlayer);
         playerObject = resolvedPlayer;

--- a/tests/spawn-hover.test.js
+++ b/tests/spawn-hover.test.js
@@ -96,3 +96,34 @@ test('character controller compensates for spawn hover', () => {
     'controller center should remain unchanged when compensating hover'
   );
 });
+
+test('character controller allows overriding hover compensation on attach', () => {
+  const CHARACTER_HEIGHT = 1.7;
+  const CHARACTER_HOVER = Math.min(0.1, Math.max(0.03, CHARACTER_HEIGHT * 0.03));
+  const sampledGroundY = 0;
+
+  const halfHeight = CHARACTER_HEIGHT * 0.5;
+  const playerMesh = new THREE.Mesh(new THREE.BoxGeometry(0.5, CHARACTER_HEIGHT, 0.5));
+  playerMesh.position.set(0, sampledGroundY + halfHeight + CHARACTER_HOVER, 0);
+
+  const camera = new THREE.PerspectiveCamera();
+  const controllerStart = new THREE.Vector3(0, sampledGroundY + halfHeight, 0);
+  const controller = new CharacterController(camera, controllerStart.clone(), {
+    height: CHARACTER_HEIGHT,
+    autoUpdateCamera: false,
+    visualHoverOffset: 0
+  });
+
+  controller.attach(playerMesh, { visualHoverOffset: CHARACTER_HOVER });
+  playerMesh.updateMatrixWorld(true);
+
+  const box = new THREE.Box3().setFromObject(playerMesh);
+  assert.ok(
+    Math.abs(box.min.y - sampledGroundY) < 1e-6,
+    'player mesh should rest on the ground after override attach'
+  );
+  assert.ok(
+    Math.abs(controller.position.y - controllerStart.y) < 1e-6,
+    'controller center should remain unchanged when overriding hover'
+  );
+});


### PR DESCRIPTION
## Summary
- wait for ground meshes and the collision BVH before creating the controller and resolving the spawn point
- ensure the avatar attach path uses CHARACTER_HOVER via the controller and allow overriding the hover offset
- add a regression test covering hover compensation overrides on attach

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68df50ccfea0832790f77779d03bb642