### PR TITLE
Adjust follow camera default distance

### DIFF
--- a/src/config/movement.ts
+++ b/src/config/movement.ts
@@ -91,15 +91,15 @@ export const movementConfig: MovementConfig = {
   },
   camera: {
     follow: {
-      offset: { x: 0, y: 3.5, z: -8 },
+      offset: { x: 0, y: 4.5, z: -10 },
       lerp: 0.12,
       lookAtOffset: { x: 0, y: 1.5, z: 0 },
-      minDistance: 4,
+      minDistance: 6,
       maxDistance: 18,
       zoomSpeed: 0.0012
     },
     seed: {
-      followDistance: 6,
+      followDistance: 9,
       shoulderHeight: 1.6,
       pitchDeg: -15
     }


### PR DESCRIPTION
## Summary
- move the follow camera further above and behind the player by default
- tighten the minimum follow distance so the camera cannot rest directly on the avatar
- increase the seeding follow distance so initial placement matches the new defaults

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_b_68e870bc28a483279982e351f84523cf