### PR TITLE
Expand follow camera buffer

### DIFF
--- a/src/config/movement.ts
+++ b/src/config/movement.ts
@@ -91,15 +91,15 @@ export const movementConfig: MovementConfig = {
   },
   camera: {
     follow: {
-      offset: { x: 0, y: 3.5, z: -8 },
+      offset: { x: 0, y: 5.5, z: -14 },
       lerp: 0.12,
       lookAtOffset: { x: 0, y: 1.5, z: 0 },
       minDistance: 4,
-      maxDistance: 18,
+      maxDistance: 28,
       zoomSpeed: 0.0012
     },
     seed: {
-      followDistance: 6,
+      followDistance: 12,
       shoulderHeight: 1.6,
       pitchDeg: -15
     }


### PR DESCRIPTION
## Summary
- move the follow camera higher and farther back from the avatar
- loosen the follow camera zoom limits so players can pull the view closer or farther in play
- update the seeded follow distance to align with the new placement

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68e870bc28a483279982e351f84523cf