### PR TITLE
Fix ensureFeetAtLocalZero to align character with ground

### DIFF
--- a/src/utils/spawn.ts
+++ b/src/utils/spawn.ts
@@ -34,18 +34,34 @@ export function collectMeshesByName(root: THREE.Object3D, substrings: string[]):
 
 export function footOffsetY(obj: THREE.Object3D): number {
   const box = new THREE.Box3().setFromObject(obj);
-  if (!isFinite(box.min.y) || !isFinite(box.max.y)) {
+  if (!Number.isFinite(box.min.y) || !Number.isFinite(box.max.y)) {
     return 0;
   }
-  return box.min.y - obj.position.y;
+
+  const parent = obj.parent;
+  const min = box.min.clone();
+
+  if (parent?.isObject3D) {
+    parent.worldToLocal(min);
+  }
+
+  return Number.isFinite(min.y) ? min.y : 0;
 }
 
 export function ensureFeetAtLocalZero(obj: THREE.Object3D) {
-  const offset = footOffsetY(obj);
-  if (isFinite(offset) && offset < 0) {
-    obj.position.y -= offset;
-    obj.updateMatrixWorld(true);
+  if (!obj) {
+    return;
   }
+
+  obj.updateMatrixWorld(true);
+
+  const offset = footOffsetY(obj);
+  if (!Number.isFinite(offset) || Math.abs(offset) <= 1e-6) {
+    return;
+  }
+
+  obj.position.y -= offset;
+  obj.updateMatrixWorld(true);
 }
 
 export function groundYAt(

--- a/tests/spawn-hover.test.js
+++ b/tests/spawn-hover.test.js
@@ -3,6 +3,7 @@ import test from 'node:test';
 import * as THREE from 'three';
 
 import { CharacterController } from '../src/controls/CharacterController.ts';
+import { ensureFeetAtLocalZero } from '../src/utils/spawn.ts';
 
 test('CHARACTER_HOVER scales with character height', () => {
   // This test verifies that CHARACTER_HOVER is calculated based on CHARACTER_HEIGHT
@@ -125,5 +126,41 @@ test('character controller allows overriding hover compensation on attach', () =
   assert.ok(
     Math.abs(controller.position.y - controllerStart.y) < 1e-6,
     'controller center should remain unchanged when overriding hover'
+  );
+});
+
+test('ensureFeetAtLocalZero lowers floating models to parent local zero', () => {
+  const parent = new THREE.Group();
+  const mesh = new THREE.Mesh(new THREE.BoxGeometry(1, 2, 1));
+  mesh.position.y = 1.5;
+  parent.add(mesh);
+  parent.position.y = 3;
+  parent.updateMatrixWorld(true);
+
+  ensureFeetAtLocalZero(parent);
+  parent.updateMatrixWorld(true);
+
+  const box = new THREE.Box3().setFromObject(parent);
+  assert.ok(Math.abs(box.min.y) < 1e-6, 'model feet should rest at world zero after normalization');
+});
+
+test('ensureFeetAtLocalZero respects parent transforms when adjusting children', () => {
+  const parent = new THREE.Group();
+  parent.position.y = 5;
+
+  const child = new THREE.Group();
+  const mesh = new THREE.Mesh(new THREE.BoxGeometry(1, 2, 1));
+  mesh.position.y = 1.25;
+  child.add(mesh);
+  parent.add(child);
+  parent.updateMatrixWorld(true);
+
+  ensureFeetAtLocalZero(child);
+  parent.updateMatrixWorld(true);
+
+  const box = new THREE.Box3().setFromObject(child);
+  assert.ok(
+    Math.abs(box.min.y - parent.position.y) < 1e-6,
+    'child model feet should align with parent local origin in world space'
   );
 });


### PR DESCRIPTION
## Summary
- update the spawn utility to compute foot offsets in parent space and correct both positive and negative offsets
- ensure ensureFeetAtLocalZero normalizes model height before placement
- expand spawn hover tests to cover floating models and parent transform handling

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68e3ae40560c8327b2f269636407c33c