### PR TITLE
Preserve origins when normalizing asset base URLs

### DIFF
--- a/src/utils/asset-paths.js
+++ b/src/utils/asset-paths.js
@@ -23,7 +23,8 @@ function normalizeBaseCandidate(candidate) {
   if (/^https?:\/\//i.test(trimmed)) {
     try {
       const absolute = new URL(trimmed);
-      return ensureTrailingSlash(absolute.pathname || '/');
+      const originAndPath = `${absolute.origin}${absolute.pathname || '/'}`;
+      return ensureTrailingSlash(originAndPath);
     } catch (error) {
       logger.warn('[asset-paths] Invalid absolute BASE_URL candidate.', error);
       return null;
@@ -35,7 +36,8 @@ function normalizeBaseCandidate(candidate) {
     if (typeof location !== 'undefined' && typeof location.href === 'string') {
       try {
         const relative = new URL(trimmed, location.href);
-        return ensureTrailingSlash(relative.pathname || '/');
+        const originAndPath = `${relative.origin}${relative.pathname || '/'}`;
+        return ensureTrailingSlash(originAndPath);
       } catch (error) {
         logger.warn('[asset-paths] Unable to resolve relative BASE_URL candidate.', error);
       }
@@ -49,12 +51,26 @@ function normalizeBaseCandidate(candidate) {
 }
 
 function computeFromEnv() {
-  if (typeof import.meta === 'undefined') {
-    return null;
+  let candidate = null;
+
+  if (typeof import.meta !== 'undefined') {
+    const env = import.meta.env ?? null;
+    if (env && typeof env.BASE_URL !== 'undefined') {
+      candidate = env.BASE_URL;
+    }
   }
-  const env = import.meta.env ?? null;
-  const base = env && typeof env.BASE_URL === 'string' ? env.BASE_URL : null;
-  return normalizeBaseCandidate(base);
+
+  if (
+    candidate === null &&
+    typeof process !== 'undefined' &&
+    process &&
+    process.env &&
+    typeof process.env.BASE_URL !== 'undefined'
+  ) {
+    candidate = process.env.BASE_URL;
+  }
+
+  return normalizeBaseCandidate(candidate);
 }
 
 function computeFromLocation() {

--- a/tests/asset-paths.test.ts
+++ b/tests/asset-paths.test.ts
@@ -1,0 +1,68 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+function withProcessBaseUrl(value: string | undefined, fn: () => Promise<void> | void) {
+  const previous = process.env.BASE_URL;
+
+  if (typeof value === 'undefined') {
+    delete process.env.BASE_URL;
+  } else {
+    process.env.BASE_URL = value;
+  }
+
+  return Promise.resolve()
+    .then(() => fn())
+    .finally(() => {
+      if (typeof previous === 'undefined') {
+        delete process.env.BASE_URL;
+      } else {
+        process.env.BASE_URL = previous;
+      }
+    });
+}
+
+async function importFreshAssetPaths() {
+  delete (globalThis as Record<string, unknown>).__AthensAssetBase;
+  const specifier = `../src/utils/asset-paths.js?cachebust=${Date.now()}-${Math.random()}`;
+  return import(specifier);
+}
+
+test('computeAssetBaseUrl retains absolute BASE_URL origins', { concurrency: 1 }, async () => {
+  await withProcessBaseUrl('https://cdn.example.com/assets', async () => {
+    try {
+      const module = await importFreshAssetPaths();
+      const base = module.computeAssetBaseUrl();
+      assert.equal(base, 'https://cdn.example.com/assets/');
+      assert.equal(module.getAssetBase(), 'https://cdn.example.com/assets/');
+      assert.equal(module.ASSET_BASE, 'https://cdn.example.com/assets/');
+
+      const scoped = globalThis as Record<string, unknown>;
+      const assetBase = scoped.__AthensAssetBase as { value: string; source: string } | undefined;
+      assert.ok(assetBase, 'expected __AthensAssetBase to be defined');
+      assert.equal(assetBase?.value, 'https://cdn.example.com/assets/');
+      assert.equal(assetBase?.source, 'env:BASE_URL');
+    } finally {
+      delete (globalThis as Record<string, unknown>).__AthensAssetBase;
+    }
+  });
+});
+
+test('computeAssetBaseUrl tolerates unusable BASE_URL values', { concurrency: 1 }, async () => {
+  await withProcessBaseUrl('   ', async () => {
+    try {
+      const module = await importFreshAssetPaths();
+      const base = module.computeAssetBaseUrl();
+      assert.equal(base, module.ASSET_BASE);
+      assert.equal(module.getAssetBase(), module.ASSET_BASE);
+      assert.ok(base.endsWith('/'), 'expected base URL to end with a slash');
+
+      const scoped = globalThis as Record<string, unknown>;
+      const assetBase = scoped.__AthensAssetBase as { value: string; source: string } | undefined;
+      assert.ok(assetBase, 'expected __AthensAssetBase to be defined');
+      assert.equal(assetBase?.value, module.ASSET_BASE);
+      assert.equal(assetBase?.source, 'import.meta.url');
+    } finally {
+      delete (globalThis as Record<string, unknown>).__AthensAssetBase;
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- include the origin when normalizing absolute BASE_URL inputs so resolved bases stay fully-qualified
- allow computeAssetBaseUrl to fall back to process.env for tests and add coverage that exercises absolute and invalid BASE_URL values

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68df6bd63f7883279dee35d9d8a1a25f