### PR TITLE
Improve timeout handling and tests

### DIFF
--- a/src/boot/__tests__/withTimeout.test.ts
+++ b/src/boot/__tests__/withTimeout.test.ts
@@ -13,3 +13,10 @@ test('withTimeout resolves with fallback when promise times out', async () => {
 
   assert.equal(result, 'fallback');
 });
+
+test('withTimeout rejects when there is no fallback', async () => {
+  await assert.rejects(
+    withTimeout(new Promise<never>(() => {}), 5, 'unit-test-no-fallback'),
+    /timeout:unit-test-no-fallback/
+  );
+});

--- a/src/boot/withTimeout.ts
+++ b/src/boot/withTimeout.ts
@@ -2,26 +2,31 @@ export async function withTimeout<T>(
   p: Promise<T>,
   ms: number,
   label: string,
-  fallback?: () => T | Promise<T>
+  fallback?: (error: unknown) => T | Promise<T>
 ): Promise<T> {
-  let timer: ReturnType<typeof setTimeout> | number | undefined;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeoutError = new Error(`timeout:${label}`);
   const timeoutPromise = new Promise<never>((_, reject) => {
     timer = setTimeout(() => {
-      reject(new Error(`timeout:${label}`));
+      reject(timeoutError);
     }, ms);
   });
 
   try {
     return await Promise.race([p, timeoutPromise]);
   } catch (error) {
-    console.warn('[Athens][Boot] timed out:', label, error);
     if (fallback) {
-      return await fallback();
+      console.warn(
+        `[Athens][Boot] ${label} timed out after ${ms}ms; running fallback.`,
+        error
+      );
+      return await fallback(error);
     }
-    return undefined as unknown as T;
+
+    throw (error instanceof Error ? error : timeoutError);
   } finally {
     if (typeof timer !== 'undefined') {
-      clearTimeout(timer as ReturnType<typeof setTimeout>);
+      clearTimeout(timer);
     }
   }
 }


### PR DESCRIPTION
## Summary
- make the boot timeout helper reuse a single timeout error and pass it to fallbacks
- throw when no fallback is provided so callers can handle timeouts explicitly
- expand the timeout unit tests to cover rejection behaviour

## Testing
- npm test -- src/boot/__tests__/withTimeout.test.ts

------
https://chatgpt.com/codex/tasks/task_b_68dfb8e34cf88327bc0c37ab9da03d03