### PR TITLE
Document flight hotkeys

### DIFF
--- a/docs/hotkeys.md
+++ b/docs/hotkeys.md
@@ -13,6 +13,9 @@ This project maps movement, camera, and interaction inputs through the hotkey sy
 | Look Right | `→` | Keyboard only camera yaw. |
 | Look Up | `↑` | Keyboard only camera pitch. |
 | Look Down | `↓` | Keyboard only camera pitch. |
+| Toggle Flight | `X` | Alias `F` also toggles flight mode. |
+| Fly Up | `Space` | Aliases `E`, fallback for the space bar, and `Space` key code variations. |
+| Fly Down | `Shift` | Aliases `Q`, `C`, and either control key also descend. |
 
 ## Changing the bindings
 

--- a/src/config/hotkeys.ts
+++ b/src/config/hotkeys.ts
@@ -393,14 +393,14 @@ const HOTKEY_DISPLAY_CONFIG: HotkeyDisplayConfig[] = [
     id: 'flight.toggle',
     actions: [flightActions.toggle.id],
     description: 'Toggle Flight',
-    contexts: ['hud'],
+    contexts: ['hud', 'docs'],
     order: 40
   },
   {
     id: 'flight.vertical',
     actions: [flightActions.ascend.id, flightActions.descend.id],
     description: 'Fly Up / Down',
-    contexts: ['hud'],
+    contexts: ['hud', 'docs'],
     order: 50
   },
   {


### PR DESCRIPTION
## Summary
- expose the flight toggle and vertical controls in the docs hotkey manifest context
- document the default flight bindings in the keyboard hotkeys reference

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68e86da7c2a88327826aadb10d437554