### PR TITLE
fix(boot): resilient env phase (soft timeouts, no abort); increased budgets + diagnostics

### DIFF
--- a/src/entry/initializeAthens.js
+++ b/src/entry/initializeAthens.js
@@ -60,6 +60,18 @@ import { setExternalGroundTexture } from '../materials/groundGrass.js';
 // SKYSYS_END
 import { withTimeout as withBootTimeout } from '../boot/withTimeout.ts';
 
+const __t0 = (typeof performance !== 'undefined' && typeof performance.now === 'function'
+  ? performance.now()
+  : Date.now());
+const __mark = (phase) => {
+  const now = typeof performance !== 'undefined' && typeof performance.now === 'function'
+    ? performance.now()
+    : Date.now();
+  try {
+    console.log(`[Athens][Boot] ${phase} @ ${(now - __t0).toFixed(1)}ms`);
+  } catch {}
+};
+
 const ENVIRONMENT_MODULE_TIMEOUT_MS = 8000;
 
 function createDeferredEnvironmentModule(modulePromise) {
@@ -764,7 +776,7 @@ export async function initializeAthens(options = {}) {
     environmentModulePromise,
     ENVIRONMENT_MODULE_TIMEOUT_MS,
     'environment-module',
-    () => createDeferredEnvironmentModule(environmentModulePromise)
+    () => createDeferredEnvironmentModule(environmentModulePromise) // fallback: never reject
   );
   const { createEnvironment } = environmentModule;
 
@@ -875,7 +887,7 @@ export async function initializeAthens(options = {}) {
       if (bootTimeoutMsParam !== null) {
         const parsed = Number(bootTimeoutMsParam);
         if (Number.isFinite(parsed)) {
-          globalWindow.__ATHENS_BOOT_TIMEOUT = Math.max(2500, parsed);
+          globalWindow.__ATHENS_BOOT_TIMEOUT = Math.max(8000, parsed);
         }
       }
     } catch {}
@@ -949,6 +961,7 @@ export async function initializeAthens(options = {}) {
     try {
       return await Promise.race([p, to]);
     } catch {
+      // SOFT TIMEOUT: resolve fallback, never propagate
       return typeof fb === 'function' ? fb() : fb;
     } finally {
       if (t) {
@@ -1016,6 +1029,7 @@ export async function initializeAthens(options = {}) {
 
   markBootPhase('env-start');
   console.info('[Athens][Boot] env-start');
+  __mark('env-start');
   try {
     setPhase('env-start');
   } catch {}
@@ -1023,8 +1037,8 @@ export async function initializeAthens(options = {}) {
   try {
     await withBootTimeout(
       applyInitialEnvironment(),
-      2000,
-      'environment-module',
+      7000,
+      'environment',
       async (error) => handleEnvironmentFallback(error)
     );
   } catch (error) {
@@ -1037,6 +1051,7 @@ export async function initializeAthens(options = {}) {
     console.info('[Athens][Boot] env-ready (fallback)');
   }
   markBootPhase('env-ready');
+  __mark('env-ready');
   try {
     setPhase('env-ready');
   } catch {}
@@ -1838,6 +1853,7 @@ if (readyPromise && typeof readyPromise.then === 'function') {
     playerNameCandidates: ['MainCharacter', 'Player']
   });
 
+  __mark('scene-ready');
   try {
     setPhase('scene-ready');
   } catch {}
@@ -2219,6 +2235,7 @@ if (readyPromise && typeof readyPromise.then === 'function') {
 
   const flyBypass = installFlyBypass({ state: flyBypassState, input: flyBypassInput });
 
+  __mark('first-frame');
   try {
     setPhase('first-frame');
   } catch {}
@@ -2333,6 +2350,7 @@ if (readyPromise && typeof readyPromise.then === 'function') {
       typeof CHARACTER_HEIGHT !== 'undefined' ? CHARACTER_HEIGHT : window.CHARACTER_HEIGHT;
   }
 
+  __mark('ready');
   markBootPhase('ready');
   console.info('[Athens][Boot] ready');
 

--- a/src/entry/landing.js
+++ b/src/entry/landing.js
@@ -30,6 +30,8 @@ let initializedContext = null;
 let bootPromise = null;
 let bootLogEmitted = false;
 
+const DEFAULT_BOOT_DEADLINE_MS = 10000;
+
 const watchdog = attachWatchdog();
 registerSW();
 setLoopWatchdog(watchdog);
@@ -110,6 +112,57 @@ function renderBootFailureOverlay(error) {
   buttonRow.appendChild(swButton);
 
   document.body.appendChild(overlay);
+}
+
+function renderBootSoftTimeoutNotice(lastPhase) {
+  if (typeof document === 'undefined') {
+    return;
+  }
+  const id = 'athens-boot-soft-timeout';
+  const message = lastPhase
+    ? `Athens is still starting… (last phase: ${lastPhase || 'unknown'})`
+    : 'Athens is still starting…';
+
+  const updateContent = (node) => {
+    try {
+      node.textContent = message;
+    } catch {}
+  };
+
+  const existing = document.getElementById(id);
+  if (existing) {
+    updateContent(existing);
+    return;
+  }
+
+  if (!document.body) {
+    return;
+  }
+
+  const notice = document.createElement('div');
+  notice.id = id;
+  notice.style.cssText =
+    'position:fixed;bottom:16px;right:16px;z-index:9998;padding:12px 16px;border-radius:8px;background:rgba(17,25,40,0.88);color:#fff;font-family:system-ui,sans-serif;font-size:13px;max-width:280px;box-shadow:0 12px 24px rgba(0,0,0,0.35);pointer-events:none;';
+  updateContent(notice);
+  document.body.appendChild(notice);
+
+  try {
+    setTimeout(() => {
+      try {
+        notice.remove();
+      } catch {}
+    }, 20000);
+  } catch {}
+}
+
+function resolveBootDeadlineMs() {
+  try {
+    const candidate = typeof window !== 'undefined' ? window.__ATHENS_BOOT_TIMEOUT : undefined;
+    if (typeof candidate === 'number' && Number.isFinite(candidate)) {
+      return Math.max(8000, candidate);
+    }
+  } catch {}
+  return DEFAULT_BOOT_DEADLINE_MS;
 }
 
 const ensureFallback = () => {
@@ -293,17 +346,29 @@ async function runAthens(options = {}) {
     setPhase('init-start');
 
     const initializationTask = initializeAthens({ ...options, container });
+    const bootDeadlineMs = resolveBootDeadlineMs();
     let bootTimer = null;
     let context;
     try {
-      const watchdogTimer = new Promise((_, reject) => {
-        bootTimer = setTimeout(() => {
-          const lastPhase = window.__athensBoot?.phase;
-          reject(new Error(`Boot timeout; last phase=${lastPhase}`));
-        }, 10000);
-      });
+      bootTimer = setTimeout(() => {
+        let lastPhase;
+        try {
+          lastPhase = typeof window !== 'undefined' ? window.__athensBoot?.phase : undefined;
+        } catch {}
+        try {
+          console.warn(`[Boot] Soft timeout; last phase=${lastPhase}. Continuing with fallbacks.`);
+        } catch {}
+        try {
+          if (typeof window !== 'undefined') {
+            window.__athensBootWarned = true;
+          }
+        } catch {}
+        try {
+          renderBootSoftTimeoutNotice(lastPhase);
+        } catch {}
+      }, bootDeadlineMs);
 
-      context = await Promise.race([initializationTask, watchdogTimer]);
+      context = await initializationTask;
     } finally {
       if (bootTimer) {
         clearTimeout(bootTimer);


### PR DESCRIPTION
## Summary
- extend environment boot budgets and ensure timeouts resolve with safe fallbacks instead of aborting the pipeline
- add boot phase timestamp logging to trace slow steps and allow query-string overrides to use higher minimum thresholds
- convert the landing watchdog to a soft warning that surfaces a non-blocking notice while keeping initialization alive

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e077e0c1588327adcc8d2adc24e3d9