### PR TITLE
Enable flight by default in controller setup

### DIFF
--- a/src/entry/initializeAthens.js
+++ b/src/entry/initializeAthens.js
@@ -1695,7 +1695,7 @@ export async function initializeAthens(options = {}) {
     : undefined;
 
   const flightOptions = {
-    enabled: false
+    enabled: typeof flightConfig.enabled === 'boolean' ? flightConfig.enabled : true
   };
   if (Number.isFinite(flightConfig.horizontalSpeed)) {
     flightOptions.horizontalSpeed = Math.max(flightConfig.horizontalSpeed, 0);


### PR DESCRIPTION
## Summary
- default flight configuration to enabled so the flight toggle hotkey works without extra settings

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68e8dbf8787083279bfe075ce03823ef