### PR TITLE
Expand default follow camera standoff

### DIFF
--- a/src/camera/followCamera.js
+++ b/src/camera/followCamera.js
@@ -28,7 +28,7 @@ export function createFollowCamera(
   camera,
   target,
   {
-    offset = new THREE.Vector3(0, 2.2, -6),
+    offset = new THREE.Vector3(0, 4, -9),
     lerp = 0.12,
     lookAtOffset = new THREE.Vector3(0, 1.5, 0),
     yawSpeed = DEFAULT_YAW_SPEED,

--- a/src/config/movement.ts
+++ b/src/config/movement.ts
@@ -88,12 +88,12 @@ export const movementConfig: MovementConfig = {
   },
   camera: {
     follow: {
-      offset: { x: 0, y: 2.2, z: -6 },
+      offset: { x: 0, y: 4, z: -9 },
       lerp: 0.12,
       lookAtOffset: { x: 0, y: 1.5, z: 0 }
     },
     seed: {
-      followDistance: 6,
+      followDistance: 9.8,
       shoulderHeight: 1.6,
       pitchDeg: -15
     }


### PR DESCRIPTION
## Summary
- push the default follow camera offset higher and farther back for more space around the avatar
- align the movement configuration follow offset and seed follow distance with the new default rig spacing

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e38956b1a08327beba8202bcc154ec