### PR TITLE
Slow down time-of-day cycle

### DIFF
--- a/src/entry/initializeAthens.js
+++ b/src/entry/initializeAthens.js
@@ -2243,7 +2243,7 @@ if (readyPromise && typeof readyPromise.then === 'function') {
   console.info('[Athens][Boot] first-frame');
   gameLoop.start();
 
-  function startTimeOfDayCycle({ minutesPerDay = 10 } = {}) {
+  function startTimeOfDayCycle({ minutesPerDay = 20 } = {}) {
     const order = ['dawn', 'day', 'golden_hour', 'dusk', 'night', 'midnight'];
     let i = Math.max(0, order.indexOf(String(environmentController.mode).toLowerCase()));
     const stepMs = Math.max(5000, (minutesPerDay * 60_000) / order.length);


### PR DESCRIPTION
## Summary
- lengthened the default time-of-day cycle to 20 minutes so each sky phase lasts longer

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e3a0a57e848327b634fb0bc757b65b