### PR TITLE
chore(dev): expose runtime refs, fix olive.glb path, relax env timeout

### DIFF
--- a/src/boot/withTimeout.ts
+++ b/src/boot/withTimeout.ts
@@ -4,12 +4,13 @@ export async function withTimeout<T>(
   label: string,
   fallback?: (error: unknown) => T | Promise<T>
 ): Promise<T> {
+  const timeoutMs = label === 'environment-module' ? 5000 : ms;
   let timer: ReturnType<typeof setTimeout> | undefined;
   const timeoutError = new Error(`timeout:${label}`);
   const timeoutPromise = new Promise<never>((_, reject) => {
     timer = setTimeout(() => {
       reject(timeoutError);
-    }, ms);
+    }, timeoutMs);
   });
 
   try {
@@ -17,7 +18,7 @@ export async function withTimeout<T>(
   } catch (error) {
     if (fallback) {
       console.warn(
-        `[Athens][Boot] ${label} timed out after ${ms}ms; running fallback.`,
+        `[Athens][Boot] ${label} timed out after ${timeoutMs}ms; running fallback.`,
         error
       );
       return await fallback(error);

--- a/src/entry/initializeAthens.js
+++ b/src/entry/initializeAthens.js
@@ -2243,6 +2243,15 @@ if (readyPromise && typeof readyPromise.then === 'function') {
     window.__athens.toggleSky = context.toggleSky;
     window.__athens.toggleStats = context.toggleStats;
     window.__athens.sanityGeometry = sanityGeometry;
+
+    window.scene = scene;
+    window.camera = camera;
+    window.mainCharacter = mainCharacter;
+    window.controller = controller;
+    window.CHARACTER_HOVER =
+      typeof CHARACTER_HOVER !== 'undefined' ? CHARACTER_HOVER : window.CHARACTER_HOVER;
+    window.CHARACTER_HEIGHT =
+      typeof CHARACTER_HEIGHT !== 'undefined' ? CHARACTER_HEIGHT : window.CHARACTER_HEIGHT;
   }
 
   return context;

--- a/src/vegetation/trees.js
+++ b/src/vegetation/trees.js
@@ -321,7 +321,14 @@ function buildInstancingData(group, height) {
 
 async function loadTreeDefinition(name, file) {
   let gltfScene = null;
-  const url = assetUrl(`assets/models/${file}`);
+  let normalizedFile = typeof file === 'string' ? file : '';
+  if (normalizedFile.startsWith('Athens/')) {
+    normalizedFile = normalizedFile.slice('Athens/'.length);
+  }
+  const relativePath = normalizedFile.startsWith('assets/')
+    ? normalizedFile
+    : `assets/models/${normalizedFile}`;
+  const url = assetUrl(relativePath);
   try {
     const gltf = await loadGLTF(url);
     gltfScene = gltf.scene || (gltf.scenes && gltf.scenes[0]) || null;


### PR DESCRIPTION
## Summary
- expose core runtime references (scene, camera, mainCharacter, controller, hover constants) on `window` after initialization completes
- sanitize tree asset paths before loading GLBs so `olive.glb` resolves under `assets/`
- extend the environment-module timeout window to 5s to reduce noisy fallbacks

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e066551a9c83279ad76262e1c07eca