### PR TITLE
Ensure Athens.boot returns a lifecycle promise

### DIFF
--- a/src/core/bootstrap.js
+++ b/src/core/bootstrap.js
@@ -3,14 +3,22 @@ import { logger } from '../utils/logger.ts';
 
 let bootReadyResolve;
 let bootReadyReject;
-const bootReady = new Promise((resolve, reject) => {
-  bootReadyResolve = resolve;
-  bootReadyReject = reject;
-});
+let bootReady;
 
-if (typeof window !== 'undefined') {
-  window.__AthensBootReady = bootReady;
-}
+const initializeBootReady = () => {
+  bootReady = new Promise((resolve, reject) => {
+    bootReadyResolve = resolve;
+    bootReadyReject = reject;
+  });
+
+  if (typeof window !== 'undefined') {
+    window.__AthensBootReady = bootReady;
+  }
+
+  return bootReady;
+};
+
+initializeBootReady();
 
 export function whenBootReady() {
   if (typeof window !== 'undefined' && window.__AthensBootReady) {
@@ -33,6 +41,18 @@ const describeBootstrapEntrypoint = (entrypoint) => {
 
 let startedAt = null;
 let lastError = null;
+let bootInvocation = null;
+let scheduledBootStart = null;
+let hasScheduledDomReadyListener = false;
+let domReadyListener = null;
+
+const resolveBootstrapEntrypoint = () => {
+  if (typeof window !== 'undefined' && typeof window.__AthensBootEntrypoint === 'function') {
+    return window.__AthensBootEntrypoint;
+  }
+
+  return main;
+};
 
 function showErrorOverlay(msg, err) {
   try {
@@ -68,23 +88,27 @@ export default async function boot(opts = {}) {
 
   const options = opts && typeof opts === 'object' ? { ...opts } : {};
 
+  const entrypoint = resolveBootstrapEntrypoint();
+
   if (!options?.preset && !options?.skydomePreset) {
     options.preset = 'High Noon';
   }
 
   logger.info('[Athens][Bootstrap] Booting', {
-    entrypoint: describeBootstrapEntrypoint(main),
+    entrypoint: describeBootstrapEntrypoint(entrypoint),
     options
   });
 
   try {
-    await main(options);
+    await entrypoint(options);
     logger.info('[Athens][Bootstrap] Boot complete', {
       elapsedMs: Date.now() - startedAt
     });
     bootReadyResolve?.(true);
     bootReadyResolve = undefined;
     bootReadyReject = undefined;
+    scheduledBootStart = null;
+    domReadyListener = null;
   } catch (err) {
     lastError = err;
     console.error('🏛️ Athens Initialization Error - Boot Wrapper', err);
@@ -92,6 +116,7 @@ export default async function boot(opts = {}) {
     bootReadyReject?.(err);
     bootReadyResolve = undefined;
     bootReadyReject = undefined;
+    domReadyListener = null;
     throw err;
   }
 }
@@ -99,13 +124,53 @@ export default async function boot(opts = {}) {
 if (typeof window !== 'undefined') {
   window.Athens = window.Athens || {};
   window.Athens.boot = (o) => {
-    const startBoot = () => boot(o);
+    if (bootInvocation) {
+      return bootInvocation;
+    }
+
+    const startBoot = () => {
+      const result = boot(o);
+      bootInvocation = result;
+      scheduledBootStart = null;
+      return result;
+    };
 
     if (typeof document !== 'undefined' && document.readyState === 'loading') {
-      window.addEventListener('DOMContentLoaded', startBoot, { once: true });
-    } else {
-      startBoot();
+      scheduledBootStart = startBoot;
+      if (!hasScheduledDomReadyListener) {
+        hasScheduledDomReadyListener = true;
+        domReadyListener = () => {
+          const scheduled = scheduledBootStart;
+          scheduledBootStart = null;
+          hasScheduledDomReadyListener = false;
+          domReadyListener = null;
+          scheduled?.();
+        };
+        window.addEventListener('DOMContentLoaded', domReadyListener, { once: true });
+      }
+
+      bootInvocation = whenBootReady();
+      return bootInvocation;
     }
+
+    return startBoot();
   };
   window.Athens.getBootInfo = () => ({ startedAt, lastError });
+}
+
+export function __resetBootstrapStateForTests() {
+  startedAt = null;
+  lastError = null;
+  bootInvocation = null;
+  scheduledBootStart = null;
+  hasScheduledDomReadyListener = false;
+
+  if (typeof window !== 'undefined') {
+    if (domReadyListener && typeof window.removeEventListener === 'function') {
+      window.removeEventListener('DOMContentLoaded', domReadyListener);
+    }
+    domReadyListener = null;
+  }
+
+  initializeBootReady();
 }

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,5 +1,13 @@
+const isDevelopmentEnvironment = (() => {
+  try {
+    return Boolean(import.meta?.env?.DEV);
+  } catch (_) {
+    return false;
+  }
+})();
+
 export const logger = {
-  info: (...a: any[]) => (import.meta.env.DEV ? console.info(...a) : void 0),
-  warn: (...a: any[]) => (import.meta.env.DEV ? console.warn(...a) : void 0),
+  info: (...a: any[]) => (isDevelopmentEnvironment ? console.info(...a) : void 0),
+  warn: (...a: any[]) => (isDevelopmentEnvironment ? console.warn(...a) : void 0),
   error: (...a: any[]) => console.error(...a), // keep errors
 };

--- a/tests/bootstrap-lifecycle.test.js
+++ b/tests/bootstrap-lifecycle.test.js
@@ -1,0 +1,177 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+const createDeferred = () => {
+  let resolve;
+  let reject;
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+};
+
+const withFakeDom = async (readyState, run) => {
+  const previousWindow = globalThis.window;
+  const previousDocument = globalThis.document;
+
+  const domReadyHandlers = [];
+  const otherHandlers = new Map();
+
+  const fakeWindow = {
+    Athens: {},
+    addEventListener: (event, handler) => {
+      if (event === 'DOMContentLoaded') {
+        domReadyHandlers.push(handler);
+        return;
+      }
+      if (!otherHandlers.has(event)) {
+        otherHandlers.set(event, []);
+      }
+      otherHandlers.get(event).push(handler);
+    },
+    removeEventListener: (event, handler) => {
+      if (event === 'DOMContentLoaded') {
+        const idx = domReadyHandlers.indexOf(handler);
+        if (idx >= 0) {
+          domReadyHandlers.splice(idx, 1);
+        }
+        return;
+      }
+      const handlers = otherHandlers.get(event);
+      if (handlers) {
+        const idx = handlers.indexOf(handler);
+        if (idx >= 0) {
+          handlers.splice(idx, 1);
+        }
+      }
+    },
+    dispatchEvent: (event) => {
+      const handlers = otherHandlers.get(event.type) || [];
+      for (const handler of handlers) {
+        handler(event);
+      }
+    }
+  };
+
+  const fakeDocument = {
+    readyState,
+    getElementById: () => null,
+    createElement: () => ({
+      style: {},
+      appendChild: () => {},
+      remove: () => {}
+    }),
+    body: {
+      appendChild: () => {}
+    }
+  };
+
+  globalThis.window = fakeWindow;
+  globalThis.document = fakeDocument;
+
+  try {
+    await run({ domReadyHandlers, fakeWindow, fakeDocument });
+  } finally {
+    if (previousWindow === undefined) {
+      delete globalThis.window;
+    } else {
+      globalThis.window = previousWindow;
+    }
+
+    if (previousDocument === undefined) {
+      delete globalThis.document;
+    } else {
+      globalThis.document = previousDocument;
+    }
+  }
+};
+
+const importBootstrap = async () => {
+  const module = await import(`../src/core/bootstrap.js?test=${Math.random()}`);
+  return module;
+};
+
+test('Athens.boot returns a promise tied to the bootstrap lifecycle', async (t) => {
+  await t.test('resolves only after entrypoint completes when DOM is ready', async () => {
+    await withFakeDom('complete', async ({ fakeWindow }) => {
+      const deferred = createDeferred();
+      const calls = [];
+      fakeWindow.__AthensBootEntrypoint = async (options) => {
+        calls.push(options);
+        await deferred.promise;
+      };
+
+      const bootstrap = await importBootstrap();
+      const bootPromise = fakeWindow.Athens.boot({ preset: 'Evening' });
+
+      assert.equal(typeof bootPromise?.then, 'function');
+      assert.deepEqual(calls, [{ preset: 'Evening' }]);
+
+      let settled = false;
+      bootPromise.then(() => {
+        settled = true;
+      });
+
+      await Promise.resolve();
+      assert.equal(settled, false, 'boot promise should not settle before entrypoint resolves');
+
+      deferred.resolve();
+      await bootPromise;
+      assert.equal(settled, true);
+
+      assert.equal(await bootstrap.whenBootReady(), true);
+    });
+  });
+
+  await t.test('queues boot until DOMContentLoaded and resolves afterwards', async () => {
+    await withFakeDom('loading', async ({ domReadyHandlers, fakeWindow }) => {
+      const deferred = createDeferred();
+      let entrypointCalls = 0;
+      fakeWindow.__AthensBootEntrypoint = async () => {
+        entrypointCalls += 1;
+        await deferred.promise;
+      };
+
+      const bootstrap = await importBootstrap();
+      const bootPromise = fakeWindow.Athens.boot();
+
+      assert.equal(typeof bootPromise?.then, 'function');
+      assert.equal(entrypointCalls, 0, 'entrypoint should not run before DOMContentLoaded');
+      assert.equal(domReadyHandlers.length, 1, 'DOMContentLoaded handler should be registered once');
+
+      let settled = false;
+      bootPromise.then(() => {
+        settled = true;
+      }, () => {
+        settled = true;
+      });
+
+      await Promise.resolve();
+      assert.equal(settled, false, 'boot promise should not settle before DOM ready');
+
+      domReadyHandlers[0]?.();
+      await Promise.resolve();
+      assert.equal(entrypointCalls, 1, 'entrypoint should run after DOMContentLoaded');
+      assert.equal(settled, false, 'boot promise should still wait for entrypoint completion');
+
+      deferred.resolve();
+      await bootPromise;
+      assert.equal(settled, true);
+      assert.equal(await bootstrap.whenBootReady(), true);
+    });
+  });
+
+  await t.test('propagates initialization failures', async () => {
+    await withFakeDom('complete', async ({ fakeWindow }) => {
+      const error = new Error('boom');
+      fakeWindow.__AthensBootEntrypoint = async () => {
+        throw error;
+      };
+
+      const bootstrap = await importBootstrap();
+      await assert.rejects(() => fakeWindow.Athens.boot(), error);
+      await assert.rejects(bootstrap.whenBootReady(), error);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- rework the bootstrap lifecycle to reuse a shared promise and expose a test reset hook
- update window.Athens.boot to always return a lifecycle promise and honor DOM readiness scheduling
- harden the logger for non-Vite environments and add tests covering the bootstrap promise behavior

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68df693bdfd483279b1d9c9f56f14172