### PR TITLE
Parallelize ground setup during boot

### DIFF
--- a/src/entry/initializeAthens.js
+++ b/src/entry/initializeAthens.js
@@ -1035,6 +1035,36 @@ export async function initializeAthens(options = {}) {
     setPhase('env-start');
   } catch {}
 
+  const groundTask = (async () => {
+    markBootPhase('ground-start');
+    __mark('ground-start');
+    try {
+      setPhase('ground-start');
+    } catch {}
+
+    let groundResult = null;
+    try {
+      groundResult = await setupGround(scene, renderer, { layout, layoutConfig });
+    } catch (error) {
+      logger.warn('[Athens][Boot] Failed to initialize ground.', error);
+      markBootPhase('ground-failed');
+      __mark('ground-failed');
+      return { ground: null, layeredGroundRoot: null, hasLayeredGround: false };
+    }
+
+    registerDisposables(groundResult);
+    const layeredGroundRoot = groundResult?.root ?? null;
+    const hasLayeredGround = Boolean(layeredGroundRoot?.userData?.layeredGround);
+
+    markBootPhase('ground-ready');
+    __mark('ground-ready');
+    try {
+      setPhase('ground-ready');
+    } catch {}
+
+    return { ground: groundResult, layeredGroundRoot, hasLayeredGround };
+  })();
+
   try {
     await withBootTimeout(
       applyInitialEnvironment(),
@@ -1214,10 +1244,7 @@ export async function initializeAthens(options = {}) {
 
 
   // CITYPLAN_START
-  const ground = await setupGround(scene, renderer, { layout, layoutConfig });
-  registerDisposables(ground);
-  const layeredGroundRoot = ground?.root ?? null;
-  const hasLayeredGround = Boolean(layeredGroundRoot?.userData?.layeredGround);
+  const { ground, layeredGroundRoot, hasLayeredGround } = await groundTask;
   // CITYPLAN_END
 
   // CITYPLAN_START


### PR DESCRIPTION
## Summary
- start ground initialization concurrently with the environment bootstrap so long-running ground loads no longer block the boot deadline
- add boot phase markers for the ground lifecycle to improve diagnostics when the fallback path is used

## Testing
- npm test -- src/entry/__tests__/boot-phase.test.ts *(fails: mock.module is not a function in this Node runtime)*

------
https://chatgpt.com/codex/tasks/task_b_68e887e82a2083279be3257dfc166ebe