### PR TITLE
fix(boot): resilient env phase (fallback instead of abort) + diagnostics

### DIFF
--- a/src/boot/__tests__/withTimeout.test.ts
+++ b/src/boot/__tests__/withTimeout.test.ts
@@ -20,3 +20,8 @@ test('withTimeout rejects when there is no fallback', async () => {
     /timeout:unit-test-no-fallback/
   );
 });
+
+test('environment-module timeout resolves softly without fallback', async () => {
+  const result = await withTimeout(new Promise<never>(() => {}), 5, 'environment-module');
+  assert.equal(result, undefined);
+});

--- a/src/boot/withTimeout.ts
+++ b/src/boot/withTimeout.ts
@@ -1,33 +1,121 @@
-export async function withTimeout<T>(
-  p: Promise<T>,
-  ms: number,
-  label: string,
-  fallback?: (error: unknown) => T | Promise<T>
-): Promise<T> {
-  const timeoutMs = label === 'environment-module' ? 5000 : ms;
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  const timeoutError = new Error(`timeout:${label}`);
-  const timeoutPromise = new Promise<never>((_, reject) => {
-    timer = setTimeout(() => {
-      reject(timeoutError);
-    }, timeoutMs);
-  });
+type TimeoutFallback<T> = (error: unknown) => T | Promise<T>;
 
-  try {
-    return await Promise.race([p, timeoutPromise]);
-  } catch (error) {
-    if (fallback) {
-      console.warn(
-        `[Athens][Boot] ${label} timed out after ${timeoutMs}ms; running fallback.`,
-        error
-      );
-      return await fallback(error);
-    }
-
-    throw (error instanceof Error ? error : timeoutError);
-  } finally {
-    if (typeof timer !== 'undefined') {
-      clearTimeout(timer);
-    }
+declare global {
+  interface Window {
+    __ATHENS_BOOT_TIMEOUT?: number;
   }
+}
+
+const resolveDebugTimeout = (): number | undefined => {
+  try {
+    const candidate = (globalThis as typeof window | undefined)?.__ATHENS_BOOT_TIMEOUT;
+    return typeof candidate === 'number' && Number.isFinite(candidate) ? candidate : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+const toError = (value: unknown, fallbackError: Error): Error => {
+  if (value instanceof Error) {
+    return value;
+  }
+  const message = typeof value === 'string' ? value : `${value}`;
+  return message && message !== '[object Object]' ? new Error(message) : fallbackError;
+};
+
+export function withTimeout<T>(
+  p: Promise<T>,
+  ms: number | undefined,
+  label: string,
+  fallback?: TimeoutFallback<T>
+): Promise<T> {
+  const providedMs = typeof ms === 'number' && Number.isFinite(ms) ? ms : 0;
+  const debugOverride = label === 'environment-module' ? undefined : resolveDebugTimeout();
+  const timeoutMs =
+    label === 'environment-module'
+      ? providedMs > 0
+        ? Math.max(providedMs, 5000)
+        : 8000
+      : debugOverride ?? (providedMs > 0 ? providedMs : 2500);
+
+  const timeoutError = new Error(`timeout:${label}`);
+
+  return new Promise<T>((resolve, reject) => {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    let settled = false;
+
+    const clearTimer = () => {
+      if (typeof timer !== 'undefined') {
+        clearTimeout(timer);
+        timer = undefined;
+      }
+    };
+
+    const settleResolve = (value: T) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimer();
+      resolve(value);
+    };
+
+    const settleReject = (reason: unknown) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimer();
+      reject(reason);
+    };
+
+    const runFallback = (error: unknown, allowUndefined: boolean) => {
+      if (fallback) {
+        try {
+          Promise.resolve(fallback(error))
+            .then((value) => {
+              settleResolve(value);
+            })
+            .catch((fbError) => {
+              settleReject(toError(fbError, toError(error, timeoutError)));
+            });
+        } catch (fbError) {
+          settleReject(toError(fbError, toError(error, timeoutError)));
+        }
+        return;
+      }
+
+      if (allowUndefined) {
+        // @ts-expect-error allow undefined fallback for environment timeouts
+        settleResolve(undefined);
+        return;
+      }
+
+      settleReject(toError(error, timeoutError));
+    };
+
+    const handleTimeout = () => {
+      if (settled) {
+        return;
+      }
+      clearTimer();
+      console.warn('[Boot][withTimeout] timed out:', label, '→ using fallback');
+      runFallback(timeoutError, label === 'environment-module');
+    };
+
+    timer = setTimeout(handleTimeout, timeoutMs);
+
+    p.then(
+      (value) => {
+        settleResolve(value);
+      },
+      (error) => {
+        if (settled) {
+          return;
+        }
+        clearTimer();
+        runFallback(error, label === 'environment-module');
+      }
+    );
+  });
 }

--- a/src/entry/initializeAthens.js
+++ b/src/entry/initializeAthens.js
@@ -60,7 +60,7 @@ import { setExternalGroundTexture } from '../materials/groundGrass.js';
 // SKYSYS_END
 import { withTimeout as withBootTimeout } from '../boot/withTimeout.ts';
 
-const ENVIRONMENT_MODULE_TIMEOUT_MS = 2500;
+const ENVIRONMENT_MODULE_TIMEOUT_MS = 8000;
 
 function createDeferredEnvironmentModule(modulePromise) {
   return {
@@ -692,6 +692,18 @@ function createPlaceholderPlayer() {
 }
 
 export async function initializeAthens(options = {}) {
+  const now =
+    typeof performance !== 'undefined' && typeof performance.now === 'function'
+      ? () => performance.now()
+      : () => Date.now();
+  const bootStartTime = now();
+  const markBootPhase = (phase) => {
+    try {
+      const elapsed = (now() - bootStartTime).toFixed(1);
+      console.log(`[Athens][Boot] ${phase} @ ${elapsed}ms`);
+    } catch {}
+  };
+
   const setPhase = getPhaseSetter();
   const container = ensureContainerElement(options);
   container.style.position = container.style.position || 'relative';
@@ -857,6 +869,16 @@ export async function initializeAthens(options = {}) {
   if (typeof window !== 'undefined') {
     globalWindow = window;
     searchParams = new URLSearchParams(globalWindow.location.search);
+    try {
+      const url = new URL(globalWindow.location.href);
+      const bootTimeoutMsParam = url.searchParams.get('bootTimeoutMs');
+      if (bootTimeoutMsParam !== null) {
+        const parsed = Number(bootTimeoutMsParam);
+        if (Number.isFinite(parsed)) {
+          globalWindow.__ATHENS_BOOT_TIMEOUT = Math.max(2500, parsed);
+        }
+      }
+    } catch {}
   }
 
   try {
@@ -957,25 +979,64 @@ export async function initializeAthens(options = {}) {
     } catch {}
   };
 
+  let environmentUsedFallback = false;
+  const ensureFallbackEnvironment = () => {
+    environmentUsedFallback = true;
+    try {
+      const existing = scene.getObjectByName?.('athens-env-fallback-hemi');
+      if (!existing) {
+        const hemi = new THREE.HemisphereLight(0xffffff, 0x444444, 0.7);
+        hemi.name = 'athens-env-fallback-hemi';
+        scene.add(hemi);
+      }
+    } catch {}
+    try {
+      environmentManager?.setMode?.('day');
+    } catch {}
+    try {
+      renderer.setClearColor(DEFAULT_BACKGROUND_HEX, 1);
+    } catch {}
+    try {
+      scene.background = new THREE.Color(DEFAULT_BACKGROUND_HEX);
+    } catch {}
+    try {
+      scene.environment = null;
+    } catch {}
+  };
+
+  const handleEnvironmentFallback = (error) => {
+    ensureFallbackEnvironment();
+    try {
+      if (typeof console !== 'undefined' && typeof console.warn === 'function') {
+        console.warn('[Athens][Boot] env-fallback', error);
+      }
+    } catch {}
+    return undefined;
+  };
+
+  markBootPhase('env-start');
+  console.info('[Athens][Boot] env-start');
   try {
     setPhase('env-start');
   } catch {}
 
-  await withBootTimeout(
-    applyInitialEnvironment(),
-    2000,
-    'environment',
-    async () => {
-      try {
-        environmentManager?.setMode?.('day');
-      } catch {}
-      renderer.setClearColor(DEFAULT_BACKGROUND_HEX, 1);
-      try {
-        scene.background = new THREE.Color(DEFAULT_BACKGROUND_HEX);
-      } catch {}
-    }
-  );
+  try {
+    await withBootTimeout(
+      applyInitialEnvironment(),
+      2000,
+      'environment-module',
+      async (error) => handleEnvironmentFallback(error)
+    );
+  } catch (error) {
+    handleEnvironmentFallback(error);
+  }
 
+  if (!environmentUsedFallback) {
+    console.info('[Athens][Boot] env-ready');
+  } else {
+    console.info('[Athens][Boot] env-ready (fallback)');
+  }
+  markBootPhase('env-ready');
   try {
     setPhase('env-ready');
   } catch {}
@@ -1409,23 +1470,36 @@ export async function initializeAthens(options = {}) {
   sanitizeVec3(playerSpawn, SAFE_PLAYER_FALLBACK);
 
   // Landmarks & overlay
-  const landmarks = await loadLandmarks({
-    scene,
-    geoJsonUrl: options.geoJsonUrl ?? DEFAULT_GEOJSON_URL,
-    groundMeshes,
-    // CITYPLAN_START
-    layout,
-    layoutConfig
-    // CITYPLAN_END
-  });
-  registerDisposables(landmarks);
+  let landmarks = null;
+  try {
+    landmarks = await loadLandmarks({
+      scene,
+      geoJsonUrl: options.geoJsonUrl ?? DEFAULT_GEOJSON_URL,
+      groundMeshes,
+      // CITYPLAN_START
+      layout,
+      layoutConfig
+      // CITYPLAN_END
+    });
+    registerDisposables(landmarks);
+  } catch (error) {
+    logger.warn('[Athens][Landmarks] Failed to load landmarks.', error);
+    landmarks = null;
+  }
 
   const overlayCanvasId = options.overlayCanvasId ?? DEFAULT_OVERLAY_ID;
   const overlayCanvas = ensureOverlayCanvas(container, overlayCanvasId);
-  const overlay = await createLandmarkOverlay(overlayCanvas, {
-    geoJsonUrl: options.geoJsonUrl ?? DEFAULT_GEOJSON_URL
-  });
-  landmarks.featureLines?.updateResolution?.();
+  let overlay = null;
+  try {
+    overlay = await createLandmarkOverlay(overlayCanvas, {
+      geoJsonUrl: options.geoJsonUrl ?? DEFAULT_GEOJSON_URL
+    });
+    registerDisposables(overlay);
+  } catch (error) {
+    logger.warn('[Athens][Landmarks] Failed to create landmark overlay.', error);
+    overlay = null;
+  }
+  landmarks?.featureLines?.updateResolution?.();
 
   const ui = createOriginalUi({ container, overlayCanvas, environmentController });
   ui?.setTimeLabel?.(formatEnvironmentLabel(environmentController?.mode) || 'High Noon');
@@ -1766,6 +1840,8 @@ if (readyPromise && typeof readyPromise.then === 'function') {
   try {
     setPhase('scene-ready');
   } catch {}
+  markBootPhase('scene-ready');
+  console.info('[Athens][Boot] scene-ready');
 
   const resolveSavedState = () => {
     if (options?.savedState) {
@@ -2145,6 +2221,8 @@ if (readyPromise && typeof readyPromise.then === 'function') {
   try {
     setPhase('first-frame');
   } catch {}
+  markBootPhase('first-frame');
+  console.info('[Athens][Boot] first-frame');
   gameLoop.start();
 
   function startTimeOfDayCycle({ minutesPerDay = 10 } = {}) {
@@ -2253,6 +2331,9 @@ if (readyPromise && typeof readyPromise.then === 'function') {
     window.CHARACTER_HEIGHT =
       typeof CHARACTER_HEIGHT !== 'undefined' ? CHARACTER_HEIGHT : window.CHARACTER_HEIGHT;
   }
+
+  markBootPhase('ready');
+  console.info('[Athens][Boot] ready');
 
   return context;
 }


### PR DESCRIPTION
## Summary
- extend the boot timeout helper to support softer timeouts, optional overrides, and an environment-module fallback resolution path
- wrap environment initialization so slow HDR loads fall back to hemisphere lighting, and record boot diagnostics for each major phase
- keep non-critical landmark assets from stalling boot by catching their failures

## Testing
- npm test -- --test-name-pattern=withTimeout

------
https://chatgpt.com/codex/tasks/task_b_68e06fd8c1e883278ccb10139751e40f