### PR TITLE
Prefer landmark GLB fallbacks under models/buildings

### DIFF
--- a/src/entry/initializeAthens.js
+++ b/src/entry/initializeAthens.js
@@ -6,6 +6,7 @@ import { setupGround, updateTrees, resetTrees } from '../main.js';
 import { disposeTreeGroves } from '../vegetation/trees.js';
 import { disposeAll } from '../utils/disposable.ts';
 import { loadLandmarks } from '../landmarks-loader.js';
+import { prefetchLandmarkModels } from '../landmarks.js';
 import { createLandmarkOverlay } from '../map/landmarks.js';
 // PLACER_START
 import { createLandmarkPlacer } from '../dev/landmarkPlacer.js';
@@ -1543,6 +1544,12 @@ export async function initializeAthens(options = {}) {
     overlay = null;
   }
   landmarks?.featureLines?.updateResolution?.();
+
+  prefetchLandmarkModels().catch((error) => {
+    if (logger && typeof logger.debug === 'function') {
+      logger.debug('[Athens][Landmarks] Prefetch models failed.', error);
+    }
+  });
 
   let followCamera = null;
   const ui = createOriginalUi({

--- a/src/landmarks.js
+++ b/src/landmarks.js
@@ -1,0 +1,122 @@
+import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
+import { resolveBaseUrl, joinPath } from './utils/baseUrl.js';
+import { logger } from './utils/logger.ts';
+
+const base = resolveBaseUrl();
+
+export const ARISTOTLE_CANDIDATES = [
+  joinPath(base, 'models/buildings/aristotle_tomb_in_macedonia_greece.glb'),
+  // fallbacks:
+  joinPath(base, 'models/landmarks/aristotle_tomb.glb'),
+  joinPath(base, 'models/landmarks/aristotle_tomb_in_macedonia_greece.glb')
+];
+
+export const POSEIDON_CANDIDATES = [
+  joinPath(base, 'models/buildings/poseidon_temple_at_sounion_greece.glb'),
+  // fallbacks:
+  joinPath(base, 'models/landmarks/poseidon_temple.glb'),
+  joinPath(base, 'models/landmarks/poseidon_temple_at_sounion_greece.glb')
+];
+
+export const AKROPOL_CANDIDATES = [
+  joinPath(base, 'models/buildings/Akropol.glb'),
+  // fallbacks:
+  joinPath(base, 'models/landmarks/akropol.glb'),
+  joinPath(base, 'models/landmarks/Akropol.glb')
+];
+
+const loggedMissing = new Set();
+
+export async function headOk(url) {
+  if (typeof fetch !== 'function') {
+    return false;
+  }
+  try {
+    const response = await fetch(url, { method: 'HEAD' });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+export async function loadGLBWithFallbacks(loader, urls = [], options = {}) {
+  let activeLoader = loader;
+  const { loaderFactory } = options;
+  const ensureLoader = () => {
+    if (activeLoader && typeof activeLoader.loadAsync === 'function') {
+      return activeLoader;
+    }
+    if (typeof loaderFactory === 'function') {
+      activeLoader = loaderFactory();
+      if (activeLoader && typeof activeLoader.loadAsync === 'function') {
+        return activeLoader;
+      }
+    }
+    activeLoader = createLoader();
+    return activeLoader;
+  };
+
+  const tried = [];
+  for (const candidate of urls) {
+    if (!candidate) {
+      continue;
+    }
+
+    const normalized = String(candidate);
+    if (!(await headOk(normalized))) {
+      tried.push([normalized, 404]);
+      continue;
+    }
+
+    try {
+      const loaderInstance = ensureLoader();
+      if (!loaderInstance || typeof loaderInstance.loadAsync !== 'function') {
+        tried.push([normalized, 'no-loader']);
+        continue;
+      }
+      return await loaderInstance.loadAsync(normalized);
+    } catch (error) {
+      tried.push([normalized, 'load-fail']);
+      if (logger && typeof logger.debug === 'function') {
+        logger.debug('[GLB] Candidate failed to load.', normalized, error);
+      }
+    }
+  }
+
+  if (tried.length) {
+    const key = tried.map(([url]) => url).join('|');
+    if (!loggedMissing.has(key)) {
+      loggedMissing.add(key);
+      const targets = tried.map(([url]) => url);
+      if (logger && typeof logger.warn === 'function') {
+        logger.warn('[GLB] No reachable candidate:', targets);
+      } else {
+        console.warn('[GLB] No reachable candidate:', targets);
+      }
+    }
+  }
+
+  return null;
+}
+
+function createLoader() {
+  return new GLTFLoader();
+}
+
+export async function prefetchLandmarkModels({ loaderFactory } = {}) {
+  if (typeof window === 'undefined' && typeof fetch === 'undefined') {
+    return {
+      aristotle: null,
+      poseidon: null,
+      akropol: null
+    };
+  }
+
+  const factory = typeof loaderFactory === 'function' ? loaderFactory : createLoader;
+
+  const aristotle = await loadGLBWithFallbacks(null, ARISTOTLE_CANDIDATES, { loaderFactory: factory });
+  const poseidon = await loadGLBWithFallbacks(null, POSEIDON_CANDIDATES, { loaderFactory: factory });
+  const akropol = await loadGLBWithFallbacks(null, AKROPOL_CANDIDATES, { loaderFactory: factory });
+
+  return { aristotle, poseidon, akropol };
+}

--- a/src/utils/baseUrl.js
+++ b/src/utils/baseUrl.js
@@ -1,0 +1,10 @@
+export function resolveBaseUrl() {
+  // Vite base: "./" => use relative paths (works in dev and on Pages).
+  return "";
+}
+export function joinPath(...parts) {
+  return parts
+    .filter(Boolean)
+    .map((p) => String(p).replace(/(^\/+/|\/+$)/g, ""))
+    .join("/");
+}


### PR DESCRIPTION
## Summary
- add a lightweight base URL join helper for landmark asset paths
- define landmark GLB candidate lists that prefer public/models/buildings with legacy fallbacks and HEAD preflight loading
- warm landmark model candidates during initialization with concise logging when assets are missing

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68e8dc2f00588327bd7db9ccb1057b09