### PR TITLE
Add follow camera zoom controls and fix character hovering

### DIFF
--- a/src/camera/followCamera.js
+++ b/src/camera/followCamera.js
@@ -14,6 +14,7 @@ const DEFAULT_PITCH_SPEED = 1.6; // radians per second
 const MAX_DT = 0.25;
 const DEFAULT_DT = 1 / 60;
 const DEFAULT_POINTER_SENSITIVITY = 0.0025;
+const DEFAULT_ZOOM_SPEED = 0.0015;
 
 function computeBaseParameters(offset) {
   const offsetVector = offset.clone();
@@ -33,7 +34,10 @@ export function createFollowCamera(
     lookAtOffset = new THREE.Vector3(0, 1.5, 0),
     yawSpeed = DEFAULT_YAW_SPEED,
     pitchSpeed = DEFAULT_PITCH_SPEED,
-    pointerSensitivity = DEFAULT_POINTER_SENSITIVITY
+    pointerSensitivity = DEFAULT_POINTER_SENSITIVITY,
+    minDistance = null,
+    maxDistance = null,
+    zoomSpeed = DEFAULT_ZOOM_SPEED
   } = {}
 ) {
   const options = {
@@ -45,26 +49,72 @@ export function createFollowCamera(
     pointerSensitivity:
       Number.isFinite(pointerSensitivity) && pointerSensitivity > 0
         ? pointerSensitivity
-        : DEFAULT_POINTER_SENSITIVITY
+        : DEFAULT_POINTER_SENSITIVITY,
+    zoomSpeed:
+      Number.isFinite(zoomSpeed) && zoomSpeed > 0
+        ? zoomSpeed
+        : DEFAULT_ZOOM_SPEED
   };
 
   let currentTarget = target || null;
   const base = computeBaseParameters(options.offset);
+  options.minDistance = Number.isFinite(minDistance) && minDistance > 0
+    ? Math.max(minDistance, 1e-3)
+    : Math.max(1, base.radius * 0.35);
+  options.maxDistance = Number.isFinite(maxDistance) && maxDistance > options.minDistance
+    ? maxDistance
+    : Math.max(base.radius, options.minDistance * 4);
   const rigState = (() => {
     if (!camera || typeof camera !== 'object') {
-      return { yaw: 0, pitch: 0, distance: base.radius };
+      return {
+        yaw: 0,
+        pitch: 0,
+        distance: base.radius,
+        minDistance: options.minDistance,
+        maxDistance: options.maxDistance
+      };
     }
     const existing = (camera).__rigState;
     if (existing && typeof existing === 'object') {
       if (!Number.isFinite(existing.distance) || existing.distance <= 0) {
         existing.distance = base.radius;
       }
+      if (!Number.isFinite(existing.minDistance) || existing.minDistance <= 0) {
+        existing.minDistance = options.minDistance;
+      }
+      if (!Number.isFinite(existing.maxDistance) || existing.maxDistance <= 0) {
+        existing.maxDistance = options.maxDistance;
+      }
       return existing;
     }
-    const state = { yaw: 0, pitch: 0, distance: base.radius };
+    const state = {
+      yaw: 0,
+      pitch: 0,
+      distance: base.radius,
+      minDistance: options.minDistance,
+      maxDistance: options.maxDistance
+    };
     (camera).__rigState = state;
     return state;
   })();
+
+  const clampDistance = (value) => {
+    const currentMin = Number.isFinite(rigState.minDistance) && rigState.minDistance > 0
+      ? rigState.minDistance
+      : options.minDistance;
+    const currentMax = Number.isFinite(rigState.maxDistance) && rigState.maxDistance > currentMin
+      ? rigState.maxDistance
+      : options.maxDistance;
+    if (!Number.isFinite(value)) {
+      return THREE.MathUtils.clamp(base.radius, currentMin, currentMax);
+    }
+    const clamped = THREE.MathUtils.clamp(value, currentMin, currentMax);
+    return clamped > 1e-6 ? clamped : currentMin;
+  };
+
+  rigState.minDistance = clampDistance(rigState.minDistance);
+  rigState.maxDistance = Math.max(clampDistance(rigState.maxDistance), rigState.minDistance + 1e-3);
+  rigState.distance = clampDistance(rigState.distance);
 
   const sanitizeYaw = (value) => {
     if (!Number.isFinite(value)) {
@@ -87,6 +137,7 @@ export function createFollowCamera(
   let pointerActive = false;
   let pointerLookDeltaX = 0;
   let pointerLookDeltaY = 0;
+  let wheelListenerAttached = false;
 
   const resetPointerState = () => {
     pointerPointerId = null;
@@ -192,6 +243,29 @@ export function createFollowCamera(
     }
   };
 
+  const applyZoomFactor = (deltaY = 0) => {
+    if (!Number.isFinite(deltaY) || deltaY === 0) {
+      return;
+    }
+    const current = clampDistance(rigState.distance);
+    const scale = Math.exp(deltaY * options.zoomSpeed);
+    rigState.distance = clampDistance(current * scale);
+  };
+
+  const handleWheel = (event) => {
+    if (!event) {
+      return;
+    }
+    const deltaY = Number.isFinite(event.deltaY) ? event.deltaY : 0;
+    if (deltaY === 0) {
+      return;
+    }
+    if (typeof event.preventDefault === 'function') {
+      event.preventDefault();
+    }
+    applyZoomFactor(deltaY);
+  };
+
   const documentListeners = [];
   const windowListeners = [];
 
@@ -219,6 +293,10 @@ export function createFollowCamera(
     element.removeEventListener?.('lostpointercapture', handlePointerCancel);
     element.removeEventListener?.('pointerleave', handlePointerCancel);
     element.removeEventListener?.('pointerout', handlePointerCancel);
+    if (wheelListenerAttached) {
+      element.removeEventListener?.('wheel', handleWheel);
+      wheelListenerAttached = false;
+    }
     if (pointerPointerId !== null && typeof element.releasePointerCapture === 'function') {
       try {
         element.releasePointerCapture(pointerPointerId);
@@ -246,6 +324,10 @@ export function createFollowCamera(
     pointerElement.addEventListener('lostpointercapture', handlePointerCancel);
     pointerElement.addEventListener('pointerleave', handlePointerCancel);
     pointerElement.addEventListener('pointerout', handlePointerCancel);
+    if (!wheelListenerAttached) {
+      pointerElement.addEventListener('wheel', handleWheel, { passive: false });
+      wheelListenerAttached = true;
+    }
   };
 
   const setPointerElement = (element) => {
@@ -281,9 +363,10 @@ export function createFollowCamera(
 
     const yaw = sanitizeYaw(rigState.yaw);
     const pitch = sanitizePitch(rigState.pitch);
+    rigState.distance = clampDistance(rigState.distance);
     const radius = Number.isFinite(rigState.distance) && rigState.distance > 1e-3
       ? rigState.distance
-      : base.radius;
+      : clampDistance(base.radius);
 
     currentTarget.getWorldPosition(targetWorldPosition);
 
@@ -369,6 +452,14 @@ export function createFollowCamera(
       rigState.pitch += pointerDeltaY * options.pointerSensitivity;
     }
 
+    const axisZoom = keyboardState?.axis && Object.prototype.hasOwnProperty.call(keyboardState.axis, 'zoom')
+      ? keyboardState.axis.zoom
+      : null;
+    if (Number.isFinite(axisZoom) && axisZoom !== 0) {
+      const zoomDelta = axisZoom * dtSafe * -60;
+      applyZoomFactor(zoomDelta);
+    }
+
     rigState.pitch = sanitizePitch(rigState.pitch);
     rigState.yaw = sanitizeYaw(rigState.yaw);
 
@@ -414,7 +505,9 @@ export function createFollowCamera(
     const worldPitch = horizontal > 1e-6 ? Math.atan2(tempPosition.y, horizontal) : 0;
     const worldYaw = Math.atan2(tempPosition.x, tempPosition.z);
     if (!Number.isFinite(rigState.distance) || rigState.distance <= 0) {
-      rigState.distance = distance > 1e-6 ? distance : base.radius;
+      rigState.distance = clampDistance(distance > 1e-6 ? distance : base.radius);
+    } else {
+      rigState.distance = clampDistance(distance);
     }
     rigState.pitch = sanitizePitch(worldPitch);
     rigState.yaw = sanitizeYaw(worldYaw);

--- a/src/camera/seedCameraBehindPlayer.js
+++ b/src/camera/seedCameraBehindPlayer.js
@@ -75,6 +75,12 @@ export function seedCameraBehindPlayer(player, camera, opts = {}) {
     rigState.yaw = yaw;
     rigState.pitch = pitch;
     rigState.distance = followDistance;
+    if (Number.isFinite(rigState.minDistance) && rigState.minDistance > 0) {
+      rigState.distance = Math.max(rigState.distance, rigState.minDistance);
+    }
+    if (Number.isFinite(rigState.maxDistance) && rigState.maxDistance > 0) {
+      rigState.distance = Math.min(rigState.distance, rigState.maxDistance);
+    }
   }
 }
 

--- a/src/config/movement.ts
+++ b/src/config/movement.ts
@@ -17,6 +17,9 @@ export interface CameraFollowConfig {
   offset?: { x: number; y: number; z: number };
   lerp?: number;
   lookAtOffset?: { x: number; y: number; z: number };
+  minDistance?: number;
+  maxDistance?: number;
+  zoomSpeed?: number;
 }
 
 export interface CameraSeedConfig {
@@ -90,7 +93,10 @@ export const movementConfig: MovementConfig = {
     follow: {
       offset: { x: 0, y: 3.5, z: -8 },
       lerp: 0.12,
-      lookAtOffset: { x: 0, y: 1.5, z: 0 }
+      lookAtOffset: { x: 0, y: 1.5, z: 0 },
+      minDistance: 4,
+      maxDistance: 18,
+      zoomSpeed: 0.0012
     },
     seed: {
       followDistance: 6,

--- a/src/entry/initializeAthens.js
+++ b/src/entry/initializeAthens.js
@@ -50,6 +50,7 @@ import {
   sanitizeVec3,
   safeSetVec3
 } from '../utils/sanitize.ts';
+import { ensureFeetAtLocalZero } from '../utils/spawn.ts';
 import { CUSTOM_AMBIENT_TRACKS } from '../audio/customAmbientTracks.generated.ts';
 import { initAmbient, AmbientAPI, AMBIENT_TRACKS, registerExternalAmbientTracks } from '../audio/ambient.ts';
 import { createSanityGeometryController } from '../debug/sanityGeometry.js';
@@ -1746,6 +1747,8 @@ const ensureMainCharacterPlacement = () => {
   if (!resolvedPlayer) {
     return null;
   }
+  ensureFeetAtLocalZero(resolvedPlayer);
+  resolvedPlayer.updateMatrixWorld?.(true);
   placeAtSpawn(resolvedPlayer);
   sanitizeVec3(resolvedPlayer.position, SAFE_PLAYER_FALLBACK);
   if (placeholderPlayer?.parent) {
@@ -1822,6 +1825,15 @@ if (readyPromise && typeof readyPromise.then === 'function') {
   const followOffset = cameraFollowConfig?.offset ?? { x: 0, y: 50, z: -10 };
   const followLookOffset = cameraFollowConfig?.lookAtOffset ?? { x: 0, y: 1.5, z: 0 };
   const followLerp = Number.isFinite(cameraFollowConfig?.lerp) ? cameraFollowConfig.lerp : 0.12;
+  const followMinDistance = Number.isFinite(cameraFollowConfig?.minDistance)
+    ? Math.max(cameraFollowConfig.minDistance, 0.5)
+    : null;
+  const followMaxDistance = Number.isFinite(cameraFollowConfig?.maxDistance)
+    ? Math.max(cameraFollowConfig.maxDistance, followMinDistance ? followMinDistance + 0.01 : 0.5)
+    : null;
+  const followZoomSpeed = Number.isFinite(cameraFollowConfig?.zoomSpeed) && cameraFollowConfig.zoomSpeed > 0
+    ? cameraFollowConfig.zoomSpeed
+    : undefined;
   const followCamera = createFollowCamera(camera, playerObject, {
     offset: new THREE.Vector3(
       Number.isFinite(followOffset?.x) ? followOffset.x : 0,
@@ -1833,7 +1845,10 @@ if (readyPromise && typeof readyPromise.then === 'function') {
       Number.isFinite(followLookOffset?.x) ? followLookOffset.x : 0,
       Number.isFinite(followLookOffset?.y) ? followLookOffset.y : 1.5,
       Number.isFinite(followLookOffset?.z) ? followLookOffset.z : 0
-    )
+    ),
+    minDistance: followMinDistance ?? undefined,
+    maxDistance: followMaxDistance ?? undefined,
+    zoomSpeed: followZoomSpeed
   });
   followCamera.setPointerLockElement?.(renderer.domElement);
 


### PR DESCRIPTION
## Summary
- allow the follow camera distance to be adjusted with scroll/gamepad input and configurable limits
- clamp seeded camera distances to the follow camera limits and expose defaults in the movement config
- ensure the main character snaps to the ground after loading so it no longer hovers

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_b_68e39f9686748327a4b9b6bd2bc0f15a