### PR TITLE
fix(camera): move follow camera farther back for third-person view

### DIFF
--- a/src/entry/initializeAthens.js
+++ b/src/entry/initializeAthens.js
@@ -1656,14 +1656,14 @@ if (readyPromise && typeof readyPromise.then === 'function') {
     globalWindow.__athensDebug.controller = controller;
   }
 
-  const followOffset = cameraFollowConfig?.offset ?? { x: 0, y: 2.2, z: -6 };
+  const followOffset = cameraFollowConfig?.offset ?? { x: 0, y: 50, z: -10 };
   const followLookOffset = cameraFollowConfig?.lookAtOffset ?? { x: 0, y: 1.5, z: 0 };
   const followLerp = Number.isFinite(cameraFollowConfig?.lerp) ? cameraFollowConfig.lerp : 0.12;
   const followCamera = createFollowCamera(camera, playerObject, {
     offset: new THREE.Vector3(
       Number.isFinite(followOffset?.x) ? followOffset.x : 0,
-      Number.isFinite(followOffset?.y) ? followOffset.y : 2.2,
-      Number.isFinite(followOffset?.z) ? followOffset.z : -6
+      Number.isFinite(followOffset?.y) ? followOffset.y : 50,
+      Number.isFinite(followOffset?.z) ? followOffset.z : -10
     ),
     lerp: followLerp,
     lookAtOffset: new THREE.Vector3(


### PR DESCRIPTION
Changed follow-camera offset from (0, 2.2, -6) to (0, 50, -10).

This moves the camera farther back and higher for a proper third-person perspective.

------
https://chatgpt.com/codex/tasks/task_b_68df752e02088327ab2d5c4a48344f6c