### PR TITLE
Fix boot timeout helper to rethrow non-timeout errors

### DIFF
--- a/src/boot/__tests__/withTimeout.test.ts
+++ b/src/boot/__tests__/withTimeout.test.ts
@@ -13,3 +13,38 @@ test('withTimeout resolves with fallback when promise times out', async () => {
 
   assert.equal(result, 'fallback');
 });
+
+test('withTimeout resolves when promise fulfills before timeout', async () => {
+  const result = await withTimeout(Promise.resolve('success'), 50, 'unit-test');
+
+  assert.equal(result, 'success');
+});
+
+test('withTimeout rethrows underlying rejection errors', async () => {
+  let fallbackCalled = false;
+
+  await assert.rejects(
+    async () =>
+      withTimeout(
+        Promise.resolve().then(() => {
+          throw new Error('boom');
+        }),
+        50,
+        'unit-test',
+        () => {
+          fallbackCalled = true;
+          return 'fallback';
+        }
+      ),
+    /boom/
+  );
+
+  assert.equal(fallbackCalled, false);
+});
+
+test('withTimeout rejects when timeout occurs without fallback', async () => {
+  await assert.rejects(
+    async () => withTimeout(new Promise<never>(() => {}), 5, 'unit-test'),
+    /timeout:unit-test/
+  );
+});

--- a/src/boot/withTimeout.ts
+++ b/src/boot/withTimeout.ts
@@ -14,11 +14,19 @@ export async function withTimeout<T>(
   try {
     return await Promise.race([p, timeoutPromise]);
   } catch (error) {
+    const isTimeoutError =
+      error instanceof Error ? error.message === `timeout:${label}` : false;
+
+    if (!isTimeoutError) {
+      throw error;
+    }
+
     console.warn('[Athens][Boot] timed out:', label, error);
     if (fallback) {
       return await fallback();
     }
-    return undefined as unknown as T;
+
+    throw error;
   } finally {
     if (typeof timer !== 'undefined') {
       clearTimeout(timer as ReturnType<typeof setTimeout>);


### PR DESCRIPTION
## Summary
- ensure the boot timeout utility only triggers the fallback for true timeout errors and rethrows other failures
- add comprehensive tests covering resolution, timeout fallback, rejection propagation, and missing fallback behavior

## Testing
- npm test -- src/boot/__tests__/withTimeout.test.ts

------
https://chatgpt.com/codex/tasks/task_b_68df559f57f0832793c263730bd4a673