### PR TITLE
fix(boot): resilient env phase (fallback instead of abort) + diagnostics

### DIFF
--- a/src/boot/__tests__/withTimeout.test.ts
+++ b/src/boot/__tests__/withTimeout.test.ts
@@ -20,3 +20,8 @@ test('withTimeout rejects when there is no fallback', async () => {
     /timeout:unit-test-no-fallback/
   );
 });
+
+test('environment-module timeout resolves softly without fallback', async () => {
+  const result = await withTimeout(new Promise<never>(() => {}), 5, 'environment-module');
+  assert.equal(result, undefined);
+});

--- a/src/boot/withTimeout.ts
+++ b/src/boot/withTimeout.ts
@@ -1,30 +1,75 @@
+declare global {
+  interface Window {
+    __ATHENS_BOOT_TIMEOUT?: number;
+  }
+}
+
+const resolveDebugTimeout = () => {
+  try {
+    const value = (typeof window !== 'undefined' && window.__ATHENS_BOOT_TIMEOUT) || undefined;
+    return typeof value === 'number' && Number.isFinite(value) ? Math.max(2500, value) : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+const normalizeError = (value: unknown, fallback: Error) => {
+  if (value instanceof Error) {
+    return value;
+  }
+  const message = typeof value === 'string' ? value : `${value}`;
+  return message && message !== '[object Object]' ? new Error(message) : fallback;
+};
+
 export async function withTimeout<T>(
   p: Promise<T>,
-  ms: number,
+  ms: number | undefined,
   label: string,
   fallback?: (error: unknown) => T | Promise<T>
 ): Promise<T> {
-  const timeoutMs = label === 'environment-module' ? 5000 : ms;
+  const providedMs = typeof ms === 'number' && Number.isFinite(ms) ? ms : 0;
+  const debugOverride = label === 'environment-module' ? undefined : resolveDebugTimeout();
+  const timeoutMs =
+    label === 'environment-module'
+      ? Math.max(providedMs, 8000)
+      : debugOverride ?? (providedMs > 0 ? providedMs : 2500);
   let timer: ReturnType<typeof setTimeout> | undefined;
   const timeoutError = new Error(`timeout:${label}`);
-  const timeoutPromise = new Promise<never>((_, reject) => {
+  const runFallback = async (error: unknown): Promise<T> => {
+    if (fallback) {
+      return await fallback(error);
+    }
+    if (label === 'environment-module') {
+      // Allow environment-module to resolve softly when no explicit fallback is provided.
+      // @ts-expect-error soft fallback may return undefined for environment phase.
+      return undefined;
+    }
+    throw normalizeError(error, timeoutError);
+  };
+
+  const timeoutPromise = new Promise<T>((resolve, reject) => {
     timer = setTimeout(() => {
-      reject(timeoutError);
+      try {
+        console.warn('[Boot][withTimeout] timed out:', label, '→ using fallback');
+      } catch {
+        // ignore console issues
+      }
+      runFallback(timeoutError)
+        .then(resolve)
+        .catch((error) => {
+          reject(normalizeError(error, timeoutError));
+        });
     }, timeoutMs);
   });
 
   try {
     return await Promise.race([p, timeoutPromise]);
   } catch (error) {
-    if (fallback) {
-      console.warn(
-        `[Athens][Boot] ${label} timed out after ${timeoutMs}ms; running fallback.`,
-        error
-      );
-      return await fallback(error);
+    try {
+      return await runFallback(error);
+    } catch (fallbackError) {
+      throw normalizeError(fallbackError, timeoutError);
     }
-
-    throw (error instanceof Error ? error : timeoutError);
   } finally {
     if (typeof timer !== 'undefined') {
       clearTimeout(timer);

--- a/src/entry/initializeAthens.js
+++ b/src/entry/initializeAthens.js
@@ -60,7 +60,7 @@ import { setExternalGroundTexture } from '../materials/groundGrass.js';
 // SKYSYS_END
 import { withTimeout as withBootTimeout } from '../boot/withTimeout.ts';
 
-const ENVIRONMENT_MODULE_TIMEOUT_MS = 2500;
+const ENVIRONMENT_MODULE_TIMEOUT_MS = 8000;
 
 function createDeferredEnvironmentModule(modulePromise) {
   return {
@@ -696,6 +696,22 @@ export async function initializeAthens(options = {}) {
   const container = ensureContainerElement(options);
   container.style.position = container.style.position || 'relative';
 
+  const now = () => {
+    if (typeof performance !== 'undefined' && typeof performance.now === 'function') {
+      return performance.now();
+    }
+    return Date.now();
+  };
+  const bootStartTime = now();
+  const markBootPhase = (phase) => {
+    try {
+      const elapsed = (now() - bootStartTime).toFixed(1);
+      console.log(`[Athens][Boot] ${phase} @ ${elapsed}ms`);
+    } catch {
+      // ignore console errors
+    }
+  };
+
   const { width: initialWidth, height: initialHeight } = computeContainerSize(container);
 
   // CITYPLAN_START
@@ -857,6 +873,13 @@ export async function initializeAthens(options = {}) {
   if (typeof window !== 'undefined') {
     globalWindow = window;
     searchParams = new URLSearchParams(globalWindow.location.search);
+    const bootTimeoutOverride = searchParams.get('bootTimeoutMs');
+    if (bootTimeoutOverride) {
+      const parsed = Number(bootTimeoutOverride);
+      if (Number.isFinite(parsed) && parsed >= 2500) {
+        globalWindow.__ATHENS_BOOT_TIMEOUT = parsed;
+      }
+    }
   }
 
   try {
@@ -957,24 +980,66 @@ export async function initializeAthens(options = {}) {
     } catch {}
   };
 
+  let environmentUsedFallback = false;
+  const ensureFallbackEnvironment = () => {
+    environmentUsedFallback = true;
+    try {
+      const existing = scene.getObjectByName?.('athens-env-fallback-hemi');
+      if (!existing) {
+        const hemi = new THREE.HemisphereLight(0xffffff, 0x444444, 0.7);
+        hemi.name = 'athens-env-fallback-hemi';
+        scene.add(hemi);
+      }
+    } catch {}
+    try {
+      environmentManager?.setMode?.('day');
+    } catch {}
+    try {
+      renderer.setClearColor(DEFAULT_BACKGROUND_HEX, 1);
+    } catch {}
+    try {
+      scene.background = new THREE.Color(DEFAULT_BACKGROUND_HEX);
+    } catch {}
+    try {
+      scene.environment = null;
+    } catch {}
+  };
+
+  const handleEnvironmentFallback = (error) => {
+    ensureFallbackEnvironment();
+    try {
+      console.warn('[Athens][Boot] env-fallback', error);
+    } catch {}
+    return undefined;
+  };
+
+  markBootPhase('env-start');
+  try {
+    console.info('[Athens][Boot] env-start');
+  } catch {}
   try {
     setPhase('env-start');
   } catch {}
 
-  await withBootTimeout(
-    applyInitialEnvironment(),
-    2000,
-    'environment',
-    async () => {
-      try {
-        environmentManager?.setMode?.('day');
-      } catch {}
-      renderer.setClearColor(DEFAULT_BACKGROUND_HEX, 1);
-      try {
-        scene.background = new THREE.Color(DEFAULT_BACKGROUND_HEX);
-      } catch {}
+  try {
+    await withBootTimeout(
+      applyInitialEnvironment(),
+      2000,
+      'environment',
+      (error) => handleEnvironmentFallback(error)
+    );
+  } catch (error) {
+    handleEnvironmentFallback(error);
+  }
+
+  try {
+    if (environmentUsedFallback) {
+      console.info('[Athens][Boot] env-ready (fallback)');
+    } else {
+      console.info('[Athens][Boot] env-ready');
     }
-  );
+  } catch {}
+  markBootPhase('env-ready');
 
   try {
     setPhase('env-ready');
@@ -1409,23 +1474,37 @@ export async function initializeAthens(options = {}) {
   sanitizeVec3(playerSpawn, SAFE_PLAYER_FALLBACK);
 
   // Landmarks & overlay
-  const landmarks = await loadLandmarks({
-    scene,
-    geoJsonUrl: options.geoJsonUrl ?? DEFAULT_GEOJSON_URL,
-    groundMeshes,
-    // CITYPLAN_START
-    layout,
-    layoutConfig
-    // CITYPLAN_END
-  });
-  registerDisposables(landmarks);
+  let landmarks = null;
+  try {
+    landmarks = await loadLandmarks({
+      scene,
+      geoJsonUrl: options.geoJsonUrl ?? DEFAULT_GEOJSON_URL,
+      groundMeshes,
+      // CITYPLAN_START
+      layout,
+      layoutConfig
+      // CITYPLAN_END
+    });
+    if (landmarks) {
+      registerDisposables(landmarks);
+    }
+  } catch (error) {
+    logger.warn('[Athens][Boot] Failed to load landmarks.', error);
+    landmarks = null;
+  }
 
   const overlayCanvasId = options.overlayCanvasId ?? DEFAULT_OVERLAY_ID;
   const overlayCanvas = ensureOverlayCanvas(container, overlayCanvasId);
-  const overlay = await createLandmarkOverlay(overlayCanvas, {
-    geoJsonUrl: options.geoJsonUrl ?? DEFAULT_GEOJSON_URL
-  });
-  landmarks.featureLines?.updateResolution?.();
+  let overlay = null;
+  try {
+    overlay = await createLandmarkOverlay(overlayCanvas, {
+      geoJsonUrl: options.geoJsonUrl ?? DEFAULT_GEOJSON_URL
+    });
+  } catch (error) {
+    logger.warn('[Athens][Boot] Failed to create landmark overlay.', error);
+    overlay = null;
+  }
+  landmarks?.featureLines?.updateResolution?.();
 
   const ui = createOriginalUi({ container, overlayCanvas, environmentController });
   ui?.setTimeLabel?.(formatEnvironmentLabel(environmentController?.mode) || 'High Noon');
@@ -1764,6 +1843,10 @@ if (readyPromise && typeof readyPromise.then === 'function') {
   });
 
   try {
+    console.info('[Athens][Boot] scene-ready');
+  } catch {}
+  markBootPhase('scene-ready');
+  try {
     setPhase('scene-ready');
   } catch {}
 
@@ -1952,8 +2035,8 @@ if (readyPromise && typeof readyPromise.then === 'function') {
       camera.aspect = aspect;
     }
     camera.updateProjectionMatrix();
-    overlay.requestRender();
-    landmarks.featureLines?.updateResolution?.();
+    overlay?.requestRender?.();
+    landmarks?.featureLines?.updateResolution?.();
   };
   window.addEventListener('resize', resizeHandler);
 
@@ -2004,7 +2087,7 @@ if (readyPromise && typeof readyPromise.then === 'function') {
       const npcContext = { groundMeshes, skippedLargeDt: Boolean(skippedLargeDt) };
       mainCharacter?.update?.(delta, npcContext);
       npcSystem?.update?.(delta, { skippedLargeDt: Boolean(skippedLargeDt) });
-      landmarks.update?.(camera);
+      landmarks?.update?.(camera);
 
       controller.update(delta, getInput(), collisionWorld);
 
@@ -2143,6 +2226,10 @@ if (readyPromise && typeof readyPromise.then === 'function') {
   const flyBypass = installFlyBypass({ state: flyBypassState, input: flyBypassInput });
 
   try {
+    console.info('[Athens][Boot] first-frame');
+  } catch {}
+  markBootPhase('first-frame');
+  try {
     setPhase('first-frame');
   } catch {}
   gameLoop.start();
@@ -2253,6 +2340,11 @@ if (readyPromise && typeof readyPromise.then === 'function') {
     window.CHARACTER_HEIGHT =
       typeof CHARACTER_HEIGHT !== 'undefined' ? CHARACTER_HEIGHT : window.CHARACTER_HEIGHT;
   }
+
+  try {
+    console.info('[Athens][Boot] ready');
+  } catch {}
+  markBootPhase('ready');
 
   return context;
 }


### PR DESCRIPTION
## Summary
- soften the boot timeout helper by extending the environment-module limit, honoring an optional debug override, and resolving softly when HDR loading lags
- instrument boot with phase timing markers, a query-string timeout override, and a resilient environment setup that applies hemisphere lighting on failure while still signalling readiness
- guard landmark and overlay loading plus related updates so non-critical assets no longer stall later boot phases

## Testing
- npm test -- --test-name-pattern=withTimeout

------
https://chatgpt.com/codex/tasks/task_b_68e06fd8c1e883278ccb10139751e40f