### PR TITLE
Adjust follow camera offset for improved perspective

### DIFF
--- a/src/camera/followCamera.js
+++ b/src/camera/followCamera.js
@@ -28,7 +28,7 @@ export function createFollowCamera(
   camera,
   target,
   {
-    offset = new THREE.Vector3(0, 2.2, -6),
+    offset = new THREE.Vector3(0, 3.5, -8),
     lerp = 0.12,
     lookAtOffset = new THREE.Vector3(0, 1.5, 0),
     yawSpeed = DEFAULT_YAW_SPEED,

--- a/src/config/movement.ts
+++ b/src/config/movement.ts
@@ -88,7 +88,7 @@ export const movementConfig: MovementConfig = {
   },
   camera: {
     follow: {
-      offset: { x: 0, y: 2.2, z: -6 },
+      offset: { x: 0, y: 3.5, z: -8 },
       lerp: 0.12,
       lookAtOffset: { x: 0, y: 1.5, z: 0 }
     },


### PR DESCRIPTION
## Summary
- move the default follow camera offset higher and further back for a wider perspective
- align the movement configuration camera offset with the new follow camera default

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e38956b1a08327beba8202bcc154ec