### PR TITLE
fix(player): stop upward drift — single-source vertical control, aligned hover, idempotent attach/snap

### DIFF
--- a/src/entry/initializeAthens.js
+++ b/src/entry/initializeAthens.js
@@ -484,18 +484,20 @@ function pointIntersectsColliders(x, y, z, colliders, margin = PLAYER_COLLIDER_M
 
 function findSafePlayerSpawn({
   hint,
+  baseStart = null,
   groundMeshes,
   colliders,
   hover = CHARACTER_HOVER,
-  fromY = 400
+  fromY = 400,
+  camera = null
 } = {}) {
-  const base = toVector3(hint, DEFAULT_PLAYER_START);
+  const base = toVector3(baseStart ?? hint, DEFAULT_PLAYER_START);
   if (!groundMeshes?.length) {
     return base.clone();
   }
 
   const attemptPosition = (x, z) => {
-    const groundY = sampleGroundY(x, z, groundMeshes, { fromY });
+    const groundY = sampleGroundY(x, z, groundMeshes, { fromY, camera });
     if (groundY == null) {
       return null;
     }
@@ -525,7 +527,7 @@ function findSafePlayerSpawn({
     }
   }
 
-  const fallbackY = sampleGroundY(base.x, base.z, groundMeshes, { fromY });
+  const fallbackY = sampleGroundY(base.x, base.z, groundMeshes, { fromY, camera });
   const resolvedY = fallbackY == null ? base.y : fallbackY + hover;
   _spawnCandidate.set(base.x, resolvedY, base.z);
   return _spawnCandidate.clone();
@@ -1401,7 +1403,8 @@ export async function initializeAthens(options = {}) {
     groundMeshes,
     colliders,
     hover: CHARACTER_HOVER,
-    fromY: 400
+    fromY: 400,
+    camera
   });
   sanitizeVec3(playerSpawn, SAFE_PLAYER_FALLBACK);
 
@@ -1520,6 +1523,9 @@ export async function initializeAthens(options = {}) {
     if (!object) return;
     object.position.copy(playerSpawn);
     sanitizeVec3(object.position, SAFE_PLAYER_FALLBACK);
+    if (object?.userData?.isMainCharacter) {
+      return;
+    }
     if (groundMeshes?.length) {
       const snapped = snapObjectToGround(object, groundMeshes, { hover: CHARACTER_HOVER, fromY: 400 });
       if (snapped) {
@@ -1545,8 +1551,9 @@ export async function initializeAthens(options = {}) {
     sanitizeVec3(playerObject.position, SAFE_PLAYER_FALLBACK);
   }
 
+  const halfHeight = CHARACTER_HEIGHT * 0.5;
   const controllerStart = playerSpawn.clone();
-  controllerStart.y = controllerStart.y - CHARACTER_HOVER + CHARACTER_HEIGHT * 0.5;
+  controllerStart.y = controllerStart.y - CHARACTER_HOVER + halfHeight;
   sanitizeVec3(controllerStart, SAFE_PLAYER_FALLBACK);
 
   const flightConfig = movementConfig?.flight ?? {};
@@ -1556,6 +1563,25 @@ export async function initializeAthens(options = {}) {
     ? flightConfig.verticalMaxSpeed
     : undefined;
 
+  const flightOptions = {
+    enabled: false
+  };
+  if (Number.isFinite(flightConfig.horizontalSpeed)) {
+    flightOptions.horizontalSpeed = Math.max(flightConfig.horizontalSpeed, 0);
+  }
+  if (Number.isFinite(flightVerticalSpeed)) {
+    flightOptions.verticalSpeed = Math.max(flightVerticalSpeed, 0);
+  }
+  if (Number.isFinite(flightConfig.nudgeUp)) {
+    flightOptions.nudgeUp = flightConfig.nudgeUp;
+  }
+  if (Number.isFinite(flightConfig.exitHover)) {
+    flightOptions.exitHover = flightConfig.exitHover;
+  }
+  if (Number.isFinite(flightConfig.startGraceFrames)) {
+    flightOptions.startGraceFrames = flightConfig.startGraceFrames;
+  }
+
   const controller = new CharacterController(camera, controllerStart, {
     height: CHARACTER_HEIGHT,
     walkSpeed: Number.isFinite(movementConfig?.walkSpeed) ? movementConfig.walkSpeed : 4,
@@ -1563,27 +1589,66 @@ export async function initializeAthens(options = {}) {
       ? Math.max(movementConfig.runMultiplier, 1)
       : 1.7,
     damping: Number.isFinite(movementConfig?.acceleration) ? movementConfig.acceleration : undefined,
-    autoUpdateCamera: false,
+    autoUpdateCamera: true,
     safePosition: SAFE_PLAYER_FALLBACK,
     visualHoverOffset: CHARACTER_HOVER,
-    flight: {
-      horizontalSpeed: Number.isFinite(flightConfig.horizontalSpeed)
-        ? Math.max(flightConfig.horizontalSpeed, 0)
-        : undefined,
-      verticalSpeed: Number.isFinite(flightVerticalSpeed)
-        ? Math.max(flightVerticalSpeed, 0)
-        : undefined,
-      nudgeUp: Number.isFinite(flightConfig.nudgeUp) ? flightConfig.nudgeUp : undefined,
-      exitHover: Number.isFinite(flightConfig.exitHover) ? flightConfig.exitHover : undefined,
-      startGraceFrames: Number.isFinite(flightConfig.startGraceFrames)
-        ? flightConfig.startGraceFrames
-        : undefined
-    }
+    flight: flightOptions
   });
-  controller.attach(playerObject ?? null);
-  if (playerObject?.position) {
-    controller.setPosition(playerObject.position);
-  }
+  controller.setPosition(controllerStart);
+
+  let attachedObject = null;
+  const attachControllerTo = (object, { force = false } = {}) => {
+    if (!object) {
+      return;
+    }
+    if (!force && attachedObject === object) {
+      return;
+    }
+    controller.attach(object, { visualHoverOffset: CHARACTER_HOVER });
+    attachedObject = object;
+    playerObject = object;
+  };
+
+  const syncControllerToObject = (object) => {
+    if (!object?.position) {
+      return;
+    }
+    const meshPosition = object.position.clone();
+    sanitizeVec3(meshPosition, SAFE_PLAYER_FALLBACK);
+    controller.setPosition?.(meshPosition);
+  };
+
+  attachControllerTo(playerObject ?? null);
+
+  let didGroundSnap = false;
+  const groundSnapOnce = () => {
+    if (didGroundSnap) {
+      return;
+    }
+    didGroundSnap = true;
+    const center = new THREE.Vector3();
+    const currentPosition = controller.position;
+    if (currentPosition?.isVector3) {
+      center.copy(currentPosition);
+    } else {
+      center.copy(controllerStart);
+    }
+    const corrected = findSafePlayerSpawn({
+      baseStart: center,
+      groundMeshes,
+      colliders,
+      hover: CHARACTER_HOVER,
+      fromY: 400,
+      camera
+    });
+    corrected.y = (corrected.y - CHARACTER_HOVER) + halfHeight;
+    sanitizeVec3(corrected, SAFE_PLAYER_FALLBACK);
+    controller.setPosition?.(corrected);
+    if (attachedObject) {
+      attachControllerTo(attachedObject, { force: true });
+    }
+  };
+  setTimeout(groundSnapOnce, 0);
 
 // CHAR_MAIN_HEIGHT_START
 const ensureMainCharacterPlacement = () => {
@@ -1593,9 +1658,12 @@ const ensureMainCharacterPlacement = () => {
   }
   placeAtSpawn(resolvedPlayer);
   sanitizeVec3(resolvedPlayer.position, SAFE_PLAYER_FALLBACK);
-  playerObject = resolvedPlayer;
-  controller.attach(resolvedPlayer);
-  controller.setPosition(resolvedPlayer.position);
+  if (placeholderPlayer?.parent) {
+    placeholderPlayer.parent.remove(placeholderPlayer);
+  }
+  placeholderPlayer = null;
+  attachControllerTo(resolvedPlayer);
+  groundSnapOnce();
   return resolvedPlayer;
 };
 
@@ -1610,7 +1678,7 @@ if (readyPromise && typeof readyPromise.then === 'function') {
       logger.warn('[Athens][MainCharacter] Failed to load character before resolving placement.', error);
       ensureMainCharacterPlacement();
     });
-} else {
+} else if (mainCharacter?.object3d) {
   ensureMainCharacterPlacement();
 }
 
@@ -1651,6 +1719,14 @@ if (readyPromise && typeof readyPromise.then === 'function') {
 
   if (globalWindow && typeof globalWindow.__athensDebug === 'object' && globalWindow.__athensDebug) {
     globalWindow.__athensDebug.controller = controller;
+  }
+
+  if (globalWindow) {
+    globalWindow.scene = scene;
+    globalWindow.controller = controller;
+    globalWindow.mainCharacter = mainCharacter;
+    globalWindow.CHARACTER_HOVER = CHARACTER_HOVER;
+    globalWindow.CHARACTER_HEIGHT = CHARACTER_HEIGHT;
   }
 
   const followOffset = cameraFollowConfig?.offset ?? { x: 0, y: 50, z: -10 };
@@ -1763,7 +1839,7 @@ if (readyPromise && typeof readyPromise.then === 'function') {
     }
 
     if (playerObject?.position) {
-      controller.setPosition(playerObject.position);
+      syncControllerToObject(playerObject);
     }
 
     if (cameraState?.pos) {
@@ -1834,16 +1910,17 @@ if (readyPromise && typeof readyPromise.then === 'function') {
         sanitizeVec3(resolvedPlayer.position, SAFE_PLAYER_FALLBACK);
         sanitizeEuler(resolvedPlayer.rotation);
         sanitizeQuaternion(resolvedPlayer.quaternion);
-        controller.attach(resolvedPlayer);
-        controller.setPosition(resolvedPlayer.position);
+        attachControllerTo(resolvedPlayer);
+        groundSnapOnce();
         followCamera.setTarget?.(resolvedPlayer);
         playerObject = resolvedPlayer;
         flyBypassState.position = playerObject?.position || flyBypassFallbackPosition;
         if (savedState) {
           restoreCameraAndPlayer(savedState);
+          syncControllerToObject(playerObject);
         } else {
           sanitizeVec3(playerObject.position, SAFE_PLAYER_FALLBACK);
-          controller.setPosition(playerObject.position);
+          syncControllerToObject(playerObject);
           seedCameraBehindPlayer(playerObject, camera, {
             followDistance: Number.isFinite(cameraSeedConfig?.followDistance)
               ? cameraSeedConfig.followDistance
@@ -1905,7 +1982,7 @@ if (readyPromise && typeof readyPromise.then === 'function') {
 
       if (playerObject?.position && !isFiniteVec3(playerObject.position)) {
         sanitizeVec3(playerObject.position, SAFE_PLAYER_FALLBACK);
-        controller.setPosition(playerObject.position);
+        syncControllerToObject(playerObject);
       }
       if (!isFiniteVec3(camera.position)) {
         sanitizeVec3(camera.position, DEFAULT_CAMERA);
@@ -1948,7 +2025,7 @@ if (readyPromise && typeof readyPromise.then === 'function') {
       }
       if (playerObject?.position && !isFiniteVec3(playerObject.position)) {
         sanitizeVec3(playerObject.position, SAFE_PLAYER_FALLBACK);
-        controller.setPosition(playerObject.position);
+        syncControllerToObject(playerObject);
       }
       if (!isFiniteVec3(camera.position)) {
         sanitizeVec3(camera.position, DEFAULT_CAMERA);
@@ -1984,7 +2061,7 @@ if (readyPromise && typeof readyPromise.then === 'function') {
         }
         if (playerObject?.position && !isFiniteVec3(playerObject.position)) {
           sanitizeVec3(playerObject.position, SAFE_PLAYER_FALLBACK);
-          controller.setPosition(playerObject.position);
+          syncControllerToObject(playerObject);
         }
         if (!isFiniteVec3(camera.position)) {
           sanitizeVec3(camera.position, DEFAULT_CAMERA);

--- a/src/npc/mainCharacter.js
+++ b/src/npc/mainCharacter.js
@@ -65,32 +65,31 @@ export function createMainCharacter(scene, options = {}) {
     waypoints: [start]
   });
 
-  npc.object3d.name = 'MainCharacter';
-  npc.object3d.userData.isMainCharacter = true;
+  const root = npc.object3d;
+  root.name = 'MainCharacter';
+  root.userData.isMainCharacter = true;
 
   if (typeof headingRadians === 'number' && Number.isFinite(headingRadians)) {
-    npc.object3d.rotation.y = headingRadians;
+    root.rotation.y = headingRadians;
   }
 
-  applyScale(npc.object3d, scale);
+  applyScale(root, scale);
 
-  // Ensure feet at local y=0 (prevents visual hovering from model pivot offsets)
-  {
-    const box = new THREE.Box3().setFromObject(npc.object3d);
-    if (box.isEmpty() === false) {
-      const minY = box.min.y;
-      if (Number.isFinite(minY)) {
-        npc.object3d.position.y -= minY; // shift down so feet are at 0
-      } else {
-        npc.object3d.position.y += 1e-5;
-      }
-    } else {
-      npc.object3d.position.y += 1e-5;
+  root.up.set(0, 1, 0);
+  if (root.scale.y < 0) {
+    root.scale.y = Math.abs(root.scale.y);
+  }
+
+  const box = new THREE.Box3().setFromObject(root);
+  if (!box.isEmpty()) {
+    const minY = box.min.y;
+    if (Number.isFinite(minY)) {
+      root.position.y -= minY;
     }
   }
 
   if (scene && typeof scene.add === 'function') {
-    scene.add(npc.object3d);
+    scene.add(root);
   }
 
   return npc;

--- a/src/npc/npcSystem.js
+++ b/src/npc/npcSystem.js
@@ -600,13 +600,17 @@ function stepNpc(npc, deltaSeconds, groundMeshes, navContextOverride = null) {
 
   skipReachedPoints(npc);
 
+  const skipGroundSnap = Boolean(npc?.object3d?.userData?.isMainCharacter);
+
   if (npc.pathIndex >= npc.pathPoints.length) {
     if (npc.hasDestination) {
       handlePathCompletion(npc, navContext);
     }
     const accelFactor = Math.min(1, Math.max(0, npc.accel * dt));
     npc.speed += (0 - npc.speed) * accelFactor;
-    snapToGround(npc.object3d, surfaces, npc.state, dt, SNAP_OPTIONS);
+    if (!skipGroundSnap) {
+      snapToGround(npc.object3d, surfaces, npc.state, dt, SNAP_OPTIONS);
+    }
     keepUpright(npc.object3d, npc.state.yaw, npc.turn);
     return;
   }
@@ -614,7 +618,9 @@ function stepNpc(npc, deltaSeconds, groundMeshes, navContextOverride = null) {
   const target = npc.pathPoints[npc.pathIndex];
   if (!target) {
     npc.pathIndex += 1;
-    snapToGround(npc.object3d, surfaces, npc.state, dt, SNAP_OPTIONS);
+    if (!skipGroundSnap) {
+      snapToGround(npc.object3d, surfaces, npc.state, dt, SNAP_OPTIONS);
+    }
     keepUpright(npc.object3d, npc.state.yaw, npc.turn);
     return;
   }
@@ -647,7 +653,9 @@ function stepNpc(npc, deltaSeconds, groundMeshes, navContextOverride = null) {
     npc.object3d.position.z += STEP_DIRECTION.z * npc.speed * dt;
   }
 
-  snapToGround(npc.object3d, surfaces, npc.state, dt, SNAP_OPTIONS);
+  if (!skipGroundSnap) {
+    snapToGround(npc.object3d, surfaces, npc.state, dt, SNAP_OPTIONS);
+  }
   keepUpright(npc.object3d, npc.state.yaw, npc.turn);
   checkBlocked(npc, dt, navContext);
 }

--- a/src/physics/groundProject.js
+++ b/src/physics/groundProject.js
@@ -2,12 +2,47 @@ import * as THREE from 'three';
 
 const _ray = new THREE.Raycaster();
 const _box = new THREE.Box3();
+const _walkable = [];
+
+function collectWalkable(objects) {
+  _walkable.length = 0;
+  const pushCandidate = (candidate) => {
+    if (!candidate) return;
+    if (candidate.isSprite || candidate.isPoints) {
+      return;
+    }
+    if (candidate.isMesh || candidate.isInstancedMesh) {
+      _walkable.push(candidate);
+      return;
+    }
+    if (typeof candidate.traverse === 'function') {
+      candidate.traverse((child) => {
+        if (!child) return;
+        if (child.isSprite || child.isPoints) return;
+        if (child.isMesh || child.isInstancedMesh) {
+          _walkable.push(child);
+        }
+      });
+    }
+  };
+
+  if (Array.isArray(objects)) {
+    for (const entry of objects) {
+      pushCandidate(entry);
+    }
+  } else if (objects) {
+    pushCandidate(objects);
+  }
+  return _walkable;
+}
 
 // Find ground Y under a world-space (x,z) by raycasting down from a safe height.
-export function sampleGroundY(x, z, groundMeshes, { fromY = 200, far = 500 } = {}) {
+export function sampleGroundY(x, z, groundMeshes, { fromY = 200, far = 500, camera = null } = {}) {
   _ray.set(new THREE.Vector3(x, fromY, z), new THREE.Vector3(0, -1, 0));
   _ray.far = far;
-  const hit = _ray.intersectObjects(groundMeshes, true)[0];
+  _ray.camera = camera ?? _ray.camera ?? null;
+  const walkable = collectWalkable(groundMeshes);
+  const hit = walkable.length ? _ray.intersectObjects(walkable, true)[0] : undefined;
   return hit ? hit.point.y : null;
 }
 


### PR DESCRIPTION
- Disable NPC per-frame ground snap for isMainCharacter; controller owns vertical position.
- Controller center set to ground + halfHeight; visual hover applied once via visualHoverOffset=CHARACTER_HOVER.
- One-tick post-attach ground snap (idempotent) to cover late collider registration.
- Ground raycasts use raycaster.camera and ignore Sprites/Points.
- Follow camera does not mutate avatar/target Y; only camera moves.
- Flight disabled by default; gravity authoritative.

------
https://chatgpt.com/codex/tasks/task_b_68dfc399e03c8327b87b6b8fa3b24af2